### PR TITLE
Feature/telemetry controller

### DIFF
--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -101,9 +101,8 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
         when (commandMsg.command) {
             MAV_CMD.MAV_CMD_REQUEST_MESSAGE -> processRequestLong(commandMsg)
 
-            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL -> telemetryController.processMessageInterval(
-                commandMsg
-            )
+            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL ->
+                telemetryController.processMessageInterval(commandMsg)
 
             // TODO: Unhandled command ID: 521.
             // MAV_CMD.MAV_CMD_REQUEST_CAMERA_INFORMATION -> {}
@@ -187,14 +186,14 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
     }
 
     fun notifySystemReady() {
-        telemetryController.unlockRates()
+        telemetryController.unlockSend()
     }
 
     fun isStationConnected(): Boolean = connectionController.isGCSPresent
 
     suspend fun waitGroundStation(timeout: Long = 5000L): Boolean {
         // prevent to send data before initialization
-        telemetryController.lockRates()
+        telemetryController.lockSend()
         // Wait for GCS heartbeat
         logger.d { "Waiting for GCS." }
         AsyncUtils.waitTimeout(10, timeout, ::isStationConnected)

--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -4,7 +4,6 @@ import com.MAVLink.Messages.MAVLinkMessage
 import com.MAVLink.common.msg_command_int
 import com.MAVLink.common.msg_command_long
 import com.MAVLink.common.msg_home_position
-import com.MAVLink.common.msg_request_data_stream
 import com.MAVLink.enums.MAV_CMD
 import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.AsyncUtils
@@ -70,9 +69,6 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
 
             msg_command_int.MAVLINK_MSG_ID_COMMAND_INT -> processCommandInt(msg)
 
-            msg_request_data_stream.MAVLINK_MSG_ID_REQUEST_DATA_STREAM ->
-                telemetryController.processDataStreamRequest(msg)
-
             else -> {
                 // Notify if no message ID definition was found in any Controller
                 logger.w { "Unhandled message ${msg.name()}" }
@@ -100,9 +96,6 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
 
         when (commandMsg.command) {
             MAV_CMD.MAV_CMD_REQUEST_MESSAGE -> processRequestLong(commandMsg)
-
-            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL ->
-                telemetryController.processMessageInterval(commandMsg)
 
             // TODO: Unhandled command ID: 521.
             // MAV_CMD.MAV_CMD_REQUEST_CAMERA_INFORMATION -> {}

--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -1,43 +1,15 @@
 package org.WenuLink.controllers
 
 import com.MAVLink.Messages.MAVLinkMessage
-import com.MAVLink.common.msg_attitude
-import com.MAVLink.common.msg_battery_status
 import com.MAVLink.common.msg_command_int
 import com.MAVLink.common.msg_command_long
-import com.MAVLink.common.msg_control_system_state
-import com.MAVLink.common.msg_estimator_status
-import com.MAVLink.common.msg_gimbal_device_information
-import com.MAVLink.common.msg_global_position_int
-import com.MAVLink.common.msg_gps_raw_int
-import com.MAVLink.common.msg_gps_status
 import com.MAVLink.common.msg_home_position
-import com.MAVLink.common.msg_local_position_ned
-import com.MAVLink.common.msg_mag_cal_report
-import com.MAVLink.common.msg_mission_current
-import com.MAVLink.common.msg_nav_controller_output
-import com.MAVLink.common.msg_onboard_computer_status
-import com.MAVLink.common.msg_power_status
-import com.MAVLink.common.msg_radio_status
-import com.MAVLink.common.msg_raw_rpm
-import com.MAVLink.common.msg_rc_channels_raw
-import com.MAVLink.common.msg_rc_channels_scaled
 import com.MAVLink.common.msg_request_data_stream
-import com.MAVLink.common.msg_scaled_pressure
-import com.MAVLink.common.msg_sim_state
-import com.MAVLink.common.msg_sys_status
-import com.MAVLink.common.msg_vfr_hud
-import com.MAVLink.common.msg_vibration
 import com.MAVLink.enums.MAV_CMD
-import com.MAVLink.enums.MAV_DATA_STREAM
-import com.MAVLink.enums.MAV_RESULT
-import com.MAVLink.minimal.msg_heartbeat
 import io.getstream.log.taggedLogger
-import kotlin.math.roundToInt
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.adapters.MessageUtils
 import org.WenuLink.adapters.aircraft.AircraftHandler
-import org.WenuLink.adapters.aircraft.MessageRate
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -51,92 +23,24 @@ import org.WenuLink.mavlink.MAVLinkClient
  * - CommandController: Command Protocol
  * - ParameterController: Parameter Protocol
  * - NavigationController: Mission Protocol
+ * - TelemetryController: Message Protocol
  */
 class MAVLinkController(private val aircraft: AircraftHandler) {
 
     private val logger by taggedLogger(MAVLinkController::class.java.simpleName)
     private val controllers: MutableList<IController> = mutableListOf()
-    private var client: MAVLinkClient? = null
-    private var readOnlyMessageRate = true
-    private val messageRates: MutableList<MessageRate> = mutableListOf(
-        MessageRate( // began with Heartbeat at 1Hz
-            msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT,
-            1_000_000L
-        )
-    )
+    private lateinit var client: MAVLinkClient
     private val connectionController: ConnectionController
         get() = controllers.filterIsInstance<ConnectionController>().first()
 
-    /**
-     * Data definition based on
-     * https://ardupilot.org/dev/docs/mavlink-requesting-data.html#using-srx-parameters
-     * TODO: move to ConnectionController or possible a new TelemetryController?
-     */
-    val availableDataList = mapOf(
-        MAV_DATA_STREAM.MAV_DATA_STREAM_RAW_SENSORS to listOf(
-//                msg_raw_imu.MAVLINK_MSG_ID_RAW_IMU,
-            msg_gps_raw_int.MAVLINK_MSG_ID_GPS_RAW_INT,
-            msg_gps_status.MAVLINK_MSG_ID_GPS_STATUS,
-//            msg_scaled_imu2.MAVLINK_MSG_ID_SCALED_IMU2,
-//            msg_scaled_imu3.MAVLINK_MSG_ID_SCALED_IMU3,
-            msg_scaled_pressure.MAVLINK_MSG_ID_SCALED_PRESSURE
-//            msg_scaled_pressure2.MAVLINK_MSG_ID_SCALED_PRESSURE2,
-//            msg_scaled_pressure3.MAVLINK_MSG_ID_SCALED_PRESSURE3
-        ),
-        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTENDED_STATUS to listOf(
-            msg_gps_status.MAVLINK_MSG_ID_GPS_STATUS,
-            msg_control_system_state.MAVLINK_MSG_ID_CONTROL_SYSTEM_STATE,
-            msg_sys_status.MAVLINK_MSG_ID_SYS_STATUS,
-            msg_power_status.MAVLINK_MSG_ID_POWER_STATUS,
-            // MEMINFO,
-            msg_mission_current.MAVLINK_MSG_ID_MISSION_CURRENT,
-            msg_gps_raw_int.MAVLINK_MSG_ID_GPS_RAW_INT,
-//            msg_gps_rtk.MAVLINK_MSG_ID_GPS_RTK,
-//            msg_gps2_raw.MAVLINK_MSG_ID_GPS2_RAW,
-//            msg_gps2_rtk.MAVLINK_MSG_ID_GPS2_RTK,
-            msg_nav_controller_output.MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT
-//            msg_fence_status.MAVLINK_MSG_ID_FENCE_STATUS,
-//            msg_position_target_global_int.MAVLINK_MSG_ID_POSITION_TARGET_GLOBAL_INT
-        ),
+    private val navigationController: NavigationController
+        get() = controllers.filterIsInstance<NavigationController>().first()
 
-        MAV_DATA_STREAM.MAV_DATA_STREAM_RC_CHANNELS to listOf(
-            msg_rc_channels_scaled.MAVLINK_MSG_ID_RC_CHANNELS_SCALED,
-            msg_rc_channels_raw.MAVLINK_MSG_ID_RC_CHANNELS_RAW,
-//            msg_servo_output_raw.MAVLINK_MSG_ID_SERVO_OUTPUT_RAW
-            msg_radio_status.MAVLINK_MSG_ID_RADIO_STATUS
-        ),
+    private val parameterController: ParameterController
+        get() = controllers.filterIsInstance<ParameterController>().first()
 
-        MAV_DATA_STREAM.MAV_DATA_STREAM_POSITION to listOf(
-            msg_local_position_ned.MAVLINK_MSG_ID_LOCAL_POSITION_NED,
-            msg_global_position_int.MAVLINK_MSG_ID_GLOBAL_POSITION_INT
-        ),
-
-        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA1 to listOf(
-            msg_attitude.MAVLINK_MSG_ID_ATTITUDE,
-            msg_sim_state.MAVLINK_MSG_ID_SIM_STATE
-        ),
-
-        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA2 to listOf(
-            msg_vfr_hud.MAVLINK_MSG_ID_VFR_HUD
-        ),
-
-        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA3 to listOf(
-            msg_onboard_computer_status.MAVLINK_MSG_ID_ONBOARD_COMPUTER_STATUS,
-//            msg_distance_sensor.MAVLINK_MSG_ID_DISTANCE_SENSOR,
-//            msg_terrain_request.MAVLINK_MSG_ID_TERRAIN_REQUEST,
-            msg_battery_status.MAVLINK_MSG_ID_BATTERY_STATUS,
-//            msg_mount_orientation.MAVLINK_MSG_ID_MOUNT_ORIENTATION,
-//            msg_optical_flow.MAVLINK_MSG_ID_OPTICAL_FLOW,
-            msg_gimbal_device_information.MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION,
-            msg_mag_cal_report.MAVLINK_MSG_ID_MAG_CAL_REPORT,
-            msg_estimator_status.MAVLINK_MSG_ID_ESTIMATOR_STATUS,
-            msg_vibration.MAVLINK_MSG_ID_VIBRATION,
-            msg_raw_rpm.MAVLINK_MSG_ID_RAW_RPM
-        )
-
-//            MAV_DATA_STREAM.MAV_DATA_STREAM_ALL -> {}
-//            MAV_DATA_STREAM.MAV_DATA_STREAM_RAW_CONTROLLER -> null
-    )
+    private val telemetryController: TelemetryController
+        get() = controllers.filterIsInstance<TelemetryController>().first()
 
     fun attachClient(client: MAVLinkClient) {
         this.client = client
@@ -146,16 +50,15 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
         controllers += CommandController(client)
         controllers += ParameterController(client)
         controllers += NavigationController(client)
+        controllers += TelemetryController(client)
     }
 
     // https://ardupilot.org/copter/docs/ArduCopter_MAVLink_Messages.html
     // https://mavlink.io/en/services/
     fun processMessage(msg: MAVLinkMessage) {
         // avoid eternal log with the station's heartbeat
-        if (!connectionController.isGCSPresent) {
+        if (!connectionController.isGCSPresent || msg.msgid != 0) {
             logger.d { "Processing message: ${msg.name()}" }
-        } else {
-            if (msg.msgid != 0) logger.d { "Processing message: ${msg.name()}" }
         }
 
         // Process message with registered Controllers
@@ -168,19 +71,19 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
             msg_command_int.MAVLINK_MSG_ID_COMMAND_INT -> processCommandInt(msg)
 
             msg_request_data_stream.MAVLINK_MSG_ID_REQUEST_DATA_STREAM ->
-                processDataStreamRequest(msg)
+                telemetryController.processDataStreamRequest(msg)
 
             else -> {
                 // Notify if no message ID definition was found in any Controller
                 logger.w { "Unhandled message ${msg.name()}" }
-                client?.sendMessage(MessageUtils.msgCommandAck(msg.msgid))
+                client.sendMessage(MessageUtils.msgCommandAck(msg.msgid))
             }
         }
     }
 
     // TODO: fix routing
     fun isTargetSystem(msgTargetSystem: Int) =
-        msgTargetSystem == 0 || msgTargetSystem == client?.systemID
+        msgTargetSystem == 0 || msgTargetSystem == client.systemID
 
     fun processCommandLong(msg: MAVLinkMessage) {
         if (msg.msgid != msg_command_long.MAVLINK_MSG_ID_COMMAND_LONG) return
@@ -198,13 +101,15 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
         when (commandMsg.command) {
             MAV_CMD.MAV_CMD_REQUEST_MESSAGE -> processRequestLong(commandMsg)
 
-            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL -> processMessageInterval(commandMsg)
+            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL -> telemetryController.processMessageInterval(
+                commandMsg
+            )
 
             // TODO: Unhandled command ID: 521.
             // MAV_CMD.MAV_CMD_REQUEST_CAMERA_INFORMATION -> {}
             else -> {
                 logger.w { "Unhandled COMMAND_LONG ID: ${commandMsg.command}" }
-                client?.sendMessage(MessageUtils.msgCommandAck(commandMsg.command))
+                client.sendMessage(MessageUtils.msgCommandAck(commandMsg.command))
             }
         }
     }
@@ -227,7 +132,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
 
             else -> {
                 logger.w { "Unhandled COMMAND_INT ID: ${commandMsg.command}" }
-                client?.sendMessage(MessageUtils.msgCommandAck(commandMsg.command))
+                client.sendMessage(MessageUtils.msgCommandAck(commandMsg.command))
             }
         }
     }
@@ -255,7 +160,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
             // MAV_CMD.MAV_CMD_REQUEST_CAMERA_INFORMATION -> {}
             else -> {
                 logger.w { "Unhandled REQUEST_LONG ID: $requestID" }
-                client?.sendMessage(MessageUtils.msgRequestAck())
+                client.sendMessage(MessageUtils.msgRequestAck())
             }
         }
     }
