### PR TITLE
feature: fix busy-wait of requestShootPhoto

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
@@ -32,6 +32,8 @@ class CameraHandler {
     private var currentCommand: CameraCommand? = null
     private val commandChannel =
         Channel<Pair<CameraCommand, (String?) -> Unit>>(capacity = Channel.UNLIMITED)
+    private var handlerScope: CoroutineScope? = null
+    private var activeCameraJob: Job? = null
     var sequenceIndex = 0
     var captureTimestamp = System.currentTimeMillis()
     val lastCaptureMillis
@@ -163,5 +165,23 @@ class CameraHandler {
 
     fun canRecordVideo(cameraIdx: Int = 0): Boolean = CameraManager.canRecordVideo()
 
-    fun registerHandlerScope(scope: CoroutineScope) = startCommandProcessor(scope)
+    fun registerHandlerScope(scope: CoroutineScope) {
+        handlerScope = scope
+        startCommandProcessor(scope)
+    }
+
+    fun launchCameraJob(block: suspend () -> Unit): Job? {
+        activeCameraJob?.cancel()
+        return handlerScope
+            ?.launch { block() }
+            ?.also { job ->
+                activeCameraJob = job
+                job.invokeOnCompletion { activeCameraJob = null }
+            }
+    }
+
+    fun cancelCameraJob() {
+        activeCameraJob?.cancel()
+        activeCameraJob = null
+    }
 }

--- a/app/src/main/java/org/WenuLink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/CameraController.kt
@@ -15,6 +15,7 @@ import com.MAVLink.enums.STORAGE_TYPE
 import com.MAVLink.enums.STORAGE_USAGE_FLAG
 import io.getstream.log.taggedLogger
 import kotlin.math.roundToLong
+import kotlinx.coroutines.delay
 import org.WenuLink.adapters.MessageUtils
 import org.WenuLink.adapters.OrientationUtils
 import org.WenuLink.adapters.aircraft.AircraftHandler
@@ -182,7 +183,7 @@ class CameraController(
         return cameraInfo
     }
 
-    private fun requestShootPhoto(
+    private suspend fun requestShootPhoto(
         commandLongMsg: msg_command_long,
         aircraft: AircraftHandler,
         cameraInfo: CameraMetadata
@@ -201,9 +202,11 @@ class CameraController(
 
         while (mustCapture()) {
             if (totalPhotos != 1 && aircraft.cameras.lastCaptureMillis < intervalMillis) {
+                delay(100)
                 continue
             }
             if (!aircraft.cameras.captureIdle(cameraInfo.id)) {
+                delay(100)
                 continue
             }
 
@@ -214,13 +217,15 @@ class CameraController(
                 if (!captureOk) logger.w { "Error in shootPhoto: $error" }
 
                 val photoData = ImageMetadata(
-                    aircraft.cameras.sequenceIndex,
-                    captureOk,
-                    cameraInfo.id,
-                    aircraft.telemetry.getData()!!
+                    index = aircraft.cameras.sequenceIndex,
+                    captureOk = captureOk,
+                    cameraID = cameraInfo.id,
+                    telemetry = aircraft.telemetry.getData()!!
                 )
 
-                client.sendMessage(msgImageCaptured(photoData))
+                client.sendMessage(
+                    msgImageCaptured(photoData)
+                )
             }
         }
     }
@@ -245,7 +250,9 @@ class CameraController(
             )
         )
 
-        requestShootPhoto(commandLongMsg, aircraft, cameraInfo)
+        aircraft.cameras.launchCameraJob {
+            requestShootPhoto(commandLongMsg, aircraft, cameraInfo)
+        }
     }
 
     private fun requestStopCapture(commandLongMsg: msg_command_long, aircraft: AircraftHandler) {
@@ -269,6 +276,7 @@ class CameraController(
         )
 
         aircraft.cameras.sequenceIndex = -1
+        aircraft.cameras.cancelCameraJob()
     }
 
     private fun requestStartRecording(commandLongMsg: msg_command_long, aircraft: AircraftHandler) {


### PR DESCRIPTION
Fixes #30 

Addresses the busy-wait in requestShootPhoto identified during review of #27.

Changes:
- CameraHandler stores its CoroutineScope and exposes launchCameraJob()
- requestShootPhoto is now a suspend function with delay(100) in both wait branches
- requestStartCapture launches requestShootPhoto via launchCameraJob instead of calling it directly