### PR TITLE
fix: send heartbeats in loop while waiting for GCS connection

### DIFF
--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -34,6 +34,7 @@ import com.MAVLink.minimal.msg_heartbeat
 import io.getstream.log.taggedLogger
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import org.WenuLink.adapters.AircraftHandler
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.adapters.MessageRate
@@ -391,15 +392,22 @@ class MAVLinkController(
         )
     }
 
-    suspend fun waitGroundStation(timeout: Long = 5000L): Boolean {
+    suspend fun waitGroundStation(timeout: Long = 30000L): Boolean {
         if (!isTelemetryRunning()) return false
+
         // prevent to send data before initialization
         readOnlyMessageRate = true
-        // Send heartbeat and wait for any GCS
-        connectionController.sendHeartbeat(aircraft)
+
         logger.d { "Waiting for GCS." }
-        AsyncUtils.waitTimeout(10, timeout, ::isStationConnected)
+
+        // Send heartbeat and wait for any GCS
+        val deadline = System.currentTimeMillis() + timeout
+        while (!isStationConnected() && System.currentTimeMillis() < deadline) {
+            connectionController.sendHeartbeat(aircraft)
+            delay(1000L)
+        }
         logger.i { "GCS found?: ${isStationConnected()}." }
+
         return isStationConnected()
     }
 

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -133,7 +133,8 @@ class MAVLinkService {
         if (hasParams) logger.d { "Parameters loaded" }
 
         isReady = controller.waitSystemReady(60000L)
-        if (isReady) controller.notifySystemReady()
+        if (isReady) logger.w { "System not ready, unlocking telemetry anyway." }
+        controller.notifySystemReady()
 
         logger.d {
             "MAVLinkService (ready?=$isReady) " +


### PR DESCRIPTION
MAVLinkController.waitGroundStation() previously sent a single heartbeat before timing out, causing the GCS handshake to fail if QGC wasn't immediately responsive. Changed to send heartbeats every 1000ms for up to 30 seconds per the MAVLink spec.

Additionally, MAVLinkService.launchService() no longer stops the service if no GCS responds within the timeout window — it logs a warning and continues. notifySystemReady() is now always called after waitSystemReady() to ensure telemetry data streams are unlocked regardless of system readiness state.