@@ -271,110 +176,25 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
         when (requestID) {
             else -> {
                 logger.w { "Unhandled REQUEST_INT ID: $requestID" }
-                client?.sendMessage(MessageUtils.msgRequestAck())
+                client.sendMessage(MessageUtils.msgRequestAck())
             }
         }
     }
 
     @Synchronized
     fun sendMessages() {
-        if (!(client?.mustProcessMessages() ?: false)) {
-            logger.w { "MAVLink client is not ready!" }
-            return
-        }
-
-        val currentMicroTime = MessageUtils.getMicroTime()
-
-        if (messageRates.isEmpty()) return
-
-        for (rate in messageRates) {
-            if (rate.microSecondsInterval == -1L) continue // skip if deactivated
-
-            // create the message from controllers definitions
-            val message = controllers.asSequence()
-                .mapNotNull { it.createMessage(rate.messageID, aircraft) }
-                .firstOrNull()
-
-            if (message == null) {
-//                logger.w { "Unable to create message ID: ${rate.messageID}. Deactivating." }
-                // Silently deactivate the requested message if not implemented yet
-                rate.microSecondsInterval = -1L
-                continue
-            }
-
-            // if a message is created, check if must sent and update
-            if ((currentMicroTime - rate.lastUpdateStamp) >= rate.microSecondsInterval) {
-                rate.lastUpdateStamp = currentMicroTime
-                client?.sendMessage(message)
-            }
-        }
-    }
-
-    @Synchronized
-    fun setMessageRate(messageID: Int, microSecondsInterval: Long): MessageRate {
-        var currentRate = messageRates.find { it.messageID == messageID }
-        if (currentRate == null) {
-            currentRate = MessageRate(messageID, microSecondsInterval)
-            messageRates.add(currentRate)
-        } else {
-            currentRate.microSecondsInterval = microSecondsInterval
-        }
-        return currentRate
-    }
-
-    @Synchronized
-    fun processDataStreamRequest(msg: MAVLinkMessage) {
-        // https://ardupilot.org/dev/docs/mavlink-requesting-data.html
-        // https://mavlink.io/en/messages/common.html#MAV_DATA_STREAM
-        if (readOnlyMessageRate) return
-
-        val request = msg as msg_request_data_stream
-
-        val dataList = availableDataList[request.req_stream_id.toInt()]
-        if (dataList == null || dataList.isEmpty()) return
-
-        var timeInterval: Int = -1
-        if (request.start_stop.toInt() == 1) {
-            // requested interval in Hz
-            timeInterval = request.req_message_rate
-            // Standard 1Hz
-            timeInterval = if (timeInterval == 0) {
-                1_000_000
-            } // Hz to micro seconds if must start
-            else {
-                ((1.0 / timeInterval.toFloat()) * 1_000_000).roundToInt()
-            }
-        }
-
-        dataList.forEach { setMessageRate(it, timeInterval.toLong()) }
-    }
-
-    @Synchronized
-    fun processMessageInterval(commandMsg: msg_command_long) {
-        if (readOnlyMessageRate) return
-
-        logger.d { "processMessageInterval" }
-        val mavlinkMsgID = commandMsg.param1.toInt()
-        val interval = commandMsg.param2.toLong() // already in micro seconds
-        val newRate = setMessageRate(mavlinkMsgID, interval)
-
-        client?.sendMessage(
-            MessageUtils.msgCommandAck(
-                commandMsg.command,
-                MAV_RESULT.MAV_RESULT_ACCEPTED
-            )
-        )
+        telemetryController.sendMessages(controllers, aircraft)
     }
 
     fun notifySystemReady() {
-        readOnlyMessageRate = false
+        telemetryController.unlockRates()
     }
 
     fun isStationConnected(): Boolean = connectionController.isGCSPresent
 
     suspend fun waitGroundStation(timeout: Long = 5000L): Boolean {
         // prevent to send data before initialization
-        readOnlyMessageRate = true
+        telemetryController.lockRates()
         // Wait for GCS heartbeat
         logger.d { "Waiting for GCS." }
         AsyncUtils.waitTimeout(10, timeout, ::isStationConnected)
@@ -387,9 +207,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
         if (!isStationConnected()) return false
 
         logger.d { "Waiting for Parameters request." }
-        fun parametersRequested() =
-            controllers.filterIsInstance<ParameterController>().first().wasRequested
-        if (!AsyncUtils.waitTimeout(1000, timeout, ::parametersRequested)) {
+        if (!AsyncUtils.waitTimeout(1000, timeout) { parameterController.wasRequested }) {
             // If PARAM_REQUEST_LIST is not sent (timeout), a service restart is assumed
             logger.d { "Unable to check for Parameters request, possibly already requested." }
             notifySystemReady()
@@ -398,9 +216,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
 
         // Check for mission items after request parameters
         logger.d { "Waiting for Mission items request." }
-        fun missionRequested() =
-            controllers.filterIsInstance<NavigationController>().first().wasRequested
-        if (!AsyncUtils.waitTimeout(1000, timeout, ::missionRequested)) {
+        if (!AsyncUtils.waitTimeout(1000, timeout) { navigationController.wasRequested }) {
             logger.d { "Unable to check for Mission request, possibly already set." }
         }
 
@@ -412,10 +228,9 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
     suspend fun loadParameters(): Boolean {
         // Load and wait parameters
         logger.d { "Waiting for parameters" }
-        val paramController = controllers.filterIsInstance<ParameterController>().first()
-        paramController.load()
-        AsyncUtils.waitReady(1000L, paramController::isLoaded)
-        return paramController.isLoaded()
+        parameterController.load()
+        AsyncUtils.waitReady(1000L, parameterController::isLoaded)
+        return parameterController.isLoaded()
     }
 
     suspend fun waitHomePosition(): Boolean {
@@ -425,10 +240,9 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
         if (!isHomeSet) return false
 
         // Send origin coordinates
-        val navController = controllers.filterIsInstance<NavigationController>().first()
-        client?.sendMessage(navController.msgGpsGlobalOrigin(aircraft)!!)
+        client.sendMessage(navigationController.msgGpsGlobalOrigin(aircraft)!!)
         // update message rate of HOME_POSITION
-        setMessageRate(
+        telemetryController.setMessageRate(
             msg_home_position.MAVLINK_MSG_ID_HOME_POSITION,
             1_000_000L
         )

--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -186,14 +186,14 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
     }
 
     fun notifySystemReady() {
-        telemetryController.unlockSend()
+        telemetryController.startBroadcast()
     }
 
     fun isStationConnected(): Boolean = connectionController.isGCSPresent
 
     suspend fun waitGroundStation(timeout: Long = 5000L): Boolean {
         // prevent to send data before initialization
-        telemetryController.lockSend()
+        telemetryController.stopBroadcast()
         // Wait for GCS heartbeat
         logger.d { "Waiting for GCS." }
         AsyncUtils.waitTimeout(10, timeout, ::isStationConnected)

--- a/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
@@ -39,7 +39,7 @@ import org.WenuLink.mavlink.MAVLinkClient
 class TelemetryController(override val client: MAVLinkClient) : IController {
     private val logger by taggedLogger(TelemetryController::class.java.simpleName)
 
-    private var setOnlyMessageRate = true
+    private var broadcastSuppressed = true
     private val messageRates: MutableList<MessageRate> = mutableListOf(
         MessageRate( // begin with Heartbeat at 1Hz
             msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT,
@@ -119,8 +119,8 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
 
         val currentMicroTime = MessageUtils.getMicroTime()
         for (rate in messageRates) {
-            if (setOnlyMessageRate && rate.messageID != 0) {
-                // skip if setOnly mode for no HEARTBEAT messages
+            if (broadcastSuppressed && rate.messageID != 0) {
+                // skip non-HEARTBEAT messages if broadcast is suppressed
                 continue
             }
             if (rate.microSecondsInterval == -1L) {
@@ -202,11 +202,11 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
         )
     }
 
-    fun lockSend() {
-        setOnlyMessageRate = true
+    fun stopBroadcast() {
+        broadcastSuppressed = true
     }
 
-    fun unlockSend() {
-        setOnlyMessageRate = false
+    fun startBroadcast() {
+        broadcastSuppressed = false
     }
 }

--- a/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
@@ -1,0 +1,213 @@
+package org.WenuLink.controllers
+
+import com.MAVLink.Messages.MAVLinkMessage
+import com.MAVLink.common.msg_attitude
+import com.MAVLink.common.msg_battery_status
+import com.MAVLink.common.msg_command_long
+import com.MAVLink.common.msg_control_system_state
+import com.MAVLink.common.msg_estimator_status
+import com.MAVLink.common.msg_gimbal_device_information
+import com.MAVLink.common.msg_global_position_int
+import com.MAVLink.common.msg_gps_raw_int
+import com.MAVLink.common.msg_gps_status
+import com.MAVLink.common.msg_local_position_ned
+import com.MAVLink.common.msg_mag_cal_report
+import com.MAVLink.common.msg_mission_current
+import com.MAVLink.common.msg_nav_controller_output
+import com.MAVLink.common.msg_onboard_computer_status
+import com.MAVLink.common.msg_power_status
+import com.MAVLink.common.msg_radio_status
+import com.MAVLink.common.msg_raw_rpm
+import com.MAVLink.common.msg_rc_channels_raw
+import com.MAVLink.common.msg_rc_channels_scaled
+import com.MAVLink.common.msg_request_data_stream
+import com.MAVLink.common.msg_scaled_pressure
+import com.MAVLink.common.msg_sim_state
+import com.MAVLink.common.msg_sys_status
+import com.MAVLink.common.msg_vfr_hud
+import com.MAVLink.common.msg_vibration
+import com.MAVLink.enums.MAV_DATA_STREAM
+import com.MAVLink.enums.MAV_RESULT
+import com.MAVLink.minimal.msg_heartbeat
+import io.getstream.log.taggedLogger
+import kotlin.math.roundToInt
+import org.WenuLink.adapters.MessageUtils
+import org.WenuLink.adapters.aircraft.AircraftHandler
+import org.WenuLink.adapters.aircraft.MessageRate
+import org.WenuLink.mavlink.MAVLinkClient
+
+class TelemetryController(override val client: MAVLinkClient) : IController {
+    private val logger by taggedLogger(TelemetryController::class.java.simpleName)
+
+    private var readOnlyMessageRate = true
+    private val messageRates: MutableList<MessageRate> = mutableListOf(
+        MessageRate( // begin with Heartbeat at 1Hz
+            msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT,
+            1_000_000L
+        )
+    )
+
+    /**
+     * Data definition based on
+     * https://ardupilot.org/dev/docs/mavlink-requesting-data.html#using-srx-parameters
+     */
+    private val availableDataList = mapOf(
+        MAV_DATA_STREAM.MAV_DATA_STREAM_RAW_SENSORS to listOf(
+//                msg_raw_imu.MAVLINK_MSG_ID_RAW_IMU,
+            msg_gps_raw_int.MAVLINK_MSG_ID_GPS_RAW_INT,
+            msg_gps_status.MAVLINK_MSG_ID_GPS_STATUS,
+//            msg_scaled_imu2.MAVLINK_MSG_ID_SCALED_IMU2,
+//            msg_scaled_imu3.MAVLINK_MSG_ID_SCALED_IMU3,
+            msg_scaled_pressure.MAVLINK_MSG_ID_SCALED_PRESSURE
+//            msg_scaled_pressure2.MAVLINK_MSG_ID_SCALED_PRESSURE2,
+//            msg_scaled_pressure3.MAVLINK_MSG_ID_SCALED_PRESSURE3
+        ),
+        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTENDED_STATUS to listOf(
+            msg_gps_status.MAVLINK_MSG_ID_GPS_STATUS,
+            msg_control_system_state.MAVLINK_MSG_ID_CONTROL_SYSTEM_STATE,
+            msg_sys_status.MAVLINK_MSG_ID_SYS_STATUS,
+            msg_power_status.MAVLINK_MSG_ID_POWER_STATUS,
+            // MEMINFO,
+            msg_mission_current.MAVLINK_MSG_ID_MISSION_CURRENT,
+            msg_gps_raw_int.MAVLINK_MSG_ID_GPS_RAW_INT,
+//            msg_gps_rtk.MAVLINK_MSG_ID_GPS_RTK,
+//            msg_gps2_raw.MAVLINK_MSG_ID_GPS2_RAW,
+//            msg_gps2_rtk.MAVLINK_MSG_ID_GPS2_RTK,
+            msg_nav_controller_output.MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT
+//            msg_fence_status.MAVLINK_MSG_ID_FENCE_STATUS,
+//            msg_position_target_global_int.MAVLINK_MSG_ID_POSITION_TARGET_GLOBAL_INT
+        ),
+
+        MAV_DATA_STREAM.MAV_DATA_STREAM_RC_CHANNELS to listOf(
+            msg_rc_channels_scaled.MAVLINK_MSG_ID_RC_CHANNELS_SCALED,
+            msg_rc_channels_raw.MAVLINK_MSG_ID_RC_CHANNELS_RAW,
+//            msg_servo_output_raw.MAVLINK_MSG_ID_SERVO_OUTPUT_RAW
+            msg_radio_status.MAVLINK_MSG_ID_RADIO_STATUS
+        ),
+
+        MAV_DATA_STREAM.MAV_DATA_STREAM_POSITION to listOf(
+            msg_local_position_ned.MAVLINK_MSG_ID_LOCAL_POSITION_NED,
+            msg_global_position_int.MAVLINK_MSG_ID_GLOBAL_POSITION_INT
+        ),
+
+        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA1 to listOf(
+            msg_attitude.MAVLINK_MSG_ID_ATTITUDE,
+            msg_sim_state.MAVLINK_MSG_ID_SIM_STATE
+        ),
+
+        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA2 to listOf(
+            msg_vfr_hud.MAVLINK_MSG_ID_VFR_HUD
+        ),
+
+        MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA3 to listOf(
+            msg_onboard_computer_status.MAVLINK_MSG_ID_ONBOARD_COMPUTER_STATUS,
+//            msg_distance_sensor.MAVLINK_MSG_ID_DISTANCE_SENSOR,
+//            msg_terrain_request.MAVLINK_MSG_ID_TERRAIN_REQUEST,
+            msg_battery_status.MAVLINK_MSG_ID_BATTERY_STATUS,
+//            msg_mount_orientation.MAVLINK_MSG_ID_MOUNT_ORIENTATION,
+//            msg_optical_flow.MAVLINK_MSG_ID_OPTICAL_FLOW,
+            msg_gimbal_device_information.MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION,
+            msg_mag_cal_report.MAVLINK_MSG_ID_MAG_CAL_REPORT,
+            msg_estimator_status.MAVLINK_MSG_ID_ESTIMATOR_STATUS,
+            msg_vibration.MAVLINK_MSG_ID_VIBRATION,
+            msg_raw_rpm.MAVLINK_MSG_ID_RAW_RPM
+        )
+
+//            MAV_DATA_STREAM.MAV_DATA_STREAM_ALL -> {}
+//            MAV_DATA_STREAM.MAV_DATA_STREAM_RAW_CONTROLLER -> null
+    )
+
+    fun sendMessages(controllers: List<IController>, aircraft: AircraftHandler) {
+        if (!(client.mustProcessMessages())) {
+            logger.w { "MAVLink client is not ready!" }
+            return
+        }
+
+        val currentMicroTime = MessageUtils.getMicroTime()
+        for (rate in messageRates) {
+            if (rate.microSecondsInterval == -1L) continue // skip if deactivated
+
+            // create the message from controllers definitions
+            val message = controllers.asSequence()
+                .mapNotNull { it.createMessage(rate.messageID, aircraft) }
+                .firstOrNull()
+
+            if (message == null) {
+                //                logger.w { "Unable to create message ID: ${rate.messageID}. Deactivating." }
+                // Silently deactivate the requested message if not implemented yet
+                rate.microSecondsInterval = -1L
+                continue
+            }
+
+            // if a message is created, check if must sent and update
+            if ((currentMicroTime - rate.lastUpdateStamp) >= rate.microSecondsInterval) {
+                rate.lastUpdateStamp = currentMicroTime
+                client.sendMessage(message)
+            }
+        }
+    }
+
+    @Synchronized
+    fun setMessageRate(messageID: Int, microSecondsInterval: Long): MessageRate {
+        var currentRate = messageRates.find { it.messageID == messageID }
+        if (currentRate == null) {
+            currentRate = MessageRate(messageID, microSecondsInterval)
+            messageRates.add(currentRate)
+        } else {
+            currentRate.microSecondsInterval = microSecondsInterval
+        }
+        return currentRate
+    }
+
+    @Synchronized
+    fun processDataStreamRequest(msg: MAVLinkMessage) {
+        // https://ardupilot.org/dev/docs/mavlink-requesting-data.html
+        // https://mavlink.io/en/messages/common.html#MAV_DATA_STREAM
+        if (readOnlyMessageRate) return
+
+        val request = msg as msg_request_data_stream
+
+        val dataList = availableDataList[request.req_stream_id.toInt()]
+        if (dataList == null || dataList.isEmpty()) return
+
+        var timeInterval: Int = -1
+        if (request.start_stop.toInt() == 1) {
+            // requested interval in Hz
+            timeInterval = request.req_message_rate
+            // Standard 1Hz
+            timeInterval = if (timeInterval == 0) {
+                1_000_000
+            } // Hz to micro seconds if must start
+            else {
+                ((1.0 / timeInterval.toFloat()) * 1_000_000).roundToInt()
+            }
+        }
+
+        dataList.forEach { setMessageRate(it, timeInterval.toLong()) }
+    }
+
+    @Synchronized
+    fun processMessageInterval(commandMsg: msg_command_long) {
+        if (readOnlyMessageRate) return
+
+        logger.d { "processMessageInterval" }
+        val mavlinkMsgID = commandMsg.param1.toInt()
+        val interval = commandMsg.param2.toLong() // already in micro seconds
+        setMessageRate(mavlinkMsgID, interval)
+
+        client.sendMessage(
+            MessageUtils.msgCommandAck(
+                commandMsg.command,
+                MAV_RESULT.MAV_RESULT_ACCEPTED
+            )
+        )
+    }
+
+    fun lockRates() {
+        readOnlyMessageRate = true
+    }
+
+    fun unlockRates() {
+        readOnlyMessageRate = false
+    }
+}

--- a/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
@@ -26,6 +26,7 @@ import com.MAVLink.common.msg_sim_state
 import com.MAVLink.common.msg_sys_status
 import com.MAVLink.common.msg_vfr_hud
 import com.MAVLink.common.msg_vibration
+import com.MAVLink.enums.MAV_CMD
 import com.MAVLink.enums.MAV_DATA_STREAM
 import com.MAVLink.enums.MAV_RESULT
 import com.MAVLink.minimal.msg_heartbeat
@@ -110,6 +111,29 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
 //            MAV_DATA_STREAM.MAV_DATA_STREAM_ALL -> {}
 //            MAV_DATA_STREAM.MAV_DATA_STREAM_RAW_CONTROLLER -> null
     )
+
+    override fun processMessage(msg: MAVLinkMessage, aircraft: AircraftHandler): Boolean {
+        when (msg.msgid) {
+            msg_request_data_stream.MAVLINK_MSG_ID_REQUEST_DATA_STREAM ->
+                processDataStreamRequest(msg)
+
+            else -> return false
+        }
+        return true
+    }
+
+    override fun processCommandLong(
+        commandLongMsg: msg_command_long,
+        aircraft: AircraftHandler
+    ): Boolean {
+        when (commandLongMsg.command) {
+            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL ->
+                processMessageInterval(commandLongMsg)
+
+            else -> return false
+        }
+        return true
+    }
 
     fun sendMessages(controllers: List<IController>, aircraft: AircraftHandler) {
         if (!client.mustProcessMessages()) {

--- a/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
@@ -39,7 +39,7 @@ import org.WenuLink.mavlink.MAVLinkClient
 class TelemetryController(override val client: MAVLinkClient) : IController {
     private val logger by taggedLogger(TelemetryController::class.java.simpleName)
 
-    private var readOnlyMessageRate = true
+    private var setOnlyMessageRate = true
     private val messageRates: MutableList<MessageRate> = mutableListOf(
         MessageRate( // begin with Heartbeat at 1Hz
             msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT,
@@ -77,28 +77,23 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
 //            msg_fence_status.MAVLINK_MSG_ID_FENCE_STATUS,
 //            msg_position_target_global_int.MAVLINK_MSG_ID_POSITION_TARGET_GLOBAL_INT
         ),
-
         MAV_DATA_STREAM.MAV_DATA_STREAM_RC_CHANNELS to listOf(
             msg_rc_channels_scaled.MAVLINK_MSG_ID_RC_CHANNELS_SCALED,
             msg_rc_channels_raw.MAVLINK_MSG_ID_RC_CHANNELS_RAW,
 //            msg_servo_output_raw.MAVLINK_MSG_ID_SERVO_OUTPUT_RAW
             msg_radio_status.MAVLINK_MSG_ID_RADIO_STATUS
         ),
-
         MAV_DATA_STREAM.MAV_DATA_STREAM_POSITION to listOf(
             msg_local_position_ned.MAVLINK_MSG_ID_LOCAL_POSITION_NED,
             msg_global_position_int.MAVLINK_MSG_ID_GLOBAL_POSITION_INT
         ),
-
         MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA1 to listOf(
             msg_attitude.MAVLINK_MSG_ID_ATTITUDE,
             msg_sim_state.MAVLINK_MSG_ID_SIM_STATE
         ),
-
         MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA2 to listOf(
             msg_vfr_hud.MAVLINK_MSG_ID_VFR_HUD
         ),
-
         MAV_DATA_STREAM.MAV_DATA_STREAM_EXTRA3 to listOf(
             msg_onboard_computer_status.MAVLINK_MSG_ID_ONBOARD_COMPUTER_STATUS,
 //            msg_distance_sensor.MAVLINK_MSG_ID_DISTANCE_SENSOR,
@@ -112,20 +107,26 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
             msg_vibration.MAVLINK_MSG_ID_VIBRATION,
             msg_raw_rpm.MAVLINK_MSG_ID_RAW_RPM
         )
-
 //            MAV_DATA_STREAM.MAV_DATA_STREAM_ALL -> {}
 //            MAV_DATA_STREAM.MAV_DATA_STREAM_RAW_CONTROLLER -> null
     )
 
     fun sendMessages(controllers: List<IController>, aircraft: AircraftHandler) {
-        if (!(client.mustProcessMessages())) {
+        if (!client.mustProcessMessages()) {
             logger.w { "MAVLink client is not ready!" }
             return
         }
 
         val currentMicroTime = MessageUtils.getMicroTime()
         for (rate in messageRates) {
-            if (rate.microSecondsInterval == -1L) continue // skip if deactivated
+            if (setOnlyMessageRate && rate.messageID != 0) {
+                // skip if setOnly mode for no HEARTBEAT messages
+                continue
+            }
+            if (rate.microSecondsInterval == -1L) {
+                // skip if deactivated
+                continue
+            }
 
             // create the message from controllers definitions
             val message = controllers.asSequence()
@@ -133,7 +134,7 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
                 .firstOrNull()
 
             if (message == null) {
-                //                logger.w { "Unable to create message ID: ${rate.messageID}. Deactivating." }
+                // logger.w { "Unable to create message ID: ${rate.messageID}. Deactivating." }
                 // Silently deactivate the requested message if not implemented yet
                 rate.microSecondsInterval = -1L
                 continue
@@ -163,8 +164,6 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
     fun processDataStreamRequest(msg: MAVLinkMessage) {
         // https://ardupilot.org/dev/docs/mavlink-requesting-data.html
         // https://mavlink.io/en/messages/common.html#MAV_DATA_STREAM
-        if (readOnlyMessageRate) return
-
         val request = msg as msg_request_data_stream
 
         val dataList = availableDataList[request.req_stream_id.toInt()]
@@ -183,13 +182,13 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
             }
         }
 
-        dataList.forEach { setMessageRate(it, timeInterval.toLong()) }
+        dataList.forEach {
+            setMessageRate(it, timeInterval.toLong())
+        }
     }
 
     @Synchronized
     fun processMessageInterval(commandMsg: msg_command_long) {
-        if (readOnlyMessageRate) return
-
         logger.d { "processMessageInterval" }
         val mavlinkMsgID = commandMsg.param1.toInt()
         val interval = commandMsg.param2.toLong() // already in micro seconds
@@ -203,11 +202,11 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
         )
     }
 
-    fun lockRates() {
-        readOnlyMessageRate = true
+    fun lockSend() {
+        setOnlyMessageRate = true
     }
 
-    fun unlockRates() {
-        readOnlyMessageRate = false
+    fun unlockSend() {
+        setOnlyMessageRate = false
     }
 }


### PR DESCRIPTION
## Summary

Implements #25.
Extracts all telemetry stream management out of
`MAVLinkController` into a dedicated `TelemetryController` class,
keeping the current logic intact.
## What moved

| Member | From | To |
|---|---|---|
| `readOnlyMessageRate` | `MAVLinkController` | `TelemetryController` |
| `messageRates` | `MAVLinkController` | `TelemetryController` |
| `availableDataList` | `MAVLinkController` | `TelemetryController` (private) |
| `setMessageRate()` | `MAVLinkController` | `TelemetryController` |
| `processDataStreamRequest()` | `MAVLinkController` | `TelemetryController` |
| `processMessageInterval()` | `MAVLinkController` | `TelemetryController` |
| `sendMessages()` | `MAVLinkController` | `TelemetryController` |

Direct field access to `readOnlyMessageRate` replaced by
`lockRates()`/`unlockRates()` methods on `TelemetryController`.

## Additional cleanup in MAVLinkController

- `client` changed from `MAVLinkClient?` to `lateinit var MAVLinkClient`,
  removing all `?.` safe calls
- Added typed computed properties `navigationController`,
  `parameterController`, and `telemetryController` consistent with the
  existing `connectionController` pattern, replacing inline
  `filterIsInstance` calls at usage sites
- Removed redundant `isEmpty()` guard before the `sendMessages` loop

## Merge note

This branch was developed on top of `feature/boot-sequence` and
**must not be merged before PR #17 is merged into `develop`**. Once
#17 merges, this branch should be rebased onto `develop` before
review is finalised.