### PR TITLE
add stop feature from RC's joystick or UI fix #15

### DIFF
--- a/app/src/main/java/org/WenuLink/MainActivity.kt
+++ b/app/src/main/java/org/WenuLink/MainActivity.kt
@@ -161,8 +161,7 @@ class MainActivity : ComponentActivity() {
         val isPermissionsGranted by viewModel.isPermissionsGranted.observeAsState(false)
         val workflowStatus by viewModel.workflowStatus.observeAsState("Idle")
         val isServiceRunning by servicesViewModel.isServiceRunning.collectAsState(false)
-        var isSimulationReady by remember { mutableStateOf(servicesViewModel.isSimulationReady()) }
-        var isSimulationActive by remember { mutableStateOf(servicesViewModel.isSimulationActive()) }
+        val isSimulationReady by servicesViewModel.isSimReady.collectAsState(false)
         // DJI
         val isSDKOk by viewModel.isRegistered.observeAsState(false)
         val sdkStatus by viewModel.sdkStatus.observeAsState("Idle")
@@ -203,32 +202,30 @@ class MainActivity : ComponentActivity() {
             if(isSDKOk){
                 Spacer(Modifier.height(8.dp))
                 Button(onClick = {
-                    servicesViewModel.runService(!isServiceRunning)
+                    servicesViewModel.runService(!isServiceRunning, false)
                 }) {
                     Text(if (isServiceRunning) {
-                        "Stop Drone Service"
+                        "Stop WenuLink Service"
                     } else {
-                        "Start Drone Service"
+                        "Start WenuLink Service"
                     })
                 }
 
-//                if (isSimulationReady) {
-                // TODO: Improve simulation enable/disable UI/UX
+                if (isSimulationReady && !isMAVLinkRunning) {
                     Button(onClick = {
-                        servicesViewModel.enableSimulation(!isSimulationActive)
-                        isSimulationActive = !isSimulationActive
+                        servicesViewModel.runService(run = true, simEnabled = true)
                     }) {
-                        Text(
-                            if (!isSimulationActive) {
-                                "Enable simulation"
-                            } else {
-                                "Disable simulation"
-                            }
-                        )
+                        Text("Start SIM WenuLink Service")
                     }
-//                }
+                }
 
                 if (isServiceRunning) {
+                    HorizontalDivider()
+                    Button(onClick = {
+                        servicesViewModel.forceStop()
+                    }) {
+                        Text("FORCE STOP")
+                    }
                     HorizontalDivider()
                     Button(onClick = {
                         servicesViewModel.runMAVLink(!isMAVLinkRunning)

--- a/app/src/main/java/org/WenuLink/adapters/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/AircraftHandler.kt
@@ -3,7 +3,6 @@ package org.WenuLink.adapters
 import com.MAVLink.enums.MAV_MODE_FLAG
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,9 +19,11 @@ class AircraftHandler {
     companion object {
         private var mInstance: AircraftHandler? = null
 
-        fun getInstance(): AircraftHandler {
+        fun getInstance(serviceScope: CoroutineScope? = null): AircraftHandler {
             if (mInstance == null)
                 mInstance = AircraftHandler()
+            if (serviceScope != null)
+                mInstance!!.registerHandlerScope(serviceScope)
             return mInstance!!
         }
 
@@ -31,22 +32,23 @@ class AircraftHandler {
     private val logger by taggedLogger("AircraftHandler")
     val startTimestamp: Long = System.currentTimeMillis()
     val systemBootTime: Long
-        get() { return System.currentTimeMillis() - startTimestamp }
-    var isHomeSet = false
-        private set
+        get() = System.currentTimeMillis() - startTimestamp
     var baseMode: Int = MAV_MODE_FLAG.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
         private set
     var copterFlightMode = ArduCopterFlightMode.STABILIZE
         private set
-    var state = AircraftStateMachine()
+    val state = AircraftStateMachine()
     var sensorsOk = false
         private set
     var preArmCheckOk = false
         private set
-    private var controlAuthority = ControlAuthority.NONE
-    var mission = MissionHandler.getInstance()
-    val missionState: Int
-        get() = mission.currentState
+    val mission = MissionHandler.getInstance()
+    val telemetry = TelemetryHandler.getInstance()
+    val homeCoordinates: Coordinates3D?
+        get() = FCManager.getHomePosition()
+    var isPowerOff = false
+    val rcInput: RCData?
+        get() = telemetry.getRCData()
 
     private val _isArmed = MutableStateFlow(false)
     val isArmed: StateFlow<Boolean> = _isArmed.asStateFlow()
@@ -63,29 +65,33 @@ class AircraftHandler {
                 if (armed) MAV_MODE_FLAG.MAV_MODE_FLAG_SAFETY_ARMED else 0
 
     fun modeTransition(copterMode: Long): Boolean {
-        val newMode = ArduCopterFlightMode.from(copterMode)
-        logger.d { "Transition: copterFlightMode=${copterFlightMode}->${newMode}" }
-        if (newMode == null) return false
+        val newMode = ArduCopterFlightMode.from(copterMode) ?: return false
+        if (newMode == copterFlightMode) return true
+        logger.d { "Mode transition: ${copterFlightMode}->${newMode}" }
         // TODO: check if transition conditions are met
         // TODO: request for necessary internal changes
-        updateModeIfArmed(newMode)
+        // TODO: validate for successful transition
 
         // Performs actions if needed
-        if (copterFlightMode == ArduCopterFlightMode.LAND && state.isArmed()) land()
-        if (controlAuthority == ControlAuthority.WAYPOINT_MISSION &&
-            copterFlightMode == ArduCopterFlightMode.AUTO &&
+        if (newMode == ArduCopterFlightMode.LAND && state.isArmed()) land()
+
+        if (newMode == ArduCopterFlightMode.AUTO &&
+            state.isMissionWaypoint() &&
             mission.isMissionRunning
-        ) mission.resume()
+        ) mission.resumeWaypoint()
+
+        if (newMode == ArduCopterFlightMode.BRAKE &&
+            state.isMissionWaypoint() &&
+            mission.isMissionRunning
+        ) mission.pauseWaypoint()
+
+        if (newMode == ArduCopterFlightMode.AUTO && state.isTimelineCommand()) mission.resumeCommand()
+
+        if (newMode == ArduCopterFlightMode.BRAKE && state.isTimelineCommand()) mission.pauseCommand()
+
+        updateModeIfArmed(newMode)
 
         return true
-    }
-
-    fun controlTransition(authority: ControlAuthority) {
-        if (controlAuthority == ControlAuthority.WAYPOINT_MISSION) {
-            // Decide policy: reject or stop mission
-            MissionManager.stopMission {}
-        }
-        controlAuthority = authority
     }
 
     fun updateModeIfArmed(newMode: ArduCopterFlightMode? = null) {
@@ -100,6 +106,7 @@ class AircraftHandler {
 
     fun readCurrentState(): Boolean {
         // TODO: read components metadata
+        // TODO: initialize state from current flightControlState for correct reinitialization if needed
         return true
     }
 
@@ -124,26 +131,43 @@ class AircraftHandler {
     }
 
     // check for home location and set
-    fun getHomePosition(): Coordinates3D? = FCManager.getHomePosition()
-
-    fun updateHomePositionFromAircraft() {
+    fun updateHomeCoordinatesFromAircraft(): Coordinates3D? {
         // Ask for home position
-        logger.d { "Requesting home position update with aircraft's location." }
+        logger.d { "Requesting home coordinates update with current aircraft's location." }
         FCManager.setHomePosition { error ->
-            if (error == null) isHomeSet = true
-            if (error != null) logger.w { "Unable to set home position: $error" }
+            if (error == null) state.homeSet(true)
+            if (error != null) logger.w { "Error request: $error" }
         }
+        return homeCoordinates
     }
 
-    suspend fun waitForHomeLocation() {
-        isHomeSet = false
-        logger.d { "waitForHomeLocation" }
-        while (!isHomeSet || getHomePosition() == null) {
-            if (!isHomeSet) updateHomePositionFromAircraft()
-            delay(1000L)
-        }
-        logger.d { "waitForHomeLocation: OK ${getHomePosition()}" }
+    suspend fun waitHomeUpdate() {
+        state.homeSet(false)
+        fun isHomeUpdated() = updateHomeCoordinatesFromAircraft() != null
+        AsyncUtils.waitReady(intervalTime = 1000L, isReady = ::isHomeUpdated)
+        logger.d { "Home coordinates: $homeCoordinates" }
     }
+
+    suspend fun waitHome() {
+        AsyncUtils.waitReady(intervalTime = 1000L, isReady = state::isHomeSet)
+        logger.d { "Home coordinates: $homeCoordinates" }
+    }
+
+    suspend fun startTelemetry(timeout: Long = 5000L): Boolean {
+        // Start telemetry process
+        telemetry.launchTelemetry(true)
+        // Second wait to receive the data ready for broadcast
+        return waitTelemetry(timeout)
+    }
+
+    suspend fun stopTelemetry(delay: Long = 1000L): Boolean {
+        // Stop telemetry process
+        telemetry.launchTelemetry(false)
+        // Second wait to remove the existing data
+        return telemetry.waitDataRemoving(delay)
+    }
+
+    suspend fun waitTelemetry(timeout: Long = 5000L): Boolean = telemetry.waitDataReading(timeout)
 
     suspend fun boot() {
         stateTransition(AircraftState.Boot)
@@ -151,9 +175,6 @@ class AircraftHandler {
         logger.d { "Aircraft booting..." }
 
         // TODO perform all required checks and aircraft's initialization
-        // TODO: initialize from current flightControlState for correct reinitialization if needed
-        if (!readCurrentState()) return
-        logger.d { "\tLoading info: TBD" }
         if (!processUserPreferences()) return
         logger.d { "\tLoading preferences: TBD" }
         if (!enableFeatures()) return
@@ -161,23 +182,31 @@ class AircraftHandler {
         if (!checkSensors()) return
         logger.d { "\tSensors status: TBD" }
 
+        if (!startTelemetry(5000L)) return
+        logger.d { "\tInit. telemetry: OK" }
+
+        if (!readCurrentState()) return
+        logger.d { "\tReading FC state: TBD" }
+
         preArmCheckOk = true
+        isPowerOff = false
+
         stateTransition(AircraftState.OnGround)
         logger.d { "Aircraft boot: OK" }
 
-        waitForHomeLocation()
+        waitHomeUpdate()
 
         standby()  // possibly must be threaded for waiting standby mode
     }
 
     fun standby() {
         if (!preArmCheckOk) {
-            logger.i { "Aircraft is not ready, prearm check failed" }
+            logger.i { "Unable to standby, prearm check failed" }
             return // only standby after prearm check condition ok
         }
 
         if (!state.isOnTheGround()) {
-            logger.i { "Unable to do, aircraft is not on the ground" }
+            logger.i { "Unable to standby, aircraft is not on the ground" }
             return // only standby on ground
         }
 
@@ -187,6 +216,10 @@ class AircraftHandler {
     }
 
     fun registerHandlerScope(handlerScope: CoroutineScope) {
+        telemetry.registerHandlerScope(handlerScope)
+//        mission.registerHandlerScope(this, handlerScope)
+        registerMissionListeners(handlerScope)
+
         isArmed.distinctUntilChangedBy { it }
             .onEach {
                 if (it) fcArmMotors()
@@ -197,15 +230,13 @@ class AircraftHandler {
         isFlying.distinctUntilChangedBy { it }
             .onEach {
                 if (it) fcTakeOff()
-                else fcLanding()
+                else landing()
             }
             .launchIn(handlerScope)
-
-        registerMissionListeners(handlerScope)
     }
 
     private fun registerMissionListeners(handlerScope: CoroutineScope) {
-        mission.registerListeners(
+        mission.startListenersWaypoint(
             onStart = {
                 handlerScope.launch {
                     logger.d { "Mission started" }
@@ -220,14 +251,11 @@ class AircraftHandler {
                 handlerScope.launch {
                     logger.d { "Waypoint reached" }
 
-                    if (index == 1 && controlAuthority == ControlAuthority.WAYPOINT_MISSION)
+                    if (index == 0 && state.isMissionWaypoint())
                     // Call pause only for second element, assumes 0 = arm, 1 = takeoff/initial alt.
-                        mission.pause()
+                        mission.pauseWaypoint()
 
                     // Wait for AUTO mode transition
-//                    fun isAutoMode() = copterFlightMode == ArduCopterFlightMode.AUTO
-//                    AsyncUtils.waitReady(100L, ::isAutoMode)
-//                    mission.resume()
                 }
             },
             onFinish = { error ->
@@ -247,7 +275,7 @@ class AircraftHandler {
         MissionActionManager.registerGoHomeFinished {
             handlerScope.launch {
                 // This assumes RTL ends with landing confirmation
-                waitLandingConfirmation()
+                waitAndConfirmLanding()
                 waitLandedStateTransition(false)
             }
         }
@@ -255,9 +283,47 @@ class AircraftHandler {
         MissionActionManager.startListener {
             // onError
             logger.e { "Action failed: $it" }
-            controlAuthority = ControlAuthority.NONE
+            controlTransition(ControlAuthority.NONE)
         }
     }
+
+    fun cancelMission() {
+        logger.d { "cancel mission" }
+        if (state.isMissionWaypoint()) mission.stopWaypoint()
+        if (state.isTimelineCommand()) mission.cancelCommand()
+    }
+
+    fun controlTransition(authority: ControlAuthority) {
+        // Decide policy: reject or stop mission
+        if (!state.isNewControlAuthority(authority)) return
+        cancelMission()
+        logger.d { "Control transition: ${state.control}->$authority" }
+        state.setControlAuthority(authority)
+    }
+
+    fun controlManual() {
+        controlTransition(ControlAuthority.REMOTE_CONTROLLER)
+        modeTransition(ArduCopterFlightMode.STABILIZE.mode)
+    }
+
+    suspend fun unload() {
+        // Change state and control
+        controlManual()
+        // Reverse boot sequence if need
+        stopTelemetry(500L)
+        isPowerOff = true
+    }
+
+//    suspend fun shutdown() {
+//        // TODO: perform RTL or LAND before?
+//        // shutdown sequence cleaning operations and reversing boot()
+//        if (state.isOnTheGround() && !state.isArmed()) {
+//            stateTransition(AircraftState.PowerOff)
+//        }
+//        // Change state and reverse boot sequence
+//        unload()
+//        isPowerOff = true
+//    }
 
     fun armMotors(mustArm: Boolean) {
         _isArmed.value = mustArm
@@ -369,11 +435,7 @@ class AircraftHandler {
         }
     }
 
-    fun land() {
-        _isFlying.value = false
-    }
-
-    suspend fun waitLandingConfirmation() {
+    suspend fun waitAndConfirmLanding() {
         // https://developer.dji.com/api-reference/android-api/Components/FlightController/DJIFlightController.html#djiflightcontroller_confirmlanding_inline
         logger.d { "\tWaiting altitude of 0.3m" }
         AsyncUtils.waitReady(100L, FCManager::needLandingConfirmation)
@@ -383,13 +445,7 @@ class AircraftHandler {
         }
     }
 
-    suspend fun fcLanding() {
-        // need to be armed or flying
-        if (!state.isArmed()) {
-            logger.d { "Invalid call, aircraft is not armed" }
-            return
-        }
-
+    suspend fun landing() {
         // need to be flying
         if (!state.isFlying()) {
             logger.d { "Invalid landing call, aircraft is not flying" }
@@ -397,18 +453,23 @@ class AircraftHandler {
         }
 
         logger.d { "Aircraft is landing"}
-//        FCManager.startLanding()
         stateTransition(AircraftState.Land)
         doLand()
-
-        // Landing confirmation when 0.3 altitude is reached
-//        waitLandingConfirmation()
 
         if (waitLandedStateTransition(false)) {
             logger.d { "\ton the ground"}
         }
         else logger.d { "\terror" }
 
+    }
+
+    fun land() {
+        _isFlying.value = false
+    }
+
+    fun doMission() {
+        controlTransition(ControlAuthority.WAYPOINT_MISSION)
+        mission.startWaypoint()
     }
 
     fun doReposition(
@@ -418,7 +479,7 @@ class AircraftHandler {
         controlTransition(ControlAuthority.TIMELINE_COMMAND)
         mission.doReposition(target, speed ?: mission.flightSpeed) { error ->
             logger.i { "Reposition completed: $error" }
-            controlAuthority = ControlAuthority.NONE
+            controlTransition(ControlAuthority.NONE)
         }
     }
 
@@ -426,7 +487,7 @@ class AircraftHandler {
         controlTransition(ControlAuthority.TIMELINE_COMMAND)
         mission.doLand { error ->
             logger.i { "Landedd:$error" }
-            controlAuthority = ControlAuthority.NONE
+            controlTransition(ControlAuthority.NONE)
         }
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/AircraftState.kt
@@ -6,7 +6,8 @@ import com.MAVLink.enums.MAV_STATE
 enum class ControlAuthority {
     NONE,
     WAYPOINT_MISSION,
-    TIMELINE_COMMAND
+    TIMELINE_COMMAND,
+    REMOTE_CONTROLLER
 }
 
 sealed interface AircraftState {
@@ -19,6 +20,7 @@ sealed interface AircraftState {
     object Land : AircraftState
     object OnGround : AircraftState
     object FlightTermination : AircraftState
+    object PowerOff : AircraftState
 }
 
 /**
@@ -29,7 +31,9 @@ class AircraftStateMachine {
 
     data class UnifiedState(
         val mavlink: Int = MAV_STATE.MAV_STATE_UNINIT,
-        val landed: Int = MAV_LANDED_STATE.MAV_LANDED_STATE_UNDEFINED
+        val landed: Int = MAV_LANDED_STATE.MAV_LANDED_STATE_UNDEFINED,
+        val isHomeSet: Boolean = false,
+        val controlAuthority: ControlAuthority = ControlAuthority.NONE
     )
 
     private var _state = UnifiedState()
@@ -38,10 +42,33 @@ class AircraftStateMachine {
 
     val landed: Int get() = _state.landed
 
+    val control: ControlAuthority get() = _state.controlAuthority
+
     fun dispatch(event: AircraftState): UnifiedState {
         _state = reduce(_state, event)
         return _state
     }
+
+    fun setControlAuthority(controlAuthority: ControlAuthority): UnifiedState {
+        _state = _state.copy(controlAuthority = controlAuthority)
+        return _state
+    }
+
+    fun isMissionWaypoint() = _state.controlAuthority == ControlAuthority.WAYPOINT_MISSION
+
+    fun isTimelineCommand() = _state.controlAuthority == ControlAuthority.TIMELINE_COMMAND
+
+    fun isRemoteController() = _state.controlAuthority == ControlAuthority.REMOTE_CONTROLLER
+
+    fun isNewControlAuthority(authority: ControlAuthority) =
+        _state.controlAuthority != authority
+
+    fun homeSet(isHomeSet: Boolean = true): UnifiedState {
+        _state = _state.copy(isHomeSet = isHomeSet)
+        return _state
+    }
+
+    fun isHomeSet() = _state.isHomeSet
 
     fun isStandBy() = _state.mavlink == MAV_STATE.MAV_STATE_STANDBY
 
@@ -85,5 +112,8 @@ class AircraftStateMachine {
 
             AircraftState.FlightTermination ->
                 s.copy(mavlink = MAV_STATE.MAV_STATE_FLIGHT_TERMINATION)
+
+            AircraftState.PowerOff ->
+                s.copy(mavlink = MAV_STATE.MAV_STATE_POWEROFF)
         }
 }

--- a/app/src/main/java/org/WenuLink/adapters/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/MissionHandler.kt
@@ -36,9 +36,9 @@ class MissionHandler {
     var currentState = MISSION_STATE.MISSION_STATE_UNKNOWN
         private set
     val totalNodes: Int
-        get() { return assembler.size() }
+        get() = assembler.size()
     val currentId: Long
-        get() { return 202512 }
+        get() = 202512
 
     @Synchronized
     fun updateState() {
@@ -71,6 +71,7 @@ class MissionHandler {
     fun canCreateMission() = currentState == MISSION_STATE.MISSION_STATE_NO_MISSION
 
     fun reset() {
+        stopWaypoint()
         assembler.reset()
     }
 
@@ -142,7 +143,7 @@ class MissionHandler {
         return commandAccepted
     }
 
-    fun upload(onResult: (String?) -> Unit) {
+    fun uploadWaypoints(onResult: (String?) -> Unit) {
         if (!MissionManager.isWaitingMission()) return
 
         val mission = assembler.build()
@@ -156,38 +157,50 @@ class MissionHandler {
         }
     }
 
-    fun pause() {
+    fun pauseWaypoint() {
         if (!isMissionRunning) return
+        logger.i { "Pause WP mission" }
         MissionManager.pauseMission { error ->
-            if (error == null) {
-                logger.d { "Paused on sequence $currentSequence" }
-                updateState()
-            }
+            if (error != null) logger.i { "Unable to pause the mission at $currentSequence: $error" }
+            updateState()
         }
     }
 
-    fun start() {
+    fun startWaypoint() {
         if (isMissionRunning) return
         currentSequence = 0
+        logger.i { "Start WP mission" }
         MissionManager.startMission { error ->
-            if (error != null) logger.i { "Unable to start the mission" }
+            if (error != null) logger.i { "Unable to start the mission: $error" }
             updateState()
         }
     }
 
-    fun resume() {
+    fun resumeWaypoint() {
         if (!isMissionRunning) return
+        logger.i { "Resume WP mission" }
         MissionManager.resumeMission { error ->
-            if (error != null) logger.i { "Unable to resume the mission" }
+            if (error != null) logger.i { "Unable to resume the mission: $error" }
             updateState()
         }
     }
 
-    fun registerListeners(
+    fun stopWaypoint() {
+        if (!isMissionRunning) return
+        currentSequence = 0
+        logger.i { "Stop WP mission" }
+        MissionManager.stopMission { error ->
+            if (error != null) logger.i { "Unable to stop the mission: $error" }
+            updateState()
+        }
+    }
+
+    fun startListenersWaypoint(
         onStart: () -> Unit,
         onWaypointReach: (Int) -> Unit,
         onFinish: (String?) -> Unit
     ) {
+        updateState()
         MissionManager.addListeners(
             onStart = {
                 onStart()
@@ -207,12 +220,30 @@ class MissionHandler {
         )
     }
 
+    fun cancelCommand() {
+        logger.i { "Cancel command" }
+        MissionActionManager.stop()
+        MissionActionManager.clear()  // <- not sure about this
+        updateState()
+    }
+
+    fun pauseCommand() {
+        logger.i { "Pause command" }
+        MissionActionManager.pause()
+        updateState()
+    }
+
+    fun resumeCommand() {
+        logger.i { "Resume command" }
+        MissionActionManager.stop()
+        updateState()
+    }
     fun doReposition(
         target: Coordinates3D,
         speed: Float?,
         onResult: (String?) -> Unit
     ) {
-
+        logger.i { "doReposition" }
         MissionActionManager.clear()
         val error = MissionActionManager.scheduleGoTo(
             coordinates = target,
@@ -233,7 +264,14 @@ class MissionHandler {
 
     fun doLand(onResult: (String?) -> Unit) {
         MissionActionManager.clear()
-        MissionActionManager.scheduleLand()
+        val error = MissionActionManager.scheduleLand()
+
+        if (error != null) {
+            onResult("Error in Land: ${error.description}")
+            return
+        }
+
+        logger.i { "scheduleLand" }
 
         MissionActionManager.registerLandFinished {
             onResult(null)

--- a/app/src/main/java/org/WenuLink/adapters/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/TelemetryData.kt
@@ -40,7 +40,26 @@ data class RCData(
     val buttonC2: Boolean,
     val buttonC3: Boolean,
     val mode: FlightModeSwitch?
-)
+) {
+    fun toMAVLink(): RCData {
+        val currRC = this.copy(
+            throttleSetting = (this.throttleSetting + 660) / 1320,  // TODO: check this value
+            // Mavlink: 1000 to 2000 with 1500 = 1.5ms as center...
+            leftStickVertical = (this.leftStickVertical * 0.8).toInt() + 1500,
+            leftStickHorizontal = (this.leftStickHorizontal * 0.8).toInt() + 1500,
+            rightStickVertical = (this.rightStickVertical * 0.8).toInt() + 1500,
+            rightStickHorizontal = (this.rightStickHorizontal * 0.8).toInt() + 1500,
+        )
+        return currRC
+    }
+
+    fun hasCenteredJoystick(): Boolean {
+        return this.leftStickVertical == 0 &&
+                this.leftStickHorizontal == 0 &&
+                this.rightStickVertical == 0 &&
+                this.rightStickHorizontal == 0
+    }
+}
 
 data class BatteryData(
     var percentCharge: Int = -1,

--- a/app/src/main/java/org/WenuLink/adapters/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/TelemetryData.kt
@@ -1,7 +1,7 @@
 package org.WenuLink.adapters
 
-
 import dji.common.remotecontroller.HardwareState.FlightModeSwitch
+import kotlin.math.roundToInt
 
 /**
  * Data class to hold telemetry info.
@@ -41,14 +41,25 @@ data class RCData(
     val buttonC3: Boolean,
     val mode: FlightModeSwitch?
 ) {
+    private fun stickValue2percent(value: Int): Int {
+        // transform from DJI range [-660, 660] => [0, 100]
+        return (((value + 660).toFloat() / 1320F) * 100).roundToInt()
+    }
+
+    private fun stickValue2rcValue(value: Int): Int {
+        // transform from DJI range [-660, 660] => [1000, 2000]
+        return ((value.toFloat() / 660) * 500).roundToInt() + 1500
+    }
+
     fun toMAVLink(): RCData {
         val currRC = this.copy(
-            throttleSetting = (this.throttleSetting + 660) / 1320,  // TODO: check this value
-            // Mavlink: 1000 to 2000 with 1500 = 1.5ms as center...
-            leftStickVertical = (this.leftStickVertical * 0.8).toInt() + 1500,
-            leftStickHorizontal = (this.leftStickHorizontal * 0.8).toInt() + 1500,
-            rightStickVertical = (this.rightStickVertical * 0.8).toInt() + 1500,
-            rightStickHorizontal = (this.rightStickHorizontal * 0.8).toInt() + 1500,
+            // Percent: [0, 100]
+            throttleSetting = stickValue2percent(this.throttleSetting),
+            // Value: [1000, 2000] with 1500 as center...
+            leftStickVertical = stickValue2rcValue(this.leftStickVertical),
+            leftStickHorizontal = stickValue2rcValue(this.leftStickHorizontal),
+            rightStickVertical = stickValue2rcValue(this.rightStickVertical),
+            rightStickHorizontal = stickValue2rcValue(this.rightStickHorizontal),
         )
         return currRC
     }

--- a/app/src/main/java/org/WenuLink/adapters/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/TelemetryHandler.kt
@@ -34,18 +34,22 @@ class TelemetryHandler {
     private val _isListeningAircraft = MutableStateFlow(false)
     val isListeningAircraft: StateFlow<Boolean> = _isListeningAircraft.asStateFlow()
     private var lastTelemetryData: TelemetryData? = null
-    private var runSimulation: Boolean = false
+    val isSimulationAvailable: Boolean
+        get() = SimManager.isAvailable()
+    val isSimulationActive: Boolean
+        get() = SimManager.isActive()
+    private var mustRunSimulation: Boolean = false
 
     private val _isBroadcasting = MutableStateFlow(false)
     val isBroadcasting: StateFlow<Boolean> = _isBroadcasting.asStateFlow()
 
     @Synchronized
-    fun hasTelemetryData(): Boolean {
+    fun hasData(): Boolean {
         return lastTelemetryData != null
     }
 
     @Synchronized
-    fun getTelemetryData(): TelemetryData? {
+    fun getData(): TelemetryData? {
         return lastTelemetryData
     }
 
@@ -54,27 +58,20 @@ class TelemetryHandler {
         lastTelemetryData = telemetry
     }
 
-    fun isSimulationReady(): Boolean = SimManager.isAvailable()
-
-    fun isSimulationActive(): Boolean = SimManager.isActive()
-
     @Synchronized
     fun enableSimulation(enable: Boolean) {
-        logger.i { "Enable Simulation $enable" }
-
         if (isActive()) {
-            logger.e { "Unable to set, Telemetry is active." }
+            logger.e { "Unable to set runSimulation=$enable, Telemetry is active." }
             return
         }
 
-        if (!isSimulationReady()) {
-            logger.e { "Unable to set, Simulation is not available." }
+        if (!isSimulationAvailable) {
+            logger.e { "Unable to set runSimulation=$enable, Simulation is not available." }
             return
         }
 
-        if (runSimulation == enable) return
-
-        runSimulation = enable
+        mustRunSimulation = enable
+        logger.i { "Enable Simulation $mustRunSimulation" }
     }
 
     fun registerSimState(register: Boolean) {
@@ -82,8 +79,6 @@ class TelemetryHandler {
         SimManager.unregisterStateCallback()
         if (register) SimManager.registerStateCallback { state ->
             // TODO: Some telemetry values such as velocities must be updated
-            if (lastTelemetryData != null)
-                SimManager.completeTelemetryData(lastTelemetryData!!, state)
             updateTelemetryData(SimManager.state2telemetry(state))
         }
     }
@@ -104,8 +99,8 @@ class TelemetryHandler {
 
     @Synchronized
     fun registerStateListeners(register: Boolean) {
-        logger.d { "registerStateListeners: $register (runSimulation: $runSimulation)" }
-        if (runSimulation) registerSimState(register)
+        logger.d { "registerStateListeners: $register (runSimulation: $mustRunSimulation)" }
+        if (mustRunSimulation) registerSimState(register)
         else registerRealState(register)
     }
 
@@ -131,7 +126,7 @@ class TelemetryHandler {
     }
 
     fun listenVehicleState(listen: Boolean) {
-        if (runSimulation) listenSimulation(listen)
+        if (mustRunSimulation) listenSimulation(listen)
         else listenAircraft(listen)
     }
 
@@ -188,28 +183,32 @@ class TelemetryHandler {
         var isFlowing = RCManager.isUpdated()
         // If simulation activated, must wait for its startup
         isFlowing = isFlowing &&
-                if (runSimulation) isSimulationActive()
+                if (mustRunSimulation) isSimulationActive
         // Assumes that if not sim, Aircraft is present
         else AircraftManager.isUpdated()
         return isFlowing
     }
 
-    suspend fun waitTelemetryUp(timeout: Long = 5000L): Boolean {
+    suspend fun waitDataReading(timeout: Long = 5000L): Boolean {
         // First check wait for listeners transfer data
-        val listenersOk = AsyncUtils.waitTimeout(timeout = timeout, isReady = ::isReadingData)
+        var listenersOk = AsyncUtils.waitTimeout(timeout = timeout, isReady = ::isReadingData)
         if (!listenersOk) return false
 
         // Second wait to receive the data ready for broadcast
-        return AsyncUtils.waitTimeout(timeout = timeout, isReady = ::hasTelemetryData)
+        listenersOk = AsyncUtils.waitTimeout(timeout = timeout, isReady = ::hasData)
+        logger.d { "Telemetry is broadcasting data: $listenersOk" }
+        return listenersOk
     }
 
-    suspend fun waitForTelemetryDown(timeout: Long = 5000L): Boolean {
+    suspend fun waitDataRemoving(delay: Long = 1000L): Boolean {
         // Wait for listeners to stop receiving data
         fun stopReading() = !isReadingData()
-        AsyncUtils.waitReady(timeout, isReady = ::stopReading)
+        AsyncUtils.waitReady(delay, isReady = ::stopReading)
         // reset the telemetry info
         updateTelemetryData(null)
-        return !(isReadingData() || hasTelemetryData())
+        val listenersOk = !(isReadingData() || hasData())
+        logger.d { "Telemetry stop: $listenersOk" }
+        return listenersOk
     }
 
     fun launchTelemetry(start: Boolean) {
@@ -220,12 +219,12 @@ class TelemetryHandler {
 
     fun getAircraftBattery(): BatteryData {
         // TODO: Maybe include some custom battery level
-        return if (runSimulation) RCManager.getBatteryData()
+        return if (mustRunSimulation) RCManager.getBatteryData()
         else AircraftManager.getBatteryData()
     }
 
     fun getAirlinkSignal(): IntArray {
-        return if (runSimulation) intArrayOf(98, 95)
+        return if (mustRunSimulation) intArrayOf(98, 95)
         else AircraftManager.getAirlinkData()
     }
 

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.WenuLink.WenuLinkApp
@@ -29,10 +30,24 @@ class WenuLinkService : Service() {
     private var serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private lateinit var mavlink: MAVLinkService
     private lateinit var webRTC: WebRTCService
+    private lateinit var aircraft: AircraftHandler
+    val mavlinkStateFlow: StateFlow<Boolean>?
+        get() = if (isMAVLinkReady()) mavlink.isRunning else null
+    val webRTCStateFlow: StateFlow<Boolean>?
+        get() = if (isWebRTCReady()) webRTC.isRunning else null
 
     override fun onCreate() {
         super.onCreate()
         (application as WenuLinkApp).wenuLinkService = this // Store the service reference
+
+        // create the aircraft instance
+        serviceScope.launch {
+            aircraft = AircraftHandler.getInstance(serviceScope)
+            // TODO: wait for boot sequence
+            aircraft.boot()
+            AsyncUtils.waitReady(1000L, aircraft.state::isStandBy)
+        }
+
         // create WebRTC instance
         if (WebRTCService.isEnabled && !isWebRTCReady())
             webRTC = WebRTCService.getInstance()// create MAVLink instance if must
@@ -55,11 +70,11 @@ class WenuLinkService : Service() {
             getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
         }
 
-        val notification: Notification.Builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Notification.Builder(this, channelId)
-        } else {
-            Notification.Builder(this)
-        }
+        val notification: Notification.Builder =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                Notification.Builder(this, channelId)
+            else
+                Notification.Builder(this)
 
         val pendingIntent = PendingIntent.getActivity(
             this,
@@ -72,16 +87,18 @@ class WenuLinkService : Service() {
         if (::mavlink.isInitialized)
             contentText = "Sending periodic heartbeats to GCS\n"
         if (::webRTC.isInitialized)
-           contentText += "WebRTC streaming: ${webRTC.mediaOptions.VIDEO_CAMERA_NAME}"
-       // .setContentText(webRTC.mediaOptions?.VIDEO_CAMERA_NAME)
+            contentText += "WebRTC streaming: ${webRTC.mediaOptions.VIDEO_CAMERA_NAME}"
+        // .setContentText(webRTC.mediaOptions?.VIDEO_CAMERA_NAME)
         // TODO: update according to each present service
-        startForeground(1, notification
-            .setContentTitle("WenuLink service is running")
-            .setContentText(contentText)
-            .setSmallIcon(R.drawable.ic_menu_compass)
-            .setContentIntent(pendingIntent) // Open MainActivity when tapped
-            .setOngoing(true)
-            .build())
+        startForeground(
+            1, notification
+                .setContentTitle("WenuLink service is running")
+                .setContentText(contentText)
+                .setSmallIcon(R.drawable.ic_menu_compass)
+                .setContentIntent(pendingIntent) // Open MainActivity when tapped
+                .setOngoing(true)
+                .build()
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -109,6 +126,14 @@ class WenuLinkService : Service() {
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    fun isAircraftReady() = ::aircraft.isInitialized
+
+    fun stopCommands() {
+        // mission's logic already stop according to the mission kind
+        serviceScope.launch { aircraft.cancelMission() }
+        // TODO: add RTL/LAND according to settings
+    }
 
     private fun startWebRTC() {
         if (!WebRTCService.isEnabled) {
@@ -138,8 +163,6 @@ class WenuLinkService : Service() {
         logger.i { "WebRTC service stop." }
     }
 
-    fun getWebRTCState(): StateFlow<Boolean>? = if (isWebRTCReady()) webRTC.isRunning else null
-
     fun isWebRTCUp(): Boolean = if (isWebRTCReady()) webRTC.isServiceUp else false
 
     fun isMAVLinkReady() = ::mavlink.isInitialized
@@ -150,33 +173,52 @@ class WenuLinkService : Service() {
             return null
         }
 
-        if (mavlink.clientIsRunning()) return null
+        if (mavlink.isServiceRunning()) return null
 
         logger.d { "Start MAVLinkService protocol." }
         return serviceScope.launch {
+            val telemOk = aircraft.waitTelemetry(5000L)
+            if (!telemOk) {
+                logger.w { "Unable to start service, no telemetry." }
+                return@launch
+            }
             mavlink.createClient(serviceScope)
             mavlink.runProcess(true)
-            AsyncUtils.waitReady(isReady = mavlink::isServiceRunning)
-            logger.i { "MAVLinkService started: ${mavlink.isServiceRunning()}" }
+            mavlink.waitStart()
+            watchRCInput(100L)
         }
     }
 
-    fun stopMAVLinkService (): Job? {
+    fun stopMAVLinkService(): Job? {
         if (!isMAVLinkReady()) return null
 
         logger.d { "Stop MAVLinkService protocol." }
         return serviceScope.launch {
+            stopCommands()
             mavlink.runProcess(false)
-            AsyncUtils.waitReady(isReady = mavlink::isServiceStop)
+            mavlink.waitStop()
             mavlink.destroyClient()
+            aircraft.unload()
             logger.i { "MAVLinkService stop: ${mavlink.isServiceStop()}" }
         }
     }
 
-    fun getMAVLinkState(): StateFlow<Boolean>? = if (isMAVLinkReady()) mavlink.isRunning else null
-
     fun isRunning(): Boolean = (isMAVLinkReady() && mavlink.isServiceRunning()) || isWebRTCUp()
 
-    fun isReady(): Boolean = isMAVLinkReady() || isWebRTCReady()
+    fun isReady(): Boolean = isAircraftReady() && (isMAVLinkReady() || isWebRTCReady())
+
+    fun isPowerOff(): Boolean = aircraft.isPowerOff
+
+    suspend fun watchRCInput(intervalTime: Long = 100L) {
+        while(!aircraft.isPowerOff) {
+            // Watch for joystick inputs
+            aircraft.rcInput?.hasCenteredJoystick()?.let {
+                serviceScope.launch {
+                    if (!it) aircraft.controlManual() // stop everything an gain the control back
+                }
+            }
+            delay(intervalTime)
+        }
+    }
 
 }

--- a/app/src/main/java/org/WenuLink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/CommandController.kt
@@ -94,7 +94,7 @@ class CommandController (
     fun sendAutopilotVersion() {
         val msg = msg_autopilot_version()
         msg.capabilities =
-                    MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_MISSION_INT.toLong()
+                    MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_MISSION_INT.toLong() or
                     MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_COMMAND_INT.toLong() or
                     MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET.toLong() or
                     MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED.toLong() or

--- a/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
@@ -77,17 +77,17 @@ class ConnectionController (
         return processed
     }
 
-    override fun createMessage(messageID: Int, telemetry: TelemetryHandler, aircraft: AircraftHandler): MAVLinkMessage? {
+    override fun createMessage(messageID: Int, aircraft: AircraftHandler): MAVLinkMessage? {
         return when (messageID) {
             msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT -> msgHeartbeat(aircraft)
-            msg_sys_status.MAVLINK_MSG_ID_SYS_STATUS -> msgSysStatus(telemetry, aircraft)
-            msg_attitude.MAVLINK_MSG_ID_ATTITUDE -> msgAttitude(telemetry)
-            msg_altitude.MAVLINK_MSG_ID_ALTITUDE -> msgAltitude(telemetry)
+            msg_sys_status.MAVLINK_MSG_ID_SYS_STATUS -> msgSysStatus(aircraft.telemetry)
+            msg_attitude.MAVLINK_MSG_ID_ATTITUDE -> msgAttitude(aircraft.telemetry)
+            msg_altitude.MAVLINK_MSG_ID_ALTITUDE -> msgAltitude(aircraft.telemetry)
             msg_vibration.MAVLINK_MSG_ID_VIBRATION -> msgVibration()
-            msg_vfr_hud.MAVLINK_MSG_ID_VFR_HUD -> msgHUD(telemetry)
-            msg_radio_status.MAVLINK_MSG_ID_RADIO_STATUS -> msgRadioStatus(telemetry)
+            msg_vfr_hud.MAVLINK_MSG_ID_VFR_HUD -> msgHUD(aircraft.telemetry)
+            msg_radio_status.MAVLINK_MSG_ID_RADIO_STATUS -> msgRadioStatus(aircraft.telemetry)
             msg_power_status.MAVLINK_MSG_ID_POWER_STATUS -> msgPowerStatus()
-            msg_battery_status.MAVLINK_MSG_ID_BATTERY_STATUS -> msgBatteryStatus(telemetry)
+            msg_battery_status.MAVLINK_MSG_ID_BATTERY_STATUS -> msgBatteryStatus(aircraft.telemetry)
             msg_extended_sys_state.MAVLINK_MSG_ID_EXTENDED_SYS_STATE -> msgExtendedSys(aircraft)
 //            msg_mag_cal_report.MAVLINK_MSG_ID_MAG_CAL_REPORT -> msgMagCal()
             else -> null
@@ -141,7 +141,7 @@ class ConnectionController (
         client.sendMessage(msgHeartbeat(aircraft))
     }
 
-    fun msgSysStatus(telemetry: TelemetryHandler, aircraft: AircraftHandler): MAVLinkMessage {
+    fun msgSysStatus(telemetry: TelemetryHandler): MAVLinkMessage {
         val aircraftBattery = telemetry.getAircraftBattery()
         val msg = msg_sys_status()
 
@@ -173,7 +173,7 @@ class ConnectionController (
     }
 
     fun msgAttitude(telemetry: TelemetryHandler): MAVLinkMessage? {
-        val telemetryData = telemetry.getTelemetryData() ?: return null
+        val telemetryData = telemetry.getData() ?: return null
 
         val msg = msg_attitude()
         // TODO: this next line causes an exception
@@ -189,7 +189,7 @@ class ConnectionController (
     }
 
     fun msgAltitude(telemetry: TelemetryHandler): MAVLinkMessage? {
-        val data = telemetry.getTelemetryData() ?: return null
+        val data = telemetry.getData() ?: return null
         val msg = msg_altitude()
         msg.altitude_relative = data.altitude
 //        client.sendMessage(msg)
@@ -202,7 +202,7 @@ class ConnectionController (
     }
 
     fun msgHUD(telemetry: TelemetryHandler): MAVLinkMessage? {
-        val telemetryData = telemetry.getTelemetryData() ?: return null
+        val telemetryData = telemetry.getData() ?: return null
         val rcData = telemetry.getRCData() ?: return null
         val msg = msg_vfr_hud()
         // Mavlink: Current airspeed in m/s
@@ -218,7 +218,7 @@ class ConnectionController (
         if (heading < 0) heading += 360
         msg.heading = heading.toInt().toShort()
         // vertical info
-        msg.throttle = rcData.throttleSetting
+        msg.throttle = rcData.toMAVLink().throttleSetting
         msg.alt = -telemetryData.altitude
         // Mavlink: Current climb rate in meters/second
         // DJI: m/s, positive values down

--- a/app/src/main/java/org/WenuLink/controllers/IController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/IController.kt
@@ -5,7 +5,6 @@ import com.MAVLink.common.msg_command_int
 import com.MAVLink.common.msg_command_long
 import kotlinx.coroutines.CoroutineScope
 import org.WenuLink.adapters.AircraftHandler
-import org.WenuLink.adapters.TelemetryHandler
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -49,7 +48,6 @@ interface IController {
 
     fun createMessage(
         messageID: Int,
-        telemetry: TelemetryHandler,
         aircraft: AircraftHandler
     ): MAVLinkMessage? {
         return null

--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -33,10 +33,8 @@ import com.MAVLink.enums.MAV_RESULT
 import com.MAVLink.minimal.msg_heartbeat
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import org.WenuLink.adapters.AircraftHandler
 import org.WenuLink.adapters.MessageRate
-import org.WenuLink.adapters.TelemetryHandler
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.adapters.MessageUtils
 import org.WenuLink.mavlink.MAVLinkClient
@@ -59,7 +57,6 @@ class MAVLinkController(
 ) {
 
     private val logger by taggedLogger("MAVLinkController")
-    private var telemetry = TelemetryHandler.getInstance()
     private var aircraft = AircraftHandler.getInstance()
     private var controllers: MutableList<IController> = mutableListOf()
     private var readOnlyMessageRate = true
@@ -145,9 +142,6 @@ class MAVLinkController(
     )
 
     init {
-        telemetry.registerHandlerScope(serviceScope)
-        aircraft.registerHandlerScope(serviceScope)
-
         // TODO: move to lazy loading?
         controllers += ConnectionController(client)
         controllers += CommandController(client)
@@ -289,7 +283,7 @@ class MAVLinkController(
 
             // create the message from controllers definitions
             val message = controllers.asSequence()
-                .mapNotNull { it.createMessage(rate.messageID, telemetry, aircraft) }
+                .mapNotNull { it.createMessage(rate.messageID, aircraft) }
                 .firstOrNull()
 
             if (message == null) {
@@ -366,36 +360,24 @@ class MAVLinkController(
 
     fun isStationConnected(): Boolean = connectionController.isGCSPresent
 
-    fun isTelemetryRunning() = telemetry.isActive()
-
-    suspend fun launchAndWaitTelemetry(timeout: Long = 5000L): Boolean {
-        if (telemetry.isActive()) return true
-        // Wait for data from SDK
-        telemetry.launchTelemetry(true)
-        return telemetry.waitTelemetryUp(timeout)
-    }
-
-    suspend fun waitTerminateTelemetry(timeout: Long = 5000L): Boolean {
-        if (!telemetry.isActive()) return true
-        telemetry.launchTelemetry(false)
-        readOnlyMessageRate = true
-        return telemetry.waitForTelemetryDown(timeout)
-    }
+    fun isTelemetryRunning() = aircraft.telemetry.isActive()
 
     fun launchListening() {
-        if (!telemetry.isActive()) return
+        if (!isTelemetryRunning()) return
         // Start listening for messages
         client.startListening(this@MAVLinkController::processMessage)
     }
 
     suspend fun launchSending(intervalTime: Long) {
-        if (!telemetry.isActive()) return
+        if (!isTelemetryRunning()) return
         // Start sending messages
         client.startSending(intervalTime, this@MAVLinkController::sendMessages)
     }
 
     suspend fun waitGroundStation(timeout: Long = 5000L): Boolean {
-        if (!telemetry.isActive()) return false
+        if (!isTelemetryRunning()) return false
+        // prevent to send data before initialization
+        readOnlyMessageRate = true
         // Send heartbeat and wait for any GCS
         connectionController.sendHeartbeat(aircraft)
         logger.d { "Waiting for GCS." }
@@ -409,7 +391,7 @@ class MAVLinkController(
         val parameter = controllers.filterIsInstance<ParameterController>().first()
         // TODO: Values must persist. Once connected, QGC does not ask for mission or parameter items twice
         // TODO: Implement as a setting or app-level variable
-        return navigation.wasRequested && parameter.wasRequested && aircraft.isHomeSet
+        return navigation.wasRequested && parameter.wasRequested && aircraft.state.isHomeSet()
     }
 
     suspend fun waitSystemReady(timeout: Long = 60000L): Boolean {
@@ -423,12 +405,18 @@ class MAVLinkController(
         return isSystemReady()
     }
 
-    suspend fun waitBoot() {
-        // Load and wait parameters for aircraft boot
+    suspend fun waitParameters(): Boolean {
+        // Load and wait parameters
+        logger.d { "Waiting for parameters" }
         val paramController = controllers.filterIsInstance<ParameterController>().first()
         paramController.load()
-        while (!paramController.wasInitialized) delay(1000L)
-        aircraft.boot()
+        AsyncUtils.waitReady(1000L, paramController::isLoaded)
+        return paramController.isLoaded()
+    }
+
+    suspend fun waitHomePosition(): Boolean {
+        // Wait for home position and add messages
+        aircraft.waitHome()
         // Send origin coordinates
         val navController = controllers.filterIsInstance<NavigationController>().first()
         client.sendMessage(navController.msgGpsGlobalOrigin(aircraft)!!)
@@ -437,6 +425,7 @@ class MAVLinkController(
             msg_home_position.MAVLINK_MSG_ID_HOME_POSITION,
             1_000_000L
         )
+        return true
     }
 
     fun shutdown() {

--- a/app/src/main/java/org/WenuLink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/NavigationController.kt
@@ -3,7 +3,6 @@ package org.WenuLink.controllers
 import com.MAVLink.Messages.MAVLinkMessage
 import com.MAVLink.common.msg_command_int
 import com.MAVLink.common.msg_command_long
-import com.MAVLink.common.msg_extended_sys_state
 import com.MAVLink.common.msg_global_position_int
 import com.MAVLink.common.msg_gps_global_origin
 import com.MAVLink.common.msg_gps_raw_int
@@ -25,7 +24,6 @@ import com.MAVLink.enums.MAV_MISSION_RESULT
 import com.MAVLink.enums.MAV_MISSION_TYPE
 import com.MAVLink.enums.MAV_RESULT
 import com.MAVLink.enums.MAV_SEVERITY
-import com.MAVLink.enums.MAV_VTOL_STATE
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
 import org.WenuLink.adapters.AircraftHandler
@@ -78,19 +76,19 @@ class NavigationController (
     ): Boolean {
         var processed = true
         when (commandLongMsg.command) {
-            MAV_CMD.MAV_CMD_MISSION_START -> missionStart(commandLongMsg, aircraft.mission)
+            MAV_CMD.MAV_CMD_MISSION_START -> missionStart(commandLongMsg, aircraft)
             else -> processed = false
         }
         return processed
     }
 
-    override fun createMessage(messageID: Int, telemetry: TelemetryHandler, aircraft: AircraftHandler): MAVLinkMessage? {
+    override fun createMessage(messageID: Int, aircraft: AircraftHandler): MAVLinkMessage? {
         return when (messageID) {
             msg_mission_current.MAVLINK_MSG_ID_MISSION_CURRENT -> msgMissionCurrent(aircraft.mission)
             msg_home_position.MAVLINK_MSG_ID_HOME_POSITION -> msgHomePosition(aircraft)
-            msg_gps_raw_int.MAVLINK_MSG_ID_GPS_RAW_INT -> msgRawGPSInt(telemetry)
-            msg_global_position_int.MAVLINK_MSG_ID_GLOBAL_POSITION_INT -> msgGlobalPositionInt(telemetry)
-            msg_local_position_ned.MAVLINK_MSG_ID_LOCAL_POSITION_NED -> msgLocalPositionNed(telemetry, aircraft)
+            msg_gps_raw_int.MAVLINK_MSG_ID_GPS_RAW_INT -> msgRawGPSInt(aircraft.telemetry)
+            msg_global_position_int.MAVLINK_MSG_ID_GLOBAL_POSITION_INT -> msgGlobalPositionInt(aircraft.telemetry)
+            msg_local_position_ned.MAVLINK_MSG_ID_LOCAL_POSITION_NED -> msgLocalPositionNed(aircraft)
             msg_gps_global_origin.MAVLINK_MSG_ID_GPS_GLOBAL_ORIGIN -> msgGpsGlobalOrigin(aircraft)
             else -> null
         }
@@ -241,7 +239,7 @@ class NavigationController (
             requestMissionItem(expectedSeq + 1)
         } else {
             // reached the end of the mission items
-            mission.upload{ error ->
+            mission.uploadWaypoints{ error ->
                 if (error != null) sendStatusText(error, MAV_SEVERITY.MAV_SEVERITY_ERROR)
             }
             sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED, mission)
@@ -263,9 +261,9 @@ class NavigationController (
         client.sendMessage(msg)
     }
 
-    fun missionStart(msg: MAVLinkMessage, mission: MissionHandler) {
+    fun missionStart(msg: MAVLinkMessage, aircraft: AircraftHandler) {
         // TODO: Process init seq to custom first mission element
-        mission.start()
+        aircraft.doMission()
         client.sendMessage(
             MessageUtils.msgCommandAck(
                 MAV_CMD.MAV_CMD_MISSION_START,
@@ -323,7 +321,7 @@ class NavigationController (
 
 
     fun msgHomePosition(aircraft: AircraftHandler): MAVLinkMessage? {
-        val coordinates = aircraft.getHomePosition() ?: return null
+        val coordinates = aircraft.homeCoordinates ?: return null
         val msg = msg_home_position()
         msg.latitude = MessageUtils.coordinateDJI2MAVLink(coordinates.lat)
         msg.longitude = MessageUtils.coordinateDJI2MAVLink(coordinates.long)
@@ -332,7 +330,7 @@ class NavigationController (
     }
 
     fun msgGlobalPositionInt(telemetry: TelemetryHandler): MAVLinkMessage? {
-        val telemetryData = telemetry.getTelemetryData() ?: return null
+        val telemetryData = telemetry.getData() ?: return null
         val msg = msg_global_position_int()
         msg.lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
         msg.lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
@@ -353,10 +351,10 @@ class NavigationController (
     }
 
     fun msgRawGPSInt(telemetry: TelemetryHandler): MAVLinkMessage? {
-        val telemetryData = telemetry.getTelemetryData() ?: return null
+        val telemetryData = telemetry.getData() ?: return null
 
         val msg = msg_gps_raw_int()
-        if (telemetry.isSimulationActive()) {
+        if (telemetry.isSimulationActive) {
             msg.fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_NO_GPS.toShort()
             return msg
         }
@@ -381,8 +379,8 @@ class NavigationController (
         return msg
     }
 
-    fun msgLocalPositionNed(telemetry: TelemetryHandler, aircraft: AircraftHandler): MAVLinkMessage? {
-        val telemetryData = telemetry.getTelemetryData() ?: return null
+    fun msgLocalPositionNed(aircraft: AircraftHandler): MAVLinkMessage? {
+        val telemetryData = aircraft.telemetry.getData() ?: return null
         val msg = msg_local_position_ned()
         msg.time_boot_ms = aircraft.systemBootTime
         msg.x = telemetryData.positionX
@@ -395,7 +393,7 @@ class NavigationController (
     }
 
     fun msgGpsGlobalOrigin(aircraft: AircraftHandler): MAVLinkMessage? {
-        val homeLoc = aircraft.getHomePosition() ?: return null
+        val homeLoc = aircraft.homeCoordinates ?: return null
         val msg = msg_gps_global_origin()
         msg.latitude = MessageUtils.coordinateDJI2MAVLink(homeLoc.lat)
         msg.longitude = MessageUtils.coordinateDJI2MAVLink(homeLoc.long)

--- a/app/src/main/java/org/WenuLink/controllers/ParameterController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/ParameterController.kt
@@ -39,6 +39,8 @@ class ParameterController (
         wasInitialized = true
     }
 
+    fun isLoaded() = wasInitialized
+
     override fun processMessage(msg: MAVLinkMessage, aircraft: AircraftHandler): Boolean {
         var processed = true
         when (msg.msgid) {

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.controllers.MAVLinkController
 import kotlin.getValue
 
@@ -57,16 +58,14 @@ class MAVLinkService {
 
     fun clientExists(): Boolean = client != null
 
-    fun clientIsRunning(): Boolean {
+    fun isServiceRunning(): Boolean {
         val hasJob = listeningJob?.isActive ?: false || sendingJob?.isActive ?: false
         return clientExists() && hasJob
     }
 
-    fun clientCanStart(): Boolean = clientExists() && !clientIsRunning()
+    fun clientCanStart(): Boolean = clientExists() && !isServiceRunning()
 
-    fun isServiceRunning(): Boolean = hasTelemetryRunning() && clientIsRunning()
-
-    fun isServiceStop(): Boolean = !(hasTelemetryRunning() || clientIsRunning())
+    fun isServiceStop(): Boolean = listeningJob == null && sendingJob == null
 
     fun createClient(serviceScope: CoroutineScope) {
         logger.d { "Creating MAVLinkClient for udp://$endpointAddress." }
@@ -97,11 +96,11 @@ class MAVLinkService {
 
     suspend fun launchService() {
         if (!clientCanStart()) {
-            logger.i { "MAVLinkClient is not ready, possibly is enabled or already running." }
+            logger.i { "MAVLinkClient is not ready, possibly is disabled or already running." }
             return
         }
 
-        if (!controller.launchAndWaitTelemetry(5000L)) {
+        if (!hasTelemetryRunning()) {
             logger.i { "Telemetry was not launch." }
             return
         }
@@ -120,14 +119,16 @@ class MAVLinkService {
 
         logger.d { "MAVLinkService (ready?=$isReady) (GCS?=${hasStationConnected()}) (listening?=${listeningJob?.isActive}) (sending=${sendingJob?.isActive})" }
 
-        mavlinkScope!!.launch {
-            isReady = controller.waitSystemReady(60000L)
-            if (isReady) controller.notifySystemReady()
-        }
+        val hasParams = controller.waitParameters()
+        if (hasParams) logger.d { "Parameters loaded" }
+
+        isReady = controller.waitSystemReady(60000L)
+        if (isReady) controller.notifySystemReady()
 
         logger.d { "MAVLinkService (ready?=$isReady) (GCS?=${hasStationConnected()}) (listening?=${listeningJob?.isActive}) (sending=${sendingJob?.isActive})" }
 
-        controller.waitBoot()
+        val hasHome = controller.waitHomePosition()
+        if (hasHome) logger.d { "Home position acquired" }
     }
 
     suspend fun stopService() {
@@ -145,7 +146,15 @@ class MAVLinkService {
         logger.d { "MAVLinkService (ready?=$isReady) (GCS?=${hasStationConnected()}) (listening?=${listeningJob?.isActive}) (sending=${sendingJob?.isActive})" }
         sendingJob = null
         listeningJob = null
-        controller.waitTerminateTelemetry(5000L)
     }
 
+    suspend fun waitStart() {
+        AsyncUtils.waitReady(isReady = ::isServiceRunning)
+        logger.i { "MAVLinkService started: ${isServiceRunning()}" }
+    }
+
+    suspend fun waitStop() {
+        AsyncUtils.waitReady(isReady = ::isServiceStop)
+        logger.i { "MAVLinkService stop: ${isServiceStop()}" }
+    }
 }

--- a/app/src/main/java/org/WenuLink/sdk/MissionActionManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/MissionActionManager.kt
@@ -51,6 +51,10 @@ object MissionActionManager {
         missionControl.stopTimeline()
     }
 
+    fun pause() {
+        missionControl.pauseTimeline()
+    }
+
     // ---- Actions ----
 
     fun scheduleTakeOff(): DJIError? {

--- a/app/src/main/java/org/WenuLink/sdk/RCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/RCManager.kt
@@ -72,12 +72,11 @@ object RCManager {
         rcInstance?.setHardwareStateCallback { hardwareState -> // DJI: range [-660,660]
             updateData(
                 RCData(
-                    throttleSetting = (hardwareState.leftStick!!.verticalPosition + 660) / 1320,
-                    // Mavlink: 1000 to 2000 with 1500 = 1.5ms as center...
-                    leftStickVertical = (hardwareState.leftStick!!.verticalPosition * 0.8).toInt() + 1500,
-                    leftStickHorizontal = (hardwareState.leftStick!!.horizontalPosition * 0.8).toInt() + 1500,
-                    rightStickVertical = (hardwareState.rightStick!!.verticalPosition * 0.8).toInt() + 1500,
-                    rightStickHorizontal = (hardwareState.rightStick!!.horizontalPosition * 0.8).toInt() + 1500,
+                    throttleSetting = hardwareState.leftStick!!.verticalPosition,
+                    leftStickVertical = hardwareState.leftStick!!.verticalPosition,
+                    leftStickHorizontal = hardwareState.leftStick!!.horizontalPosition,
+                    rightStickVertical = hardwareState.rightStick!!.verticalPosition,
+                    rightStickHorizontal = hardwareState.rightStick!!.horizontalPosition,
                     buttonC1 = hardwareState.c1Button?.isClicked ?: false,
                     buttonC2 = hardwareState.c2Button?.isClicked ?: false,
                     buttonC3 = hardwareState.c3Button?.isClicked ?: false,

--- a/app/src/main/java/org/WenuLink/sdk/RCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/RCManager.kt
@@ -52,7 +52,6 @@ object RCManager {
 
     @Synchronized
     private fun updateData(data: RCData?) {
-        // TODO: safety: bajar MAVLink si detecta control de usuario
         lastData = data
     }
 
@@ -69,7 +68,7 @@ object RCManager {
 
     private fun startHardwareListener() {
         logger.d { "Starting RC HardwareListener" }
-        rcInstance?.setHardwareStateCallback { hardwareState -> // DJI: range [-660,660]
+        rcInstance?.setHardwareStateCallback { hardwareState ->
             updateData(
                 RCData(
                     throttleSetting = hardwareState.leftStick!!.verticalPosition,

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -10,11 +10,12 @@ import androidx.lifecycle.viewModelScope
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.WenuLink.WenuLinkApp
+import org.WenuLink.adapters.AircraftHandler
 import org.WenuLink.adapters.WenuLinkService
 import org.WenuLink.adapters.TelemetryData
-import org.WenuLink.adapters.TelemetryHandler
 import org.WenuLink.adapters.AsyncUtils
 import kotlin.getValue
 
@@ -24,38 +25,39 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
 
     private var thisApp = (getApplication() as WenuLinkApp)
 
+    private val aircraft: AircraftHandler = AircraftHandler.getInstance()
+
     private val _isServiceRunning = MutableStateFlow(false)
     val isServiceRunning: StateFlow<Boolean> = _isServiceRunning
+
+    val isDataFlowing: StateFlow<Boolean> = aircraft.telemetry.isBroadcasting
 
     private val _telemetryData = MutableLiveData<TelemetryData?>()
     val telemetryData: LiveData<TelemetryData?> = _telemetryData
 
     // To expose the StateFlow for MAVLink
     val isMAVLinkRunning: StateFlow<Boolean>
-        get() = thisApp.wenuLinkService?.getMAVLinkState() ?: MutableStateFlow(false)
+        get() = thisApp.wenuLinkService?.mavlinkStateFlow ?: MutableStateFlow(false)
 
     // To expose the StateFlow for WebRTC
     val isWebRTCRunning: StateFlow<Boolean>
-        get() = thisApp.wenuLinkService?.getWebRTCState() ?: MutableStateFlow(false)
+        get() = thisApp.wenuLinkService?.webRTCStateFlow ?: MutableStateFlow(false)
 
-    val isDataFlowing: StateFlow<Boolean> = TelemetryHandler.getInstance().isBroadcasting
+    private val _isSimReady = MutableStateFlow(false)
+    val isSimReady: StateFlow<Boolean> = _isSimReady.asStateFlow()
 
-    fun isSimulationReady(): Boolean = TelemetryHandler.getInstance().isSimulationReady()
-
-    fun isSimulationActive(): Boolean = TelemetryHandler.getInstance().isSimulationActive()
-
-    fun enableSimulation(enable: Boolean) = viewModelScope.launch {
-        // TODO check for required conditions
-        TelemetryHandler.getInstance().enableSimulation(enable)
-//        thisApp.droneService?.enableSimulation(enable)
-        // TODO: updateSimulationState?
-    }
+    fun isSimulationReady(): Boolean = aircraft.telemetry.isSimulationAvailable
 
     fun isServiceRunning(): Boolean = thisApp.wenuLinkService?.isRunning() ?: false
 
     fun isServiceReady(): Boolean = thisApp.wenuLinkService?.isReady() ?: false
 
-    fun isServiceStop() = !isServiceRunning()
+    init {
+        viewModelScope.launch {
+            // Wait for flag change
+            _isSimReady.value = AsyncUtils.waitTimeout(1000, 60000, ::isSimulationReady)
+        }
+    }
 
     fun startService() {
         if (thisApp.wenuLinkService != null) return
@@ -79,11 +81,19 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
         runMAVLink(false)
         runWebRTC(false)
         viewModelScope.launch {
-            AsyncUtils.waitReady(isReady = ::isServiceStop)
+            AsyncUtils.waitReady(isReady = thisApp.wenuLinkService!!::isPowerOff)
+            aircraft.telemetry.enableSimulation(false) // always disable
             thisApp.stopService(
                 Intent(thisApp, WenuLinkService::class.java)
             )
             _isServiceRunning.value = false
+        }
+    }
+
+    fun forceStop() {
+        if (thisApp.wenuLinkService == null) return
+        viewModelScope.launch {
+            thisApp.wenuLinkService?.stopCommands()
         }
     }
 
@@ -105,8 +115,9 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    fun runService(run: Boolean) {
+    fun runService(run: Boolean, simEnabled: Boolean = false) {
         logger.d { "runService($run)" }
+        if (simEnabled) aircraft.telemetry.enableSimulation(true)
         if (run) startService()
         else stopService()
     }


### PR DESCRIPTION
The following changes aims to solve #15 and the architecture was affedted. `AircraftHandler` now act as entry point for all SDK drone-related interaction. `TelemetryHandler` and `MissionHandler` now are contained by `AircraftHandler` for easy mission and commands management.

A full start/stop and pause/resume test is needed to ensure a good functioning, maybe this can me merged and create new issues for possible bugs.

@mjohenneken you can accept the merge if you don't have any comments