### PR TITLE
style/refactor: Kotlin code quality improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/WenuLi
 
 ## Styleguide
 
-The overall coding style is based con actual Kotlin/Android development specifications. Specific definitions needs to be made for a more detailed style to address. Initially, the only requirement is to follow the package and visibility aspects so far.
+The overall coding style is based on actual Kotlin/Android development specifications. Specific definitions needs to be made for a more detailed style to address. Initially, the only requirement is to follow the package and visibility aspects so far.
 
 In terms of package organization:
 

--- a/app/src/main/java/org/WenuLink/MainActivity.kt
+++ b/app/src/main/java/org/WenuLink/MainActivity.kt
@@ -76,11 +76,11 @@ class MainActivity : ComponentActivity() {
         )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            permissionsList += arrayOf(Manifest.permission.FOREGROUND_SERVICE)
+            permissionsList += Manifest.permission.FOREGROUND_SERVICE
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            permissionsList += arrayOf(Manifest.permission.POST_NOTIFICATIONS)
+            permissionsList += Manifest.permission.POST_NOTIFICATIONS
         }
 
         val missingPermissions = permissionsList.filter {
@@ -152,7 +152,7 @@ class MainActivity : ComponentActivity() {
         if (!servicesViewModel.isServiceRunning.value) {
             homeViewModel.stopSDK(applicationContext)
         }
-        // TODO: mostrar aviso para forzar salida
+        // TODO: display warning to force exit
     }
 
     @Composable

--- a/app/src/main/java/org/WenuLink/adapters/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/MissionHandler.kt
@@ -4,8 +4,6 @@ import com.MAVLink.common.msg_mission_item_int
 import com.MAVLink.enums.MAV_CMD
 import com.MAVLink.enums.MISSION_STATE
 import io.getstream.log.taggedLogger
-import kotlin.math.max
-import kotlin.math.min
 import org.WenuLink.adapters.aircraft.Coordinates3D
 import org.WenuLink.adapters.mission.MissionAction
 import org.WenuLink.adapters.mission.MissionAssembler
@@ -27,7 +25,7 @@ class MissionHandler {
 
     private val logger by taggedLogger(MissionHandler::class.java.simpleName)
     private val assembler = MissionAssembler()
-    var flightSpeed: Float = 5.0f
+    var flightSpeed = 5.0f
         private set
     var currentSequence = 0
         private set
@@ -112,7 +110,7 @@ class MissionHandler {
         // Assumes Global only
         val coordinates = getItemCoordinates(itemMsg)
         val delay = itemMsg.param1.toInt()
-        val yaw: Float = itemMsg.param4
+        val yaw = itemMsg.param4
 
         // TODO: airframe check
 //         val frameReference = itemMsg.frame.toInt()
@@ -249,8 +247,8 @@ class MissionHandler {
         logger.i { "doReposition" }
         MissionActionManager.clear()
         val error = MissionActionManager.scheduleGoTo(
-            coordinates = target,
-            speed = speed
+            target,
+            speed
         )
 
         if (error != null) {

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -85,7 +85,7 @@ class WenuLinkService : Service() {
             contentText = "Sending periodic heartbeats to GCS\n"
         }
         if (::webRTC.isInitialized) {
-            contentText += "WebRTC streaming: ${webRTC.mediaOptions.VIDEO_CAMERA_NAME}"
+            contentText += "WebRTC streaming: ${webRTC.mediaOptions.videoCameraName}"
         }
         // .setContentText(webRTC.mediaOptions?.VIDEO_CAMERA_NAME)
         // TODO: update according to each present service

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -1,7 +1,5 @@
 package org.WenuLink.adapters
 
-import android.R
-import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -9,6 +7,7 @@ import android.app.Service
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import androidx.core.app.NotificationCompat
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,7 +25,7 @@ import org.WenuLink.webrtc.WebRTCService
 
 class WenuLinkService : Service() {
     private val logger by taggedLogger(WenuLinkService::class.java.simpleName)
-    private var serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private lateinit var mavlink: MAVLinkService
     private lateinit var webRTC: WebRTCService
     private lateinit var aircraft: AircraftHandler
@@ -57,21 +56,16 @@ class WenuLinkService : Service() {
     private fun startForegroundServiceWithNotification() {
         val channelId = "MAVLINK_CHANNEL"
 
+        // Create channel (required for Android 8+)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 channelId,
                 "WenuLink Service",
                 NotificationManager.IMPORTANCE_LOW
             )
-            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+            getSystemService(NotificationManager::class.java)
+                .createNotificationChannel(channel)
         }
-
-        val notification: Notification.Builder =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                Notification.Builder(this, channelId)
-            } else {
-                Notification.Builder(this)
-            }
 
         val pendingIntent = PendingIntent.getActivity(
             this,
@@ -87,14 +81,13 @@ class WenuLinkService : Service() {
         if (::webRTC.isInitialized) {
             contentText += "WebRTC streaming: ${webRTC.mediaOptions.videoCameraName}"
         }
-        // .setContentText(webRTC.mediaOptions?.VIDEO_CAMERA_NAME)
         // TODO: update according to each present service
         startForeground(
             1,
-            notification
+            NotificationCompat.Builder(this, channelId)
                 .setContentTitle("WenuLink service running")
                 .setContentText(contentText)
-                .setSmallIcon(R.drawable.ic_menu_compass)
+                .setSmallIcon(android.R.drawable.ic_menu_compass)
                 .setContentIntent(pendingIntent) // Open MainActivity when tapped
                 .setOngoing(true)
                 .build()
@@ -226,6 +219,6 @@ class WenuLinkService : Service() {
             stopMAVLinkService()?.join()
             aircraft.unload() // aircraft.dispatch(PowerOffCommand())
         }
-        AsyncUtils.waitTimeout(intervalTime = 1000L, timeout = 20000L, isReady = ::isPowerOff)
+        AsyncUtils.waitTimeout(1000L, 20000L, ::isPowerOff)
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
@@ -96,7 +96,6 @@ object MessageUtils {
 }
 
 object OrientationUtils {
-
     fun eulerDegToQuaternion(rollDeg: Double, pitchDeg: Double, yawDeg: Double): Quaternion {
         val roll = Math.toRadians(rollDeg)
         val pitch = Math.toRadians(pitchDeg)

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
@@ -26,7 +26,6 @@ data class BootCommand(val timeout: Long = 5000L) : AircraftCommand {
 }
 
 data class ArmCommand(val timeout: Long = 5000L) : AircraftCommand {
-
     override fun validate(ctx: AircraftHandler): String? {
         if (!ctx.sensorsHealthy) return "Sensors failing"
         return ctx.stateMachine.canDispatch(ArmTransition)
@@ -55,7 +54,6 @@ data class ArmCommand(val timeout: Long = 5000L) : AircraftCommand {
 }
 
 data class DisarmCommand(val timeout: Long = 5000L) : AircraftCommand {
-
     override fun validate(ctx: AircraftHandler): String? =
         ctx.stateMachine.canDispatch(StandbyTransition)
 
@@ -72,7 +70,6 @@ data class DisarmCommand(val timeout: Long = 5000L) : AircraftCommand {
 }
 
 data class TakeoffCommand(val initialAltitude: Float = 2f) : AircraftCommand {
-
     override fun validate(ctx: AircraftHandler): String? =
         ctx.stateMachine.canDispatch(TakeoffTransition)
 
@@ -136,7 +133,6 @@ data class RepositionCommand(val targetCoordinates: Coordinates3D, val speed: Fl
 }
 
 object GoHomeCommand : AircraftCommand {
-
     override fun validate(ctx: AircraftHandler): String? =
         ctx.stateMachine.canDispatch(FlyingTransition)
 

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -35,29 +35,29 @@ class AircraftHandler : IHandler<AircraftHandler> {
     }
 
     private val logger by taggedLogger(AircraftHandler::class.java.simpleName)
-    val startTimestamp: Long = System.currentTimeMillis()
-    val systemBootTime: Long get() = System.currentTimeMillis() - startTimestamp
-    var baseMode: Int = MAV_MODE_FLAG.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
+    val startTimestamp = System.currentTimeMillis()
+    val systemBootTime
+        get() = System.currentTimeMillis() - startTimestamp
+    var baseMode = MAV_MODE_FLAG.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
         private set
     var copterFlightMode = ArduCopterFlightMode.STABILIZE
         private set
     val stateMachine = AircraftStateMachine()
     val state: AircraftState get() = stateMachine.state
-    var sensorsTimestamp: Long = startTimestamp
-    var homeTimestamp: Long = startTimestamp
+    var sensorsTimestamp = startTimestamp
+    var homeTimestamp = startTimestamp
     var sensorsHealthy = false
         private set
     val mission = MissionHandler.getInstance()
     val telemetry = TelemetryHandler.getInstance()
     val cameras = CameraHandler.getInstance()
-    var hasCameras: Boolean = false
+    var hasCameras = false
     var isPowerOff = true
     private val processor = CommandProcessor(this, logger)
     private var monitorJob: Job? = null
 
-    override fun dispatchCommand(cmd: ICommand<AircraftHandler>, onResult: (String?) -> Unit) {
+    override fun dispatchCommand(cmd: ICommand<AircraftHandler>, onResult: (String?) -> Unit) =
         processor.dispatch(cmd, onResult)
-    }
 
     override fun stopCommand(): String? = processor.cancel()
 
@@ -74,16 +74,9 @@ class AircraftHandler : IHandler<AircraftHandler> {
     }
 
     private fun isModeAllowed(mode: ArduCopterFlightMode): Boolean = when (mode) {
-        ArduCopterFlightMode.GUIDED ->
-            state.isFlying() || state.isStandBy()
-
-        ArduCopterFlightMode.AUTO ->
-            state.isFlying() && mission.isMissionRunning
-
-        ArduCopterFlightMode.LAND,
-        ArduCopterFlightMode.RTL ->
-            state.isFlying()
-
+        ArduCopterFlightMode.GUIDED -> state.isFlying() || state.isStandBy()
+        ArduCopterFlightMode.AUTO -> state.isFlying() && mission.isMissionRunning
+        ArduCopterFlightMode.LAND, ArduCopterFlightMode.RTL -> state.isFlying()
         else -> true
     }
 
@@ -104,21 +97,22 @@ class AircraftHandler : IHandler<AircraftHandler> {
     }
 
     private fun enforceModeConsistency() {
-        if (!isModeAllowed(copterFlightMode)) {
-            val fallbackMode = if (state.isFlying()) {
-                ArduCopterFlightMode.GUIDED
-            } else {
-                ArduCopterFlightMode.STABILIZE
-            }
-
-            logger.w {
-                "Mode $copterFlightMode invalid for state ${state.mavlink}, fallback to $fallbackMode"
-            }
-
-            setMode(fallbackMode)
-        } else {
+        if (isModeAllowed(copterFlightMode)) {
             syncBaseMode()
+            return
         }
+
+        val fallbackMode = if (state.isFlying()) {
+            ArduCopterFlightMode.GUIDED
+        } else {
+            ArduCopterFlightMode.STABILIZE
+        }
+
+        logger.w {
+            "Mode $copterFlightMode invalid for state ${state.mavlink}, fallback to $fallbackMode"
+        }
+
+        setMode(fallbackMode)
     }
 
     suspend fun syncState(sensorsInterval: Long = 1000L, homeInterval: Long = 5000L) {
@@ -185,8 +179,8 @@ class AircraftHandler : IHandler<AircraftHandler> {
     suspend fun sensorChecks(timeout: Long = 10000L): Boolean {
         val perSensorTime = (timeout.toFloat() / 3).roundToLong()
         logger.i { "Waiting sensors data" }
-        var sensorsOk = true
-        if (!AsyncUtils.waitTimeout(100L, timeout, isReady = telemetry::isReadingSensors)) {
+
+        if (!AsyncUtils.waitTimeout(100L, timeout, telemetry::isReadingSensors)) {
             logger.e { "No sensor readings!" }
             return false
         }
@@ -195,25 +189,26 @@ class AircraftHandler : IHandler<AircraftHandler> {
         val compassOk = AsyncUtils.waitTimeout(
             100L,
             perSensorTime,
-            isReady = telemetry::isCompassOk
+            telemetry::isCompassOk
         )
         if (!compassOk) logger.e { "Compass error!" }
-        sensorsOk = sensorsOk && compassOk
 
         // https://developer.dji.com/api-reference/android-api/Components/IMUState/DJIIMUState.html
         val accOk = AsyncUtils.waitTimeout(
             100L,
             perSensorTime,
-            isReady = telemetry::isAccelerometerOk
+            telemetry::isAccelerometerOk
         )
         if (!accOk) logger.e { "Accelerometer error!" }
-        sensorsOk = sensorsOk && accOk
 
-        val gyroOk = AsyncUtils.waitTimeout(100L, perSensorTime, isReady = telemetry::isGyroscopeOk)
+        val gyroOk = AsyncUtils.waitTimeout(
+            100L,
+            perSensorTime,
+            telemetry::isGyroscopeOk
+        )
         if (!gyroOk) logger.e { "Gyroscope error!" }
-        sensorsOk = sensorsOk && gyroOk
 
-        return sensorsOk
+        return compassOk && accOk && gyroOk
     }
 
     // check for home location and set
@@ -410,11 +405,9 @@ class AircraftHandler : IHandler<AircraftHandler> {
 
         val motorsUpdated = AsyncUtils.waitTimeout(timeout = timeout, isReady = ::motorsMatchTarget)
 
-        if (mustArm && state.isArmed()) {
+        if (motorsUpdated) {
             logger.i { "Aircraft armed" }
-        }
-
-        if (!mustArm && !state.isArmed()) {
+        } else {
             logger.i { "Aircraft in standby" }
         }
 
@@ -423,12 +416,15 @@ class AircraftHandler : IHandler<AircraftHandler> {
 
     fun getCurrentCoordinates(): Coordinates3D? {
         logger.d { "getCurrentCoordinates" }
-        val takeoffAltitude = FCManager.fcInstance?.state?.takeoffLocationAltitude
+
         val location = FCManager.fcInstance?.state?.aircraftLocation ?: return null
+        val takeoffAltitude = FCManager.fcInstance?.state?.takeoffLocationAltitude
+
         logger.d {
             "getCurrentCoordinates: currentAltitude: ${location.altitude}, " +
                 "takeoffAltitude: $takeoffAltitude"
         }
+
         return Coordinates3D(location.longitude, location.latitude, location.altitude)
     }
 
@@ -450,7 +446,7 @@ class AircraftHandler : IHandler<AircraftHandler> {
     suspend fun awaitFlightState(takingOff: Boolean): Boolean {
         logger.d { "Waiting for ${if (takingOff) "taking off" else "touching ground"}" }
         fun flyingMatchesTarget(): Boolean = takingOff == state.isFlying()
-        AsyncUtils.waitReady(100L, isReady = ::flyingMatchesTarget)
+        AsyncUtils.waitReady(100L, ::flyingMatchesTarget)
 
         if (takingOff && state.isFlying()) {
             logger.d { "Aircraft flying" }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
@@ -17,7 +17,6 @@ data class AircraftState(
     val controlAuthority: ControlAuthority = ControlAuthority.NONE,
     val homeCoordinates: Coordinates3D? = null
 ) {
-
     fun isHomeSet() = homeCoordinates != null
 
     fun isStandBy() = mavlink == MAV_STATE.MAV_STATE_STANDBY
@@ -35,16 +34,15 @@ data class AircraftState(
     fun isPowerOff() = mavlink == MAV_STATE.MAV_STATE_POWEROFF
 
     fun resolveFrom(isArmed: Boolean, isFlying: Boolean): AircraftState {
-        val mavState = when (this.mavlink) {
+        val criticalStates = intArrayOf(
             MAV_STATE.MAV_STATE_FLIGHT_TERMINATION,
             MAV_STATE.MAV_STATE_CRITICAL,
-            MAV_STATE.MAV_STATE_EMERGENCY -> this.mavlink
-
-            else -> if (isArmed) {
-                MAV_STATE.MAV_STATE_ACTIVE
-            } else {
-                MAV_STATE.MAV_STATE_STANDBY
-            }
+            MAV_STATE.MAV_STATE_EMERGENCY
+        )
+        val mavState = when {
+            this.mavlink in criticalStates -> this.mavlink
+            isArmed -> MAV_STATE.MAV_STATE_ACTIVE
+            else -> MAV_STATE.MAV_STATE_STANDBY
         }
 
         val landedState = when {
@@ -67,31 +65,27 @@ data class AircraftState(
 }
 
 sealed interface StateTransition {
-
     fun canTransition(from: AircraftState): String?
 
     fun reduce(from: AircraftState): AircraftState
 }
 
 object InitialTransition : StateTransition {
-
-    override fun canTransition(from: AircraftState): String? =
-        if (!(from.isBoot() || from.isPowerOff())) {
+    override fun canTransition(from: AircraftState): String? = when {
+        !(from.isBoot() || from.isPowerOff()) ->
             "Cannot reset to initial from MAV_STATE=${from.mavlink}"
-        } else {
-            null
-        }
+
+        else -> null
+    }
 
     override fun reduce(from: AircraftState): AircraftState =
         from.copy(mavlink = MAV_STATE.MAV_STATE_UNINIT)
 }
 
 object BootTransition : StateTransition {
-
-    override fun canTransition(from: AircraftState): String? = if (!from.isUninitialized()) {
-        "Already initialized"
-    } else {
-        null
+    override fun canTransition(from: AircraftState): String? = when {
+        !from.isUninitialized() -> "Already initialized"
+        else -> null
     }
 
     override fun reduce(from: AircraftState): AircraftState =
@@ -99,11 +93,9 @@ object BootTransition : StateTransition {
 }
 
 object StandbyTransition : StateTransition {
-
-    override fun canTransition(from: AircraftState): String? = if (from.isFlying()) {
-        "Aircraft is flying"
-    } else {
-        null
+    override fun canTransition(from: AircraftState): String? = when {
+        from.isFlying() -> "Aircraft is flying"
+        else -> null
     }
 
     override fun reduce(from: AircraftState): AircraftState = from.copy(
@@ -113,11 +105,9 @@ object StandbyTransition : StateTransition {
 }
 
 object ArmTransition : StateTransition {
-
-    override fun canTransition(from: AircraftState): String? = if (!from.isStandBy()) {
-        "Not ready to arm"
-    } else {
-        null
+    override fun canTransition(from: AircraftState): String? = when {
+        !from.isStandBy() -> "Not ready to arm"
+        else -> null
     }
 
     override fun reduce(from: AircraftState): AircraftState =
@@ -125,7 +115,6 @@ object ArmTransition : StateTransition {
 }
 
 object TakeoffTransition : StateTransition {
-
     override fun canTransition(from: AircraftState): String? = when {
         !from.isArmed() -> "Not armed"
         !from.isOnTheGround() -> "Not on the ground"
@@ -137,7 +126,6 @@ object TakeoffTransition : StateTransition {
 }
 
 object FlyingTransition : StateTransition {
-
     override fun canTransition(from: AircraftState): String? = when {
         !from.isArmed() -> "Not armed"
         else -> null
@@ -148,7 +136,6 @@ object FlyingTransition : StateTransition {
 }
 
 object LandTransition : StateTransition {
-
     override fun canTransition(from: AircraftState): String? = when {
         !from.isArmed() -> "Not armed"
         !from.isFlying() -> "Not flying"
@@ -161,7 +148,6 @@ object LandTransition : StateTransition {
 }
 
 object FlightTerminationTransition : StateTransition {
-
     override fun canTransition(from: AircraftState): String? = when {
         !from.isArmed() -> "Not armed"
         !from.isFlying() -> "Not flying"
@@ -174,7 +160,6 @@ object FlightTerminationTransition : StateTransition {
 }
 
 object PowerOffTransition : StateTransition {
-
     override fun canTransition(from: AircraftState): String? = when {
         !from.isStandBy() -> "Still armed"
         !from.isOnTheGround() -> "Still flying"
@@ -191,7 +176,6 @@ object PowerOffTransition : StateTransition {
  * FSM / Reducer pattern.
  */
 class AircraftStateMachine {
-
     var state = AircraftState()
         private set
 
@@ -232,7 +216,6 @@ class AircraftStateMachine {
  * Internal strategy for MAVLink base mode flag composition.
  */
 private enum class BaseModeType(val flags: Int) {
-
     MANUAL(
         MAV_MODE_FLAG.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED or
             MAV_MODE_FLAG.MAV_MODE_FLAG_STABILIZE_ENABLED or

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -143,13 +143,14 @@ data class BatteryData(
 }
 
 data class MAVLinkBatteryData(
-    val currentConsumed: Int, // mAh, -1 = unknown
-    val temperature: Short, // cdegC, INT16_MAX = unknown
-    val voltages: List<Int>, // mV
-    val currentBattery: Short, // cA, -1 = unknown
-    val batteryRemaining: Byte, // %, -1 = unknown
-    val voltagesBattery: Int, // mV, -1 = unknown
-    val currentBatteryRaw: Short // 10mA, -1 = unknown
+    val currentConsumed: Int, mAh, -1 = unknown
+    val temperature: Short, cdegC, INT16_MAX = unknown
+    val voltages: List<Int>, mV
+    val currentBattery: Short, cA, -1 = unknown
+    val batteryRemaining: Byte, %, -1 = unknown
+    val voltagesBattery: Int, mV, -1 = unknown
+    // 10mA, -1 = unknown
+    val currentBatteryRaw: Short
 )
 
 object BatteryMapper {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -143,13 +143,19 @@ data class BatteryData(
 }
 
 data class MAVLinkBatteryData(
-    val currentConsumed: Int, mAh, -1 = unknown
-    val temperature: Short, cdegC, INT16_MAX = unknown
-    val voltages: List<Int>, mV
-    val currentBattery: Short, cA, -1 = unknown
-    val batteryRemaining: Byte, %, -1 = unknown
-    val voltagesBattery: Int, mV, -1 = unknown
-    // 10mA, -1 = unknown
+    // mAh, -1 = unknown
+    val currentConsumed: Int,
+    // cdegC, INT16_MAX = unknown
+    val temperature: Short,
+    // mV
+    val voltages: List<Int>,
+    // cA, -1 = unknown
+    val currentBattery: Short,
+    // %, -1 = unknown
+    val batteryRemaining: Byte,
+    // mV, -1 = unknown
+    val voltagesBattery: Int,
+    /* 10mA, -1 = unknown */
     val currentBatteryRaw: Short
 )
 

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -1,6 +1,5 @@
 package org.WenuLink.adapters.aircraft
 
-import com.MAVLink.enums.CAMERA_MODE
 import dji.common.remotecontroller.HardwareState.FlightModeSwitch
 import kotlin.Int
 import kotlin.math.roundToInt
@@ -54,7 +53,6 @@ data class MAVLinkTelemetryData(
 )
 
 object TelemetryMapper {
-
     fun toMavlink(source: TelemetryData): MAVLinkTelemetryData = MAVLinkTelemetryData(
         timestamp = source.timestamp,
         roll = source.roll.toFloat(),
@@ -91,21 +89,20 @@ data class RCData(
         // transform from DJI range [-660, 660] => [1000, 2000]
         ((value.toFloat() / 660) * 500).roundToInt() + 1500
 
-    fun toMAVLink(): RCData {
-        val currRC = this.copy(
-            throttleSetting = stickValue2percent(this.throttleSetting),
-            leftStickVertical = stickValue2rcValue(this.leftStickVertical),
-            leftStickHorizontal = stickValue2rcValue(this.leftStickHorizontal),
-            rightStickVertical = stickValue2rcValue(this.rightStickVertical),
-            rightStickHorizontal = stickValue2rcValue(this.rightStickHorizontal)
-        )
-        return currRC
-    }
+    fun toMAVLink(): RCData = this.copy(
+        throttleSetting = stickValue2Percent(this.throttleSetting),
+        leftStickVertical = stickValue2RcValue(this.leftStickVertical),
+        leftStickHorizontal = stickValue2RcValue(this.leftStickHorizontal),
+        rightStickVertical = stickValue2RcValue(this.rightStickVertical),
+        rightStickHorizontal = stickValue2RcValue(this.rightStickHorizontal)
+    )
 
-    fun hasCenteredJoystick(): Boolean = this.leftStickVertical == 0 &&
-        this.leftStickHorizontal == 0 &&
-        this.rightStickVertical == 0 &&
-        this.rightStickHorizontal == 0
+    fun hasCenteredJoystick(): Boolean = listOf(
+        this.leftStickVertical,
+        this.leftStickHorizontal,
+        this.rightStickVertical,
+        this.rightStickHorizontal
+    ).all { it == 0 }
 }
 
 data class BatteryData(
@@ -137,10 +134,10 @@ data class BatteryData(
 
     override fun toString(): String = "BatteryData(" +
         "percentCharge=$percentCharge%, " +
-        "voltage=$voltage V, " +
-        "current=$current A, " +
-        "fullChargeCapacity=$fullChargeCapacity A, " +
-        "fullChargeCapacity=$chargeRemaining A, " +
+        "voltage=$voltage mV, " +
+        "current=$current mA, " +
+        "fullChargeCapacity=$fullChargeCapacity mAh, " +
+        "chargeRemaining=$chargeRemaining mAh, " +
         "temperature=$temperature °C, " +
         "voltageCells=${voltageCells?.joinToString()})"
 }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -111,26 +111,31 @@ data class RCData(
 }
 
 data class BatteryData(
-    var percentCharge: Int = -1,
-    var voltage: Int = -1,
-    var current: Int = -1,
-    var fullChargeCapacity: Int = -1,
-    var chargeRemaining: Int = -1,
-    var temperature: Float = -1.0f,
-    var voltageCells: IntArray? = null
+    val percentCharge: Int? = null,
+    val voltage: Int? = null,
+    val current: Int? = null,
+    val fullChargeCapacity: Int? = null,
+    val chargeRemaining: Int? = null,
+    val temperature: Float? = null,
+    val voltageCells: List<Int>? = null
 ) {
-
-    fun updateFrom(other: BatteryData) {
-        if (other.percentCharge != -1) percentCharge = other.percentCharge
-        if (other.voltage != -1) voltage = other.voltage
-        if (other.current != -1) current = other.current
-        if (other.fullChargeCapacity != -1) fullChargeCapacity = other.fullChargeCapacity
-        if (other.chargeRemaining != -1) chargeRemaining = other.chargeRemaining
-        if (other.temperature != -1.0f) temperature = other.temperature
-        other.voltageCells?.let {
-            voltageCells = other.voltageCells?.clone() // Clone to avoid reference issues
-        }
-    }
+    fun merge(
+        percentCharge: Int? = null,
+        voltage: Int? = null,
+        current: Int? = null,
+        fullChargeCapacity: Int? = null,
+        chargeRemaining: Int? = null,
+        temperature: Float? = null,
+        voltageCells: List<Int>? = null
+    ): BatteryData = copy(
+        percentCharge = percentCharge ?: this.percentCharge,
+        voltage = voltage ?: this.voltage,
+        current = current ?: this.current,
+        fullChargeCapacity = fullChargeCapacity ?: this.fullChargeCapacity,
+        chargeRemaining = chargeRemaining ?: this.chargeRemaining,
+        temperature = temperature ?: this.temperature,
+        voltageCells = voltageCells ?: this.voltageCells
+    )
 
     override fun toString(): String = "BatteryData(" +
         "percentCharge=$percentCharge%, " +
@@ -140,6 +145,47 @@ data class BatteryData(
         "fullChargeCapacity=$chargeRemaining A, " +
         "temperature=$temperature °C, " +
         "voltageCells=${voltageCells?.joinToString()})"
+}
+
+data class MAVLinkBatteryData(
+    val currentConsumed: Int, // mAh, -1 = unknown
+    val temperature: Short, // cdegC, INT16_MAX = unknown
+    val voltages: List<Int>, // mV
+    val currentBattery: Short, // cA, -1 = unknown
+    val batteryRemaining: Byte, // %, -1 = unknown
+    val voltagesBattery: Int, // mV, -1 = unknown
+    val currentBatteryRaw: Short // 10mA, -1 = unknown
+)
+
+object BatteryMapper {
+    private const val UNKNOWN_INT = -1
+    private const val UNKNOWN_SHORT = Short.MAX_VALUE // INT16_MAX per MAVLink spec
+
+    fun toMavlink(source: BatteryData): MAVLinkBatteryData {
+        val fullCharge = source.fullChargeCapacity
+        val remaining = source.chargeRemaining
+        return MAVLinkBatteryData(
+            currentConsumed = if (fullCharge != null && remaining != null) {
+                fullCharge - remaining
+            } else {
+                UNKNOWN_INT
+            },
+            temperature = source.temperature
+                ?.let { (it * 100.0).toInt().toShort() }
+                ?: UNKNOWN_SHORT,
+            voltages = source.voltageCells ?: emptyList(),
+            currentBattery = source.current
+                ?.let { (it * 10).toShort() }
+                ?: UNKNOWN_INT.toShort(),
+            batteryRemaining = if (fullCharge != null && remaining != null) {
+                (remaining.toFloat() / fullCharge * 100f).toInt().toByte()
+            } else {
+                UNKNOWN_INT.toByte()
+            },
+            voltagesBattery = source.voltage ?: UNKNOWN_INT,
+            currentBatteryRaw = source.current?.toShort() ?: UNKNOWN_INT.toShort()
+        )
+    }
 }
 
 data class Coordinates3D(val lat: Double, val long: Double, val alt: Float)

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -32,7 +32,7 @@ data class TelemetryData(
     val satelliteCount: Int,
     // DJI reports signal quality on a scale of 1-11
     // Mavlink has separate codes for fix type.
-    val gpsLevel: BooleanArray,
+    val gpsLevel: List<Boolean>,
     val gpsFixType: Int = 0
 )
 
@@ -83,15 +83,13 @@ data class RCData(
     val buttonC3: Boolean,
     val mode: FlightModeSwitch?
 ) {
-    private fun stickValue2percent(value: Int): Int {
+    private fun stickValue2Percent(value: Int): Int =
         // transform from DJI range [-660, 660] => [0, 100]
-        return (((value + 660).toFloat() / 1320f) * 100).roundToInt()
-    }
+        (((value + 660).toFloat() / 1320f) * 100).roundToInt()
 
-    private fun stickValue2rcValue(value: Int): Int {
+    private fun stickValue2RcValue(value: Int): Int =
         // transform from DJI range [-660, 660] => [1000, 2000]
-        return ((value.toFloat() / 660) * 500).roundToInt() + 1500
-    }
+        ((value.toFloat() / 660) * 500).roundToInt() + 1500
 
     fun toMAVLink(): RCData {
         val currRC = this.copy(

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -40,7 +40,7 @@ class TelemetryHandler {
         get() = SimManager.isAvailable()
     val isSimulationActive: Boolean
         get() = SimManager.isActive()
-    private var mustRunSimulation: Boolean = false
+    private var mustRunSimulation = false
 
     private val _isBroadcasting = MutableStateFlow(false)
     val isBroadcasting: StateFlow<Boolean> = _isBroadcasting.asStateFlow()
@@ -57,17 +57,11 @@ class TelemetryHandler {
     }
 
     @Synchronized
-    fun enableSimulation(enable: Boolean) {
-        if (isActive()) {
-            logger.e { "Unable to set runSimulation=$enable, Telemetry active." }
-            return
-        }
-
-        if (!isSimulationAvailable) {
-            logger.e { "Unable to set runSimulation=$enable, Simulation not available." }
-            return
-        }
-
+    fun enableSimulation(enable: Boolean) = if (isActive()) {
+        logger.e { "Unable to set runSimulation=$enable, Telemetry active." }
+    } else if (!isSimulationAvailable) {
+        logger.e { "Unable to set runSimulation=$enable, Simulation not available." }
+    } else {
         mustRunSimulation = enable
         logger.i { "Enable Simulation $mustRunSimulation" }
     }
@@ -77,7 +71,7 @@ class TelemetryHandler {
         SimManager.unregisterStateCallback()
         if (register) {
             SimManager.registerStateCallback { state ->
-                updateTelemetryData(SimManager.state2telemetry(state, lastTelemetryData))
+                updateTelemetryData(SimManager.state2Telemetry(state, lastTelemetryData))
             }
         }
     }
@@ -110,20 +104,16 @@ class TelemetryHandler {
         registerSensorState(register)
     }
 
-    fun listenRemoteController(listen: Boolean) {
-        if (listen) {
-            RCManager.startListeners()
-        } else {
-            RCManager.stopListeners()
-        }
+    fun listenRemoteController(listen: Boolean) = if (listen) {
+        RCManager.startListeners()
+    } else {
+        RCManager.stopListeners()
     }
 
-    fun listenAircraft(listen: Boolean) {
-        if (listen) {
-            AircraftManager.startListeners()
-        } else {
-            AircraftManager.stopListeners()
-        }
+    fun listenAircraft(listen: Boolean) = if (listen) {
+        AircraftManager.startListeners()
+    } else {
+        AircraftManager.stopListeners()
     }
 
     fun listenSimulation(listen: Boolean) {
@@ -146,12 +136,10 @@ class TelemetryHandler {
         }
     }
 
-    fun listenVehicleState(listen: Boolean) {
-        if (mustRunSimulation) {
-            listenSimulation(listen)
-        } else {
-            listenAircraft(listen)
-        }
+    fun listenVehicleState(listen: Boolean) = if (mustRunSimulation) {
+        listenSimulation(listen)
+    } else {
+        listenAircraft(listen)
     }
 
     fun registerSensorState(listen: Boolean) {
@@ -177,10 +165,10 @@ class TelemetryHandler {
     fun isCompassOk() = FCManager.compassOk()
 
     @Synchronized
-    fun isAccelerometerOk() = lastIMUState?.accelerometer?.all { it == SensorState.OK } ?: false
+    fun isAccelerometerOk() = lastIMUState?.accelerometer?.all { it == SensorState.OK } == true
 
     @Synchronized
-    fun isGyroscopeOk() = lastIMUState?.gyroscope?.all { it == SensorState.OK } ?: false
+    fun isGyroscopeOk() = lastIMUState?.gyroscope?.all { it == SensorState.OK } == true
 
     fun startBroadcast() {
         if (isReadingData()) {
@@ -234,19 +222,15 @@ class TelemetryHandler {
             .launchIn(handlerScope)
     }
 
-    fun isReadingData(): Boolean {
-        // RC should always exists
-        var isFlowing = RCManager.isUpdated()
-        // If simulation activated, must wait for its startup
-        isFlowing = isFlowing &&
+    fun isReadingData(): Boolean = // RC should always exists
+        RCManager.isUpdated() &&
+            // If simulation activated, must wait for its startup
             if (mustRunSimulation) {
                 isSimulationActive
             } // Assumes that if not sim, Aircraft is present
             else {
                 AircraftManager.isUpdated()
             }
-        return isFlowing
-    }
 
     suspend fun waitDataReading(timeout: Long = 5000L): Boolean {
         // First check wait for listeners transfer data
@@ -262,7 +246,7 @@ class TelemetryHandler {
     suspend fun waitDataRemoving(delay: Long = 1000L): Boolean {
         // Wait for listeners to stop receiving data
         fun stopReading() = !isReadingData()
-        AsyncUtils.waitReady(delay, isReady = ::stopReading)
+        AsyncUtils.waitReady(delay, ::stopReading)
         // reset the telemetry info
         updateTelemetryData(null)
         val listenersOk = !(isReadingData() || hasData())
@@ -276,14 +260,12 @@ class TelemetryHandler {
 
     fun getRCData(): RCData? = RCManager.getHardwareData()
 
-    fun getAircraftBattery(): BatteryData {
-        // TODO: Maybe include some custom battery level
-        return if (mustRunSimulation) {
+    fun getAircraftBattery(): BatteryData = // TODO: Maybe include some custom battery level
+        if (mustRunSimulation) {
             RCManager.getBatteryData()
         } else {
             AircraftManager.getBatteryData()
         }
-    }
 
     fun getAirlinkSignal(): SignalQuality = if (mustRunSimulation) {
         SignalQuality(98, 95)

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -12,6 +12,7 @@ import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.sdk.AircraftManager
 import org.WenuLink.sdk.FCManager
 import org.WenuLink.sdk.RCManager
+import org.WenuLink.sdk.SignalQuality
 import org.WenuLink.sdk.SimManager
 
 class TelemetryHandler {
@@ -92,7 +93,7 @@ class TelemetryHandler {
         if (register) {
             FCManager.registerStateCallback { state ->
                 // TODO: positionX,Y,Z values must be updated
-                updateTelemetryData(FCManager.state2telemetry(state))
+                updateTelemetryData(FCManager.state2Telemetry(state))
             }
         }
     }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -284,8 +284,8 @@ class TelemetryHandler {
         }
     }
 
-    fun getAirlinkSignal(): IntArray = if (mustRunSimulation) {
-        intArrayOf(98, 95)
+    fun getAirlinkSignal(): SignalQuality = if (mustRunSimulation) {
+        SignalQuality(98, 95)
     } else {
         AircraftManager.getAirlinkData()
     }

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraCapturer.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraCapturer.kt
@@ -13,12 +13,32 @@ import org.webrtc.VideoCapturer
 
 class CameraCapturer : VideoCapturer {
     data class MediaMetadata(
-        var MEDIA_STREAM_ID: String = "WenuLink-${CameraManager.cameraStreamID!!}",
-        var VIDEO_CAMERA_NAME: String = CameraManager.cameraName!!,
-        var VIDEO_RESOLUTION_WIDTH: Int = CameraManager.frameWidth,
-        var VIDEO_RESOLUTION_HEIGHT: Int = CameraManager.frameHeight,
-        var FPS: Int = round(CameraManager.frameRate).toInt()
-    )
+        val mediaStreamId: String,
+        val videoCameraName: String,
+        val videoResolutionWidth: Int,
+        val videoResolutionHeight: Int,
+        val fps: Int
+    ) {
+        companion object {
+            fun fromCameraManager(): MediaMetadata? {
+                val streamId = CameraManager.cameraStreamID ?: return null
+                val cameraName = CameraManager.cameraName ?: return null
+                if (CameraManager.frameWidth <= 0 ||
+                    CameraManager.frameHeight <= 0 ||
+                    CameraManager.frameRate <= 0
+                ) {
+                    return null
+                }
+                return MediaMetadata(
+                    "WenuLink-$streamId",
+                    cameraName,
+                    CameraManager.frameWidth,
+                    CameraManager.frameHeight,
+                    round(CameraManager.frameRate).toInt()
+                )
+            }
+        }
+    }
 
     companion object {
         private val logger by taggedLogger(CameraCapturer::class.java.simpleName)

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
@@ -12,22 +12,22 @@ data class SetModeCommand(val newMode: Int, val cameraIdx: Int) : CameraCommand 
     override suspend fun validate(ctx: CameraHandler): String? = null
 
     suspend fun setPhotoMode(cameraIdx: Int = 0): Result<String?> {
-        if (CameraManager.isPhotoMode()) return Result.success(null)
-
-        val error = CameraManager.setPhotoMode()
-        if (error != null) {
-            return Result.failure(IllegalStateException("setPhotoMode error: $error"))
+        if (!CameraManager.isPhotoMode()) {
+            val error = CameraManager.setPhotoMode()
+            if (error != null) {
+                return Result.failure(IllegalStateException("setPhotoMode error: $error"))
+            }
         }
 
         return Result.success(null)
     }
 
     suspend fun setVideoMode(cameraIdx: Int = 0): Result<String?> {
-        if (CameraManager.isVideoMode()) return Result.success(null)
-
-        val error = CameraManager.setVideoMode()
-        if (error != null) {
-            return Result.failure(IllegalStateException("setVideoMode error: $error"))
+        if (!CameraManager.isVideoMode()) {
+            val error = CameraManager.setVideoMode()
+            if (error != null) {
+                return Result.failure(IllegalStateException("setVideoMode error: $error"))
+            }
         }
 
         return Result.success(null)
@@ -57,7 +57,6 @@ data class SetModeCommand(val newMode: Int, val cameraIdx: Int) : CameraCommand 
 }
 
 data class TakePhotoCommand(val cameraIdx: Int) : CameraCommand {
-
     override suspend fun validate(ctx: CameraHandler): String? = when {
         !ctx.isPhotoMode(cameraIdx) -> "Not in photo mode!"
         !ctx.captureIdle(cameraIdx) -> "Busy"
@@ -80,7 +79,6 @@ data class TakePhotoCommand(val cameraIdx: Int) : CameraCommand {
 }
 
 data class StartRecordCommand(val cameraIdx: Int) : CameraCommand {
-
     override suspend fun validate(ctx: CameraHandler): String? = when {
         !ctx.isVideoMode(cameraIdx) -> "Not in video mode!"
         !ctx.canRecordVideo(cameraIdx) -> "Unable to start recording"
@@ -103,7 +101,6 @@ data class StartRecordCommand(val cameraIdx: Int) : CameraCommand {
 }
 
 data class StopRecordCommand(val cameraIdx: Int) : CameraCommand {
-
     override suspend fun validate(ctx: CameraHandler): String? = when {
         !ctx.isVideoMode(cameraIdx) -> "Not in video mode!"
         !ctx.captureInProgress(cameraIdx) -> "Record not started"

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
@@ -32,9 +32,10 @@ class CameraHandler {
     private var currentCommand: CameraCommand? = null
     private val commandChannel =
         Channel<Pair<CameraCommand, (String?) -> Unit>>(capacity = Channel.UNLIMITED)
-    var sequenceIndex: Int = 0
-    var captureTimestamp: Long = System.currentTimeMillis()
-    val lastCaptureMillis: Long get() = System.currentTimeMillis() - captureTimestamp
+    var sequenceIndex = 0
+    var captureTimestamp = System.currentTimeMillis()
+    val lastCaptureMillis
+        get() = System.currentTimeMillis() - captureTimestamp
 
     private fun startCommandProcessor(scope: CoroutineScope) {
         commandJob?.cancel()
@@ -71,9 +72,8 @@ class CameraHandler {
     }
 
     suspend fun initCameras(): Boolean {
-        if (!CameraManager.isConnected()) {
-            return false
-        }
+        if (!CameraManager.isConnected()) return false
+
         logger.d { "initCamera" }
         CameraManager.retrieveMetadata()
 
@@ -111,10 +111,10 @@ class CameraHandler {
         }
 
         val newState = CameraState(
-            mavlinkMode = newMode,
-            captureType = captureType,
-            captureStatus = CameraCaptureStatus.IDLE,
-            captureTime = 0
+            newMode,
+            captureType,
+            CameraCaptureStatus.IDLE,
+            0
         )
 
         getCamera(cameraIdx)?.let {
@@ -148,15 +148,20 @@ class CameraHandler {
         cameraIdx
     )
 
-    fun isPhotoMode(cameraIdx: Int = 0): Boolean =
-        getCamera(cameraIdx)?.state?.mavlinkMode == CAMERA_MODE.CAMERA_MODE_IMAGE
+    fun checkCameraMode(mode: Int, cameraIdx: Int = 0): Boolean =
+        getCamera(cameraIdx)?.state?.mavlinkMode == mode
 
-    fun isVideoMode(cameraIdx: Int = 0): Boolean =
-        getCamera(cameraIdx)?.state?.mavlinkMode == CAMERA_MODE.CAMERA_MODE_VIDEO
+    fun isPhotoMode(cameraIdx: Int = 0): Boolean = checkCameraMode(
+        CAMERA_MODE.CAMERA_MODE_IMAGE,
+        cameraIdx
+    )
+
+    fun isVideoMode(cameraIdx: Int = 0): Boolean = checkCameraMode(
+        CAMERA_MODE.CAMERA_MODE_VIDEO,
+        cameraIdx
+    )
 
     fun canRecordVideo(cameraIdx: Int = 0): Boolean = CameraManager.canRecordVideo()
 
-    fun registerHandlerScope(scope: CoroutineScope) {
-        startCommandProcessor(scope)
-    }
+    fun registerHandlerScope(scope: CoroutineScope) = startCommandProcessor(scope)
 }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
@@ -5,7 +5,7 @@ import org.WenuLink.adapters.aircraft.Coordinates3D
 class MissionAssembler {
     private val nodes = mutableListOf<MissionNode>()
     private var rtlWhenFinish = false
-    var nWaypoints: Int = 0
+    var nWaypoints = 0
         private set
 
     fun getNode(nId: Int) = nodes[nId]

--- a/app/src/main/java/org/WenuLink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/CameraController.kt
@@ -272,7 +272,7 @@ class CameraController(
     }
 
     private fun requestStartRecording(commandLongMsg: msg_command_long, aircraft: AircraftHandler) {
-        val cameraInfo= getCamera(commandLongMsg.param3.toInt(), aircraft)
+        val cameraInfo = getCamera(commandLongMsg.param3.toInt(), aircraft)
 
         if (cameraInfo == null) {
             client.sendMessage(

--- a/app/src/main/java/org/WenuLink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/CameraController.kt
@@ -38,14 +38,12 @@ class CameraController(
     override val client: MAVLinkClient,
     private val onSetMessageRate: (messageId: Int, intervalMs: Long) -> Unit
 ) : IController {
-
     private val logger by taggedLogger(CameraController::class.java.simpleName)
 
     override fun processCommandLong(
         commandLongMsg: msg_command_long,
         aircraft: AircraftHandler
     ): Boolean {
-        var processed = true
         when (commandLongMsg.command) {
             MAV_CMD.MAV_CMD_REQUEST_CAMERA_INFORMATION ->
                 handleCameraInformation(commandLongMsg, aircraft)
@@ -60,16 +58,15 @@ class CameraController(
 
             MAV_CMD.MAV_CMD_VIDEO_STOP_CAPTURE -> requestStopRecording(commandLongMsg, aircraft)
 
-            else -> processed = false
+            else -> return false
         }
-        return processed
+        return true
     }
 
     override fun processRequestLong(
         commandLongMsg: msg_command_long,
         aircraft: AircraftHandler
     ): Boolean {
-        var processed = true
         val requestID = commandLongMsg.param1.toInt()
         when (requestID) {
             msg_camera_information.MAVLINK_MSG_ID_CAMERA_INFORMATION -> reportCameras(aircraft)
@@ -82,29 +79,27 @@ class CameraController(
             msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS ->
                 sendCaptureStatus(aircraft)
 
-            else -> processed = false
+            else -> return false
         }
-        return processed
+        return true
     }
 
-    private fun sendRequestAck(result: Int) {
-        client.sendMessage(
-            MessageUtils.msgRequestAck(result)
-        )
-    }
+    private fun sendRequestAck(result: Int) = client.sendMessage(
+        MessageUtils.msgRequestAck(result)
+    )
 
-    private fun sendCommandAck(messageID: Int, result: Int, progress: Int = -1) {
+    private fun sendCommandAck(messageID: Int, result: Int, progress: Int = -1) =
         client.sendMessage(
             MessageUtils.msgCommandAck(messageID, result, progress)
         )
-    }
 
     private fun reportCameras(aircraft: AircraftHandler) {
         if (!aircraft.hasCameras) {
-            sendRequestAck(MAV_RESULT.MAV_RESULT_UNSUPPORTED)
             logger.d { "Unsupported: No cameras were detected" }
+            sendRequestAck(MAV_RESULT.MAV_RESULT_UNSUPPORTED)
             return
         }
+
         sendRequestAck(MAV_RESULT.MAV_RESULT_ACCEPTED)
         aircraft.cameras.list.forEach {
             // Append boot time before send
@@ -127,10 +122,11 @@ class CameraController(
 
     private fun reportSettings(aircraft: AircraftHandler) {
         if (!aircraft.hasCameras) {
-            sendRequestAck(MAV_RESULT.MAV_RESULT_UNSUPPORTED)
             logger.d { "Unsupported: No cameras were detected" }
+            sendRequestAck(MAV_RESULT.MAV_RESULT_UNSUPPORTED)
             return
         }
+
         sendRequestAck(MAV_RESULT.MAV_RESULT_ACCEPTED)
         aircraft.cameras.list.forEach {
             // Append boot time before send
@@ -146,10 +142,10 @@ class CameraController(
         sendCommandAck(
             commandLongMsg.command,
             MAV_RESULT.MAV_RESULT_IN_PROGRESS,
-            progress = 0
+            0
         )
-        val index: Int = commandLongMsg.param1.toInt()
-        val mode: Int = commandLongMsg.param2.toInt()
+        val index = commandLongMsg.param1.toInt()
+        val mode = commandLongMsg.param2.toInt()
 
         aircraft.cameras.dispatchCommand(
             SetModeCommand(mode, index)
@@ -161,27 +157,22 @@ class CameraController(
                 } else {
                     MAV_RESULT.MAV_RESULT_FAILED
                 },
-                progress = 100
+                100
             )
         }
     }
 
-    private fun sendStorageStatus(aircraft: AircraftHandler) {
-        client.sendMessage(
-            msgStorageInformation().apply {
-                time_boot_ms = aircraft.systemBootTime
-            }
-        )
-    }
+    private fun sendStorageStatus(aircraft: AircraftHandler) = client.sendMessage(
+        msgStorageInformation().apply {
+            time_boot_ms = aircraft.systemBootTime
+        }
+    )
 
-    private fun sendCaptureStatus(aircraft: AircraftHandler) {
-        val cameraInfo: CameraMetadata = aircraft.cameras.list.first()
-        client.sendMessage(
-            msgCaptureStatus(cameraInfo).apply {
-                time_boot_ms = aircraft.systemBootTime
-            }
-        )
-    }
+    private fun sendCaptureStatus(aircraft: AircraftHandler) = client.sendMessage(
+        msgCaptureStatus(aircraft.cameras.list.first()).apply {
+            time_boot_ms = aircraft.systemBootTime
+        }
+    )
 
     private fun getCamera(targetCamera: Int, aircraft: AircraftHandler): CameraMetadata? {
         val cameraInfo = aircraft.cameras.getCamera(targetCamera)
@@ -196,9 +187,9 @@ class CameraController(
         aircraft: AircraftHandler,
         cameraInfo: CameraMetadata
     ) {
-        val intervalMillis: Long = (commandLongMsg.param2 * 1000).toLong() // milliseconds
-        val initSequence: Int = commandLongMsg.param4.toInt()
-        val totalPhotos: Int = commandLongMsg.param3.toInt()
+        val intervalMillis = (commandLongMsg.param2 * 1000).toLong() // milliseconds
+        val totalPhotos = commandLongMsg.param3.toInt()
+        val initSequence = commandLongMsg.param4.toInt()
 
         fun mustCapture() = if (totalPhotos == 0) {
             aircraft.cameras.sequenceIndex != -1
@@ -218,28 +209,24 @@ class CameraController(
 
             aircraft.cameras.dispatchCommand(
                 TakePhotoCommand(cameraInfo.id)
-            )
-                { error ->
-                    val captureOk = error == null
-                    if (!captureOk) {
-                        logger.w { "Error in shootPhoto: $error" }
-                    }
-                    val photoData = ImageMetadata(
-                        index = aircraft.cameras.sequenceIndex,
-                        captureOk = captureOk,
-                        cameraID = cameraInfo.id,
-                        telemetry = aircraft.telemetry.getData()!!
-                    )
+            ) { error ->
+                val captureOk = error == null
+                if (!captureOk) logger.w { "Error in shootPhoto: $error" }
 
-                    client.sendMessage(
-                        msgImageCaptured(photoData)
-                    )
-                }
+                val photoData = ImageMetadata(
+                    aircraft.cameras.sequenceIndex,
+                    captureOk,
+                    cameraInfo.id,
+                    aircraft.telemetry.getData()!!
+                )
+
+                client.sendMessage(msgImageCaptured(photoData))
+            }
         }
     }
 
     private fun requestStartCapture(commandLongMsg: msg_command_long, aircraft: AircraftHandler) {
-        val cameraInfo: CameraMetadata? = getCamera(commandLongMsg.param1.toInt(), aircraft)
+        val cameraInfo = getCamera(commandLongMsg.param1.toInt(), aircraft)
 
         if (cameraInfo == null) {
             client.sendMessage(
@@ -262,7 +249,7 @@ class CameraController(
     }
 
     private fun requestStopCapture(commandLongMsg: msg_command_long, aircraft: AircraftHandler) {
-        val cameraInfo: CameraMetadata? = getCamera(commandLongMsg.param1.toInt(), aircraft)
+        val cameraInfo = getCamera(commandLongMsg.param1.toInt(), aircraft)
 
         if (cameraInfo == null) {
             client.sendMessage(
@@ -285,7 +272,7 @@ class CameraController(
     }
 
     private fun requestStartRecording(commandLongMsg: msg_command_long, aircraft: AircraftHandler) {
-        val cameraInfo: CameraMetadata? = getCamera(commandLongMsg.param3.toInt(), aircraft)
+        val cameraInfo= getCamera(commandLongMsg.param3.toInt(), aircraft)
 
         if (cameraInfo == null) {
             client.sendMessage(
@@ -309,23 +296,22 @@ class CameraController(
 
         aircraft.cameras.dispatchCommand(
             StartRecordCommand(cameraInfo.id)
-        )
-            { error ->
-                val captureOk = error == null
-                if (!captureOk) {
-                    logger.w { "Error in requestStartRecording: $error" }
-                } else {
-                    // setting messages frequency
-                    onSetMessageRate(
-                        msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
-                        ((1f / statusFreq) * 1_000).roundToLong()
-                    )
-                }
+        ) { error ->
+            val captureOk = error == null
+            if (!captureOk) {
+                logger.w { "Error in requestStartRecording: $error" }
+            } else {
+                // setting messages frequency
+                onSetMessageRate(
+                    msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
+                    ((1f / statusFreq) * 1_000).roundToLong()
+                )
             }
+        }
     }
 
     private fun requestStopRecording(commandLongMsg: msg_command_long, aircraft: AircraftHandler) {
-        val cameraInfo: CameraMetadata? = getCamera(commandLongMsg.param2.toInt(), aircraft)
+        val cameraInfo = getCamera(commandLongMsg.param2.toInt(), aircraft)
 
         if (cameraInfo == null) {
             client.sendMessage(
@@ -348,19 +334,17 @@ class CameraController(
 
         aircraft.cameras.dispatchCommand(
             StopRecordCommand(cameraInfo.id)
-        )
-            { error ->
-                val captureOk = error == null
-                if (!captureOk) {
-                    logger.w { "Error in requestStopRecording: $error" }
-                } else {
-                    // deactivating messages
-                    onSetMessageRate(
-                        msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
-                        -1
-                    )
-                }
+        ) { error ->
+            if (error != null) {
+                logger.w { "Error in requestStopRecording: $error" }
+                return@dispatchCommand
             }
+            // deactivating messages
+            onSetMessageRate(
+                msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
+                -1
+            )
+        }
     }
 
     fun msgCameraInformation(cameraInfo: CameraMetadata): msg_camera_information =
@@ -400,9 +384,9 @@ class CameraController(
         camera_device_id = cameraInfo.id.toShort()
     }
 
-    fun msgStorageInformation(): msg_storage_information {
+    fun msgStorageInformation(): msg_storage_information =
         // TODO: get from https://developer.dji.com/api-reference/android-api/Components/Camera/DJICamera_DJICameraSDCardState.html
-        return msg_storage_information().apply {
+        msg_storage_information().apply {
             storage_id = 1
             storage_count = 1
             status = STORAGE_STATUS.STORAGE_STATUS_READY.toShort()
@@ -414,14 +398,13 @@ class CameraController(
             name = "FakeSDCard".toByteArray()
             storage_usage = STORAGE_USAGE_FLAG.STORAGE_USAGE_FLAG_PHOTO.toShort()
         }
-    }
 
     fun msgCaptureStatus(cameraInfo: CameraMetadata): msg_camera_capture_status {
         // TODO: add proper updates
         var imageStatus = CameraCaptureStatus.IDLE
-        var imageInterval: Float = 0f
+        var imageInterval = 0f
         var videoStatus = CameraCaptureStatus.IDLE
-        var videoTime: Long = 0
+        var videoTime = 0L
         if (cameraInfo.state.mavlinkMode == CAMERA_MODE.CAMERA_MODE_IMAGE) {
             imageStatus = cameraInfo.state.captureStatus
             imageInterval = cameraInfo.state.captureTime.toFloat()
@@ -450,9 +433,9 @@ class CameraController(
             alt = mavData.altitude
             relative_alt = mavData.relativeAltitude
             q = OrientationUtils.eulerDegToQuaternion(
-                rollDeg = mavData.roll.toDouble(),
-                pitchDeg = mavData.pitch.toDouble(),
-                yawDeg = mavData.yaw.toDouble()
+                mavData.roll.toDouble(),
+                mavData.pitch.toDouble(),
+                mavData.yaw.toDouble()
             ).toFloatArray()
             image_index = imageInfo.index
             capture_result = (if (imageInfo.captureOk) 1 else 0).toByte()

--- a/app/src/main/java/org/WenuLink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/CommandController.kt
@@ -78,9 +78,7 @@ class CommandController(override var client: MAVLinkClient) : IController {
         messageID: Int,
         result: Int = MAV_RESULT.MAV_RESULT_UNSUPPORTED,
         progress: Int = -1
-    ) {
-        client.sendMessage(MessageUtils.msgCommandAck(messageID, result, progress))
-    }
+    ) = client.sendMessage(MessageUtils.msgCommandAck(messageID, result, progress))
 
     fun sendAutopilotAck() = sendCommandAck(
         MAV_CMD.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES,
@@ -118,15 +116,15 @@ class CommandController(override var client: MAVLinkClient) : IController {
 
         if (customMode == null) {
             sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
-        } else {
-            aircraft.requestMode(customMode)
-                .onSuccess {
-                    sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
-                }
-                .onFailure {
-                    sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
-                }
+            return
         }
+        aircraft.requestMode(customMode)
+            .onSuccess {
+                sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
+            }
+            .onFailure {
+                sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
+            }
     }
 
     fun processArmDisarm(commandMsg: msg_command_long, aircraft: AircraftHandler) {
@@ -144,11 +142,8 @@ class CommandController(override var client: MAVLinkClient) : IController {
 
         logger.d { "Requesting to ${if (action) "arm" else "disarm"} motors" }
 
-        val command = if (action) {
-            ArmCommand()
-        } else {
-            DisarmCommand()
-        }
+        val command = if (action) ArmCommand() else DisarmCommand()
+
         aircraft.dispatchCommand(command) { error ->
             logger.d { "processTakeoff: $error" }
         }

--- a/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
@@ -20,7 +20,6 @@ import com.MAVLink.enums.MAV_SYS_STATUS_SENSOR
 import com.MAVLink.enums.MAV_TYPE
 import com.MAVLink.enums.MAV_VTOL_STATE
 import com.MAVLink.minimal.msg_heartbeat
-import io.getstream.log.taggedLogger
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
@@ -37,8 +36,7 @@ import org.WenuLink.mavlink.MAVLinkClient
  * https://mavlink.io/en/services/heartbeat.html
  */
 class ConnectionController(override val client: MAVLinkClient) : IController {
-    private val logger by taggedLogger(ConnectionController::class.java.simpleName)
-    private var gcsLastTimestamp: Long = 0
+    private var gcsLastTimestamp = 0L
     val isGCSPresent: Boolean
         get() {
             val hasGCS = gcsLastTimestamp > 0
@@ -91,29 +89,18 @@ class ConnectionController(override val client: MAVLinkClient) : IController {
     }
 
     override fun createMessage(messageID: Int, aircraft: AircraftHandler): MAVLinkMessage? =
+        // msg_mag_cal_report.MAVLINK_MSG_ID_MAG_CAL_REPORT -> msgMagCal()
         when (messageID) {
             msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT -> msgHeartbeat(aircraft)
-
             msg_sys_status.MAVLINK_MSG_ID_SYS_STATUS -> msgSysStatus(aircraft.telemetry)
-
             msg_attitude.MAVLINK_MSG_ID_ATTITUDE -> msgAttitude(aircraft.telemetry)
-
             msg_altitude.MAVLINK_MSG_ID_ALTITUDE -> msgAltitude(aircraft.telemetry)
-
             msg_vibration.MAVLINK_MSG_ID_VIBRATION -> msgVibration()
-
             msg_vfr_hud.MAVLINK_MSG_ID_VFR_HUD -> msgHUD(aircraft.telemetry)
-
             msg_radio_status.MAVLINK_MSG_ID_RADIO_STATUS -> msgRadioStatus(aircraft.telemetry)
-
             msg_power_status.MAVLINK_MSG_ID_POWER_STATUS -> msgPowerStatus()
-
-            msg_battery_status.MAVLINK_MSG_ID_BATTERY_STATUS ->
-                msgBatteryStatus(aircraft.telemetry)
-
+            msg_battery_status.MAVLINK_MSG_ID_BATTERY_STATUS -> msgBatteryStatus(aircraft.telemetry)
             msg_extended_sys_state.MAVLINK_MSG_ID_EXTENDED_SYS_STATE -> msgExtendedSys(aircraft)
-
-            //            msg_mag_cal_report.MAVLINK_MSG_ID_MAG_CAL_REPORT -> msgMagCal()
             else -> null
         }
 

--- a/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
@@ -243,9 +243,11 @@ class ConnectionController(override val client: MAVLinkClient) : IController {
         // quality. MAVLink uses [0, 254] as uint8_t
 
         // AirLink's DownLinkSignalQuality
-        msg.rssi = ((airlinkSignal[0] / 100f) * 255f).roundToInt().toShort()
+        msg.rssi = airlinkSignal.downlink?.let { ((it / 100f) * 255f).roundToInt().toShort() }
+            ?: Short.MAX_VALUE
         // AirLink's UpLinkSignalQuality
-        msg.remrssi = ((airlinkSignal[1] / 100f) * 255f).roundToInt().toShort()
+        msg.remrssi = airlinkSignal.uplink?.let { ((it / 100f) * 255f).roundToInt().toShort() }
+            ?: Short.MAX_VALUE
         return msg
     }
 

--- a/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/ConnectionController.kt
@@ -26,6 +26,7 @@ import kotlin.math.roundToInt
 import kotlin.math.sqrt
 import org.WenuLink.adapters.MessageUtils
 import org.WenuLink.adapters.aircraft.AircraftHandler
+import org.WenuLink.adapters.aircraft.BatteryMapper
 import org.WenuLink.adapters.aircraft.TelemetryHandler
 import org.WenuLink.mavlink.MAVLinkClient
 
@@ -63,6 +64,21 @@ class ConnectionController(override val client: MAVLinkClient) : IController {
         MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_BATTERY or
         MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_PREARM_CHECK or
         MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_PROPULSION
+
+    // TODO: Update accordingly?
+    val sensorsEnabled = sensorsPresent and
+        MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL.inv() and
+        MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL.inv() and
+        MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_GEOFENCE.inv() and
+        MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_LOGGING.inv()
+
+    val sensorsHealth = (
+        sensorsPresent or
+            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_GPS or
+            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_PROXIMITY
+        ) and
+        MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL.inv() and
+        MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL.inv()
 
     override fun processMessage(msg: MAVLinkMessage, aircraft: AircraftHandler): Boolean {
         when (msg.msgid) {
@@ -149,21 +165,8 @@ class ConnectionController(override val client: MAVLinkClient) : IController {
     }
 
     fun msgSysStatus(telemetry: TelemetryHandler): MAVLinkMessage {
-        val aircraftBattery = telemetry.getAircraftBattery()
+        val battery = BatteryMapper.toMavlink(telemetry.getAircraftBattery())
         val msg = msg_sys_status()
-
-        // TODO: Update accordingly?
-        val sensorsEnabled = sensorsPresent and
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL.inv() and
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL.inv() and
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_GEOFENCE.inv() and
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_LOGGING.inv()
-
-        val sensorsHealth = sensorsPresent or
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_GPS or
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_PROXIMITY and
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL.inv() and
-            MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL.inv()
 
 //        if (!aircraft.preArmCheckOk) sensorsHealth = sensorsHealth and
 //                MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_PREARM_CHECK.inv()
@@ -172,9 +175,9 @@ class ConnectionController(override val client: MAVLinkClient) : IController {
         msg.onboard_control_sensors_enabled = sensorsEnabled.toLong()
         msg.onboard_control_sensors_health = sensorsHealth.toLong()
 
-        msg.battery_remaining = aircraftBattery.percentCharge.toByte()
-        msg.voltage_battery = aircraftBattery.voltage
-        msg.current_battery = aircraftBattery.current.toShort()
+        msg.battery_remaining = battery.batteryRemaining
+        msg.voltage_battery = battery.voltagesBattery
+        msg.current_battery = battery.currentBatteryRaw
 //        client.sendMessage(msg)
         return msg
     }
@@ -249,17 +252,13 @@ class ConnectionController(override val client: MAVLinkClient) : IController {
     fun msgPowerStatus(): MAVLinkMessage = msg_power_status()
 
     fun msgBatteryStatus(telemetry: TelemetryHandler): MAVLinkMessage {
-        val aircraftBattery = telemetry.getAircraftBattery()
+        val battery = BatteryMapper.toMavlink(telemetry.getAircraftBattery())
         val msg = msg_battery_status()
-        msg.current_consumed = aircraftBattery.fullChargeCapacity - aircraftBattery.chargeRemaining
-        msg.voltages = aircraftBattery.voltageCells
-        msg.temperature = (aircraftBattery.temperature * 100.0).toInt().toShort()
-        msg.current_battery = (aircraftBattery.current * 10).toShort()
-        msg.battery_remaining = (
-            aircraftBattery.chargeRemaining.toFloat() /
-                aircraftBattery.fullChargeCapacity.toFloat() *
-                100.0f
-            ).toInt().toByte()
+        msg.current_consumed = battery.currentConsumed
+        msg.temperature = battery.temperature
+        msg.voltages = battery.voltages.toIntArray()
+        msg.battery_remaining = battery.batteryRemaining
+        msg.current_battery = battery.currentBattery
 //        client.sendMessage(msg)
         return msg
     }

--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -70,11 +70,8 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
 
             msg_command_int.MAVLINK_MSG_ID_COMMAND_INT -> processCommandInt(msg)
 
-            else -> {
-                // Notify if no message ID definition was found in any Controller
-                logger.w { "Unhandled message ${msg.name()}" }
-                client.sendMessage(MessageUtils.msgCommandAck(msg.msgid))
-            }
+            // Notify if no message ID definition was found in any Controller
+            else -> unhandledCommand(msg.name(), msg.msgid)
         }
     }
 
@@ -100,10 +97,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
 
             // TODO: Unhandled command ID: 521.
             // MAV_CMD.MAV_CMD_REQUEST_CAMERA_INFORMATION -> {}
-            else -> {
-                logger.w { "Unhandled COMMAND_LONG ID: ${commandMsg.command}" }
-                client.sendMessage(MessageUtils.msgCommandAck(commandMsg.command))
-            }
+            else -> unhandledCommand("COMMAND_LONG", commandMsg.command)
         }
     }
 
@@ -122,11 +116,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
 
         when (commandMsg.command) {
             MAV_CMD.MAV_CMD_REQUEST_MESSAGE -> processRequestInt(commandMsg)
-
-            else -> {
-                logger.w { "Unhandled COMMAND_INT ID: ${commandMsg.command}" }
-                client.sendMessage(MessageUtils.msgCommandAck(commandMsg.command))
-            }
+            else -> unhandledCommand("COMMAND_INT", commandMsg.command)
         }
     }
 
@@ -147,10 +137,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
             // TODO: Unhandled request ID: 397
             // https://mavlink.io/en/messages/common.html#COMPONENT_METADATA
             // MAVLINK_MSG_ID_COMPONENT_METADATA -> {}// MAVLink WIP
-            else -> {
-                logger.w { "Unhandled REQUEST_LONG ID: $requestID" }
-                client.sendMessage(MessageUtils.msgRequestAck())
-            }
+            else -> unhandledRequest("REQUEST_LONG", requestID)
         }
     }
 
@@ -163,10 +150,7 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
         if (processed) return
 
         when (requestID) {
-            else -> {
-                logger.w { "Unhandled REQUEST_INT ID: $requestID" }
-                client.sendMessage(MessageUtils.msgRequestAck())
-            }
+            else -> unhandledRequest("REQUEST_INT", requestID)
         }
     }
 
@@ -236,5 +220,15 @@ class MAVLinkController(private val aircraft: AircraftHandler) {
             1_000_000L
         )
         return true
+    }
+
+    private fun unhandledCommand(label: String, id: Int) {
+        logger.w { "Unhandled $label ID: $id" }
+        client.sendMessage(MessageUtils.msgCommandAck(id))
+    }
+
+    private fun unhandledRequest(label: String, id: Int) {
+        logger.w { "Unhandled $label ID: $id" }
+        client.sendMessage(MessageUtils.msgRequestAck())
     }
 }

--- a/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/MAVLinkController.kt
@@ -25,7 +25,6 @@ import org.WenuLink.mavlink.MAVLinkClient
  * - TelemetryController: Message Protocol
  */
 class MAVLinkController(private val aircraft: AircraftHandler) {
-
     private val logger by taggedLogger(MAVLinkController::class.java.simpleName)
     private val controllers: MutableList<IController> = mutableListOf()
     private lateinit var client: MAVLinkClient

--- a/app/src/main/java/org/WenuLink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/NavigationController.kt
@@ -143,7 +143,7 @@ class NavigationController(override val client: MAVLinkClient) : IController {
         return msg
     }
 
-    fun node2missionItemMsg(nIdx: Int, mission: MissionHandler): msg_mission_item_int {
+    fun node2MissionItemMsg(nIdx: Int, mission: MissionHandler): msg_mission_item_int {
         val node = mission.getWaypointNode(nIdx)
         val coordinates = node.coordinates3D
         val command = when (node) {
@@ -188,7 +188,7 @@ class NavigationController(override val client: MAVLinkClient) : IController {
         val idx = itemMsg.seq
         logger.d { "sendMissionItem #$idx" }
         if (mission.hasWaypointNodes()) {
-            val itemMsg = node2missionItemMsg(idx, mission)
+            val itemMsg = node2MissionItemMsg(idx, mission)
             client.sendMessage(itemMsg)
         }
     }

--- a/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/controllers/TelemetryController.kt
@@ -41,7 +41,7 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
     private val logger by taggedLogger(TelemetryController::class.java.simpleName)
 
     private var broadcastSuppressed = true
-    private val messageRates: MutableList<MessageRate> = mutableListOf(
+    private val messageRates = mutableListOf(
         MessageRate( // begin with Heartbeat at 1Hz
             msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT,
             1_000_000L
@@ -127,9 +127,7 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
         aircraft: AircraftHandler
     ): Boolean {
         when (commandLongMsg.command) {
-            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL ->
-                processMessageInterval(commandLongMsg)
-
+            MAV_CMD.MAV_CMD_SET_MESSAGE_INTERVAL -> processMessageInterval(commandLongMsg)
             else -> return false
         }
         return true
@@ -193,7 +191,7 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
         val dataList = availableDataList[request.req_stream_id.toInt()]
         if (dataList == null || dataList.isEmpty()) return
 
-        var timeInterval: Int = -1
+        var timeInterval = -1
         if (request.start_stop.toInt() == 1) {
             // requested interval in Hz
             timeInterval = request.req_message_rate

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
@@ -22,11 +22,11 @@ class MAVLinkClient(
     private val localPort: Int = 14550
 ) {
     private val logger by taggedLogger(MAVLinkClient::class.java.simpleName)
-    private var socket: DatagramSocket = DatagramSocket(localPort)
+    private var socket = DatagramSocket(localPort)
     private val mavlinkParser = Parser()
     private val clientScope = CoroutineScope(Dispatchers.IO) // TODO: Use mavlinkScope
-    val mustReceiveMessages: AtomicBoolean = AtomicBoolean(false)
-    val mustSendMessages: AtomicBoolean = AtomicBoolean(false)
+    val mustReceiveMessages = AtomicBoolean(false)
+    val mustSendMessages = AtomicBoolean(false)
     var systemID = 1
         private set
 
@@ -93,7 +93,7 @@ class MAVLinkClient(
             return
         }
         clientScope.launch {
-            val packet: MAVLinkPacket = msg.pack()
+            val packet = msg.pack()
             packet.sysid = systemID
             packet.compid = MAV_COMP_ID_AUTOPILOT1
             packet.isMavlink2 = true // force mavlink2 protocol

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -20,20 +20,20 @@ data class Endpoint(val ip: String, val port: Int) {
 
 class MAVLinkService(aircraft: AircraftHandler) {
     companion object {
-        var isEnabled: Boolean = true
+        var isEnabled = true
             private set
     }
     private val logger by taggedLogger(MAVLinkService::class.java.simpleName)
 
     private var client: MAVLinkClient? = null
-    private var controller: MAVLinkController = MAVLinkController(aircraft)
+    private var controller = MAVLinkController(aircraft)
     private var endpoint = Endpoint("192.168.1.220", 14550)
     private var mavlinkScope: CoroutineScope? = null
     private var listeningJob: Job? = null
     private var sendingJob: Job? = null
-    var isReady: Boolean = false
+    var isReady = false
         private set
-    val hasStationConnected: Boolean
+    val hasStationConnected
         get() = controller.isStationConnected()
 
     private val _isRunning = MutableStateFlow(false)
@@ -69,19 +69,15 @@ class MAVLinkService(aircraft: AircraftHandler) {
         logger.d { "MAVLinkClient ended." }
     }
 
-    fun launchListeningJob(): Job {
-        // Start listening for messages
-        return mavlinkScope!!.launch {
+    fun launchListeningJob(): Job = // Start listening for messages
+        mavlinkScope!!.launch {
             client?.startListening(controller::processMessage)
         }
-    }
 
-    fun launchSendingJob(): Job {
-        // Start sending messages
-        return mavlinkScope!!.launch {
+    fun launchSendingJob(): Job = // Start sending messages
+        mavlinkScope!!.launch {
             client?.startSending(controller::sendMessages)
         }
-    }
 
     suspend fun launchService(onResult: (String?) -> Unit) {
         logger.d { "Requesting to launch MAVLinkService." }

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -14,7 +14,9 @@ import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.adapters.aircraft.AircraftHandler
 import org.WenuLink.controllers.MAVLinkController
 
-data class Endpoint(val ip: String, val port: Int)
+data class Endpoint(val ip: String, val port: Int) {
+    fun toUrl(): String = "udp://$ip:$port"
+}
 
 class MAVLinkService(aircraft: AircraftHandler) {
     companion object {
@@ -37,9 +39,8 @@ class MAVLinkService(aircraft: AircraftHandler) {
     private val _isRunning = MutableStateFlow(false)
     val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
 
-    fun updateServerAddress(serverAddress: String) {
-        val (ip, port) = serverAddress.split(":")
-        endpoint = Endpoint(ip, port.toInt())
+    fun updateServerAddress(endpoint: Endpoint) {
+        this.endpoint = endpoint
     }
 
     fun clientExists(): Boolean = client != null
@@ -53,10 +54,10 @@ class MAVLinkService(aircraft: AircraftHandler) {
 
     fun createClient() {
         if (clientExists()) {
-            logger.d { "MAVLinkClient already created for udp://$endpoint." }
+            logger.d { "MAVLinkClient already created for udp://${endpoint.toUrl()}." }
             return
         }
-        logger.d { "Creating MAVLinkClient for udp://$endpoint." }
+        logger.d { "Creating MAVLinkClient for udp://${endpoint.toUrl()}." }
 
         client = MAVLinkClient(endpoint.ip, endpoint.port)
     }

--- a/app/src/main/java/org/WenuLink/parameters/ArduPilotParametersProvider.kt
+++ b/app/src/main/java/org/WenuLink/parameters/ArduPilotParametersProvider.kt
@@ -6,7 +6,6 @@ import com.MAVLink.enums.MAV_PARAM_TYPE
  * ArduPilot parameters take for functionality with GCS
  */
 object ArduPilotParametersProvider : ParameterProvider {
-
     override fun provide(): List<ParameterSpec> {
         /* ---------- internal storage ---------- */
         val values = mutableMapOf<String, ParamValue>()
@@ -17,45 +16,41 @@ object ArduPilotParametersProvider : ParameterProvider {
             semantic: SemanticType,
             reader: ((ParamValue?) -> Unit) -> Unit
         ) = SimpleParameter(
-            name = name,
-            type = type,
-            semantic = semantic,
-            reader = reader,
-            writer = { v, cb ->
-                values[name] = v
-                cb(null)
-            }
-        )
+            name,
+            type,
+            semantic,
+            reader
+        ) { v, cb ->
+            values[name] = v
+            cb(null)
+        }
 
         fun intParam(name: String, initial: Int) = numberParam(
             name,
             MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT32,
-            SemanticType.INT,
-            reader = { cb -> cb(values[name] ?: ParamValue.IntVal(initial)) }
-        )
+            SemanticType.INT
+        ) { cb -> cb(values[name] ?: ParamValue.IntVal(initial)) }
 
         fun floatParam(name: String, initial: Float) = numberParam(
             name,
             MAV_PARAM_TYPE.MAV_PARAM_TYPE_REAL32,
-            SemanticType.FLOAT,
-            reader = { cb -> cb(values[name] ?: ParamValue.FloatVal(initial)) }
-        )
+            SemanticType.FLOAT
+        ) { cb -> cb(values[name] ?: ParamValue.FloatVal(initial)) }
 
         fun int8Param(name: String, initial: Int) = numberParam(
             name,
             MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT8,
-            SemanticType.INT,
-            reader = { cb -> cb(values[name] ?: ParamValue.IntVal(initial)) }
-        )
+            SemanticType.INT
+        ) { cb -> cb(values[name] ?: ParamValue.IntVal(initial)) }
 
         fun boolParam(name: String, initial: Boolean) = SimpleParameter(
-            name = name,
-            type = MAV_PARAM_TYPE.MAV_PARAM_TYPE_UINT8,
-            semantic = SemanticType.BOOL,
-            reader = { cb ->
+            name,
+            MAV_PARAM_TYPE.MAV_PARAM_TYPE_UINT8,
+            SemanticType.BOOL,
+            { cb ->
                 cb(values[name] ?: ParamValue.BoolVal(initial))
             },
-            writer = { v, cb ->
+            { v, cb ->
                 values[name] = ParamValue.BoolVal((v as ParamValue.BoolVal).v)
                 cb(null)
             }

--- a/app/src/main/java/org/WenuLink/parameters/DJIParameters.kt
+++ b/app/src/main/java/org/WenuLink/parameters/DJIParameters.kt
@@ -14,15 +14,9 @@ import org.WenuLink.sdk.FCManager
 
 abstract class DJIParameter(name: String, type: Int, semantic: SemanticType) :
     ParameterSpec(name, type, semantic) {
-
     /* ---------- Shared helpers ---------- */
-    protected fun completionResult(error: DJIError?, onResult: (String?) -> Unit) {
-        if (error == null) {
-            onResult(null)
-        } else {
-            onResult(error.description)
-        }
-    }
+    protected fun completionResult(error: DJIError?, onResult: (String?) -> Unit) =
+        onResult(error?.description)
 }
 
 class DJIBooleanParameter(
@@ -34,7 +28,6 @@ class DJIBooleanParameter(
     MAV_PARAM_TYPE.MAV_PARAM_TYPE_UINT8,
     SemanticType.BOOL
 ) {
-
     override fun read(onResult: (ParamValue?) -> Unit) {
         getter(object : CommonCallbacks.CompletionCallbackWith<Boolean> {
             override fun onSuccess(value: Boolean?) {
@@ -46,19 +39,12 @@ class DJIBooleanParameter(
         })
     }
 
-    override fun write(value: ParamValue, onResult: (String?) -> Unit) {
-        val v = (value as ParamValue.BoolVal).v
-        setter(
-            v,
-            CommonCallbacks.CompletionCallback { err ->
-                if (err == null) {
-                    onResult(null)
-                } else {
-                    onResult(err.description)
-                }
-            }
-        )
-    }
+    override fun write(value: ParamValue, onResult: (String?) -> Unit) = setter(
+        (value as ParamValue.BoolVal).v,
+        CommonCallbacks.CompletionCallback { error ->
+            onResult(error?.description)
+        }
+    )
 }
 
 class DJIIntParameter(
@@ -102,7 +88,6 @@ class DJIFailSafeParameter(
     MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT32,
     SemanticType.ENUM
 ) {
-
     private fun enumToInt(v: ConnectionFailSafeBehavior): Int = when (v) {
         ConnectionFailSafeBehavior.HOVER -> 0
         ConnectionFailSafeBehavior.LANDING -> 1
@@ -141,7 +126,6 @@ class DJIControlModeParameter(
     MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT32,
     SemanticType.ENUM
 ) {
-
     private fun enumToInt(v: ControlMode): Int = when (v) {
         ControlMode.MANUAL -> 0
         ControlMode.SMART -> 2
@@ -182,7 +166,6 @@ class DJIRollPitchControlModeParameter(
     MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT32,
     SemanticType.ENUM
 ) {
-
     fun intToEnum(value: Int): RollPitchControlMode {
         val mode = RollPitchControlMode.entries.find { it.ordinal == value }
         return mode ?: RollPitchControlMode.ANGLE
@@ -209,7 +192,6 @@ class DJIVerticalControlModeParameter(
     MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT32,
     SemanticType.ENUM
 ) {
-
     fun intToEnum(value: Int): VerticalControlMode {
         val mode = VerticalControlMode.entries.find { it.ordinal == value }
         return mode ?: VerticalControlMode.VELOCITY
@@ -236,7 +218,6 @@ class DJIYawModeControlModeParameter(
     MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT32,
     SemanticType.ENUM
 ) {
-
     fun intToEnum(value: Int): YawControlMode {
         val mode = YawControlMode.entries.find { it.ordinal == value }
         return mode ?: YawControlMode.ANGLE
@@ -259,86 +240,85 @@ class DJIYawModeControlModeParameter(
  */
 
 object DJIParametersProvider : ParameterProvider {
-
     private val fc: FlightController
         get() = FCManager.fcInstance
             ?: error("FlightController not available")
 
     override fun provide(): List<ParameterSpec> = listOf(
         DJIBooleanParameter(
-            name = "DJI_SPIN_ENABLED",
-            getter = { cb -> fc.getQuickSpinEnabled(cb) },
-            setter = { v, cb -> fc.setAutoQuickSpinEnabled(v, cb) }
+            "DJI_SPIN_ENABLED",
+            { cb -> fc.getQuickSpinEnabled(cb) },
+            { v, cb -> fc.setAutoQuickSpinEnabled(v, cb) }
         ),
         DJIBooleanParameter(
-            name = "DJI_RADIUS_ENABLED",
-            getter = { cb -> fc.getMaxFlightRadiusLimitationEnabled(cb) },
-            setter = { v, cb -> fc.setMaxFlightRadiusLimitationEnabled(v, cb) }
+            "DJI_RADIUS_ENABLED",
+            { cb -> fc.getMaxFlightRadiusLimitationEnabled(cb) },
+            { v, cb -> fc.setMaxFlightRadiusLimitationEnabled(v, cb) }
         ),
         DJIBooleanParameter(
-            name = "DJI_FOLLOW_ENABLED",
-            getter = { cb -> fc.getTerrainFollowModeEnabled(cb) },
-            setter = { v, cb -> fc.setTerrainFollowModeEnabled(v, cb) }
+            "DJI_FOLLOW_ENABLED",
+            { cb -> fc.getTerrainFollowModeEnabled(cb) },
+            { v, cb -> fc.setTerrainFollowModeEnabled(v, cb) }
         ),
         DJIBooleanParameter(
-            name = "DJI_TRIPOD_ENABLED",
-            getter = { cb -> fc.getTripodModeEnabled(cb) },
-            setter = { v, cb -> fc.setTripodModeEnabled(v, cb) }
+            "DJI_TRIPOD_ENABLED",
+            { cb -> fc.getTripodModeEnabled(cb) },
+            { v, cb -> fc.setTripodModeEnabled(v, cb) }
         ),
         DJIBooleanParameter(
-            name = "DJI_SMART_RTL_ENABLED",
-            getter = { cb -> fc.getSmartReturnToHomeEnabled(cb) },
-            setter = { v, cb -> fc.setSmartReturnToHomeEnabled(v, cb) }
+            "DJI_SMART_RTL_ENABLED",
+            { cb -> fc.getSmartReturnToHomeEnabled(cb) },
+            { v, cb -> fc.setSmartReturnToHomeEnabled(v, cb) }
         ),
         DJIIntParameter(
-            name = "DJI_RTL_HEIGHT",
-            getter = { cb -> fc.getGoHomeHeightInMeters(cb) },
-            setter = { v, cb -> fc.setGoHomeHeightInMeters(v, cb) }
+            "DJI_RTL_HEIGHT",
+            { cb -> fc.getGoHomeHeightInMeters(cb) },
+            { v, cb -> fc.setGoHomeHeightInMeters(v, cb) }
         ),
         DJIIntParameter(
-            name = "DJI_MAX_HEIGHT",
-            getter = { cb -> fc.getMaxFlightHeight(cb) },
-            setter = { v, cb -> fc.setMaxFlightHeight(v, cb) }
+            "DJI_MAX_HEIGHT",
+            { cb -> fc.getMaxFlightHeight(cb) },
+            { v, cb -> fc.setMaxFlightHeight(v, cb) }
         ),
         DJIIntParameter(
-            name = "DJI_MAX_RADIUS",
-            getter = { cb -> fc.getMaxFlightRadius(cb) },
-            setter = { v, cb -> fc.setMaxFlightRadius(v, cb) }
+            "DJI_MAX_RADIUS",
+            { cb -> fc.getMaxFlightRadius(cb) },
+            { v, cb -> fc.setMaxFlightRadius(v, cb) }
         ),
         DJIIntParameter(
-            name = "DJI_BAT_LOW",
-            getter = { cb -> fc.getLowBatteryWarningThreshold(cb) },
-            setter = { v, cb -> fc.setLowBatteryWarningThreshold(v, cb) }
+            "DJI_BAT_LOW",
+            { cb -> fc.getLowBatteryWarningThreshold(cb) },
+            { v, cb -> fc.setLowBatteryWarningThreshold(v, cb) }
         ),
         DJIIntParameter(
-            name = "DJI_BAT_CRITIC",
-            getter = { cb -> fc.getSeriousLowBatteryWarningThreshold(cb) },
-            setter = { v, cb -> fc.setSeriousLowBatteryWarningThreshold(v, cb) }
+            "DJI_BAT_CRITIC",
+            { cb -> fc.getSeriousLowBatteryWarningThreshold(cb) },
+            { v, cb -> fc.setSeriousLowBatteryWarningThreshold(v, cb) }
         ),
         DJIFailSafeParameter(
-            name = "DJI_FAILSAFE",
-            getter = { cb -> fc.getConnectionFailSafeBehavior(cb) },
-            setter = { v, cb -> fc.setConnectionFailSafeBehavior(v, cb) }
+            "DJI_FAILSAFE",
+            { cb -> fc.getConnectionFailSafeBehavior(cb) },
+            { v, cb -> fc.setConnectionFailSafeBehavior(v, cb) }
         ),
         DJIControlModeParameter(
-            name = "DJI_CTRL_MODE",
-            getter = { cb -> fc.getControlMode(cb) },
-            setter = { v, cb -> fc.setControlMode(v, cb) }
+            "DJI_CTRL_MODE",
+            { cb -> fc.getControlMode(cb) },
+            { v, cb -> fc.setControlMode(v, cb) }
         ),
         DJIRollPitchControlModeParameter(
-            name = "DJI_ROLL_PITCH_MODE",
-            getter = { cb -> cb(fc.rollPitchControlMode.ordinal) },
-            setter = { v, cb -> fc.setRollPitchControlMode(v) }
+            "DJI_ROLL_PITCH_MODE",
+            { cb -> cb(fc.rollPitchControlMode.ordinal) },
+            { v, cb -> fc.setRollPitchControlMode(v) }
         ),
         DJIVerticalControlModeParameter(
-            name = "DJI_VERT_MODE",
-            getter = { cb -> cb(fc.verticalControlMode.ordinal) },
-            setter = { v, cb -> fc.setVerticalControlMode(v) }
+            "DJI_VERT_MODE",
+            { cb -> cb(fc.verticalControlMode.ordinal) },
+            { v, cb -> fc.setVerticalControlMode(v) }
         ),
         DJIYawModeControlModeParameter(
-            name = "DJI_YAW_MODE",
-            getter = { cb -> cb(fc.yawControlMode.ordinal) },
-            setter = { v, cb -> fc.setYawControlMode(v) }
+            "DJI_YAW_MODE",
+            { cb -> cb(fc.yawControlMode.ordinal) },
+            { v, cb -> fc.setYawControlMode(v) }
         )
     )
 }

--- a/app/src/main/java/org/WenuLink/parameters/ParameterBase.kt
+++ b/app/src/main/java/org/WenuLink/parameters/ParameterBase.kt
@@ -22,7 +22,6 @@ sealed class ParameterSpec(
     val semantic: SemanticType,
     var index: Int = -1
 ) {
-
     init {
         require(name.isNotBlank()) { "Parameter name cannot be blank" }
     }
@@ -31,7 +30,8 @@ sealed class ParameterSpec(
     abstract fun write(value: ParamValue, onResult: (String?) -> Unit)
 
     fun toMavlink(value: ParamValue): Int = when (value) {
-        is ParamValue.BoolVal -> if (value.v) 1 else 0
+        is ParamValue.BoolVal if value.v -> 1
+        is ParamValue.BoolVal -> 0
         is ParamValue.IntVal -> value.v
         is ParamValue.EnumVal -> value.v
         is ParamValue.FloatVal -> value.v.toInt()
@@ -58,7 +58,6 @@ open class SimpleParameter(
     private val reader: ((ParamValue?) -> Unit) -> Unit,
     private val writer: (ParamValue, (String?) -> Unit) -> Unit = { _, cb -> cb(null) }
 ) : ParameterSpec(name, type, semantic) {
-
     override fun read(onResult: (ParamValue?) -> Unit) {
         reader(onResult)
     }
@@ -87,8 +86,8 @@ class ParameterRegistry(private val providers: List<ParameterProvider>) {
                     spec.index = index
                     index += 1
                     availableParams += WenuLinkParameter(
-                        spec = spec,
-                        value = value
+                        spec,
+                        value
                     )
                 }
                 counter += 1

--- a/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
@@ -9,14 +9,17 @@ import dji.sdk.products.Aircraft
 import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.aircraft.BatteryData
 
+data class SignalQuality(val downlink: Int?, val uplink: Int?)
+
 object AircraftManager {
     private val logger by taggedLogger(AircraftManager::class.java.simpleName)
-    private val lastAirLinkQuality: IntArray = intArrayOf(-1, -1)
     private var lastBatteryData = BatteryData()
+    private var downlinkQuality: Int? = null
+    private var uplinkQuality: Int? = null
     private var aircraftInstance: Aircraft? = null
     private var batteryInstance: Battery? = null
     private var airLinkInstance: AirLink? = null
-    private var useAirLink: Boolean = false
+    private var useAirLink = false
 
     @Synchronized
     fun init(aircraft: Aircraft) {
@@ -35,7 +38,7 @@ object AircraftManager {
 
     @Synchronized
     fun isUpdated(): Boolean = lastBatteryData.percentCharge != null &&
-        (!useAirLink || (lastAirLinkQuality[0] > -1 && lastAirLinkQuality[1] > -1)
+        (!useAirLink || (downlinkQuality != null && uplinkQuality != null))
 
     @Synchronized
     fun isAircraftConnected(): Boolean = aircraftInstance != null
@@ -75,12 +78,12 @@ object AircraftManager {
     }
 
     @Synchronized
-    fun getAirlinkData(): IntArray = lastAirLinkQuality
+    fun getAirlinkData(): SignalQuality = SignalQuality(downlinkQuality, uplinkQuality)
 
     @Synchronized
     private fun updateAirlink(downLink: Int?, upLink: Int?) {
-        if (downLink != null) lastAirLinkQuality[0] = downLink
-        if (upLink != null) lastAirLinkQuality[1] = upLink
+        downLink?.let { downlinkQuality = it }
+        upLink?.let { uplinkQuality = it }
     }
 
     private fun startBatteryListeners() {
@@ -101,25 +104,25 @@ object AircraftManager {
 
     private fun stopBatteryListeners() {
         logger.d { "Stopping Battery updates" }
-        batteryInstance?.setStateCallback { null }
-        updateBattery(BatteryData())
+        batteryInstance?.setStateCallback { }
+        lastBatteryData = BatteryData()
     }
 
     private fun startAirLinkListeners() {
         if (!useAirLink) {
-            updateAirlink(-1, -1)
+            updateAirlink(null, null)
             logger.w { "Unable to start AirLink updates, no AirLink present" }
             return
         }
         logger.d { "Starting AirLink updates" }
-        airLinkInstance?.setDownlinkSignalQualityCallback { i: Int -> updateAirlink(i, null) }
-        airLinkInstance?.setUplinkSignalQualityCallback { i: Int -> updateAirlink(null, i) }
+        airLinkInstance?.setDownlinkSignalQualityCallback { updateAirlink(it, null) }
+        airLinkInstance?.setUplinkSignalQualityCallback { updateAirlink(null, it) }
     }
 
     private fun stopAirLinkListeners() {
         logger.d { "Stopping AirLink updates" }
-        airLinkInstance?.setDownlinkSignalQualityCallback { i -> }
-        airLinkInstance?.setUplinkSignalQualityCallback { i -> }
-        updateAirlink(-1, -1)
+        airLinkInstance?.setDownlinkSignalQualityCallback { }
+        airLinkInstance?.setUplinkSignalQualityCallback { }
+        updateAirlink(null, null)
     }
 }

--- a/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
@@ -11,8 +11,8 @@ import org.WenuLink.adapters.aircraft.BatteryData
 
 object AircraftManager {
     private val logger by taggedLogger(AircraftManager::class.java.simpleName)
-    private val lastBatteryData: BatteryData = BatteryData()
     private val lastAirLinkQuality: IntArray = intArrayOf(-1, -1)
+    private var lastBatteryData = BatteryData()
     private var aircraftInstance: Aircraft? = null
     private var batteryInstance: Battery? = null
     private var airLinkInstance: AirLink? = null
@@ -34,15 +34,8 @@ object AircraftManager {
     }
 
     @Synchronized
-    fun isUpdated(): Boolean {
-        var isUpdated = lastBatteryData.percentCharge > -1
-        if (useAirLink) {
-            isUpdated = isUpdated &&
-                lastAirLinkQuality[0] > -1 &&
-                lastAirLinkQuality[1] > -1
-        }
-        return isUpdated
-    }
+    fun isUpdated(): Boolean = lastBatteryData.percentCharge != null &&
+        (!useAirLink || (lastAirLinkQuality[0] > -1 && lastAirLinkQuality[1] > -1)
 
     @Synchronized
     fun isAircraftConnected(): Boolean = aircraftInstance != null
@@ -65,13 +58,20 @@ object AircraftManager {
     fun getModel(): String = aircraftInstance?.model?.toString() ?: "NONE"
 
     @Synchronized
-    private fun updateBattery(battery: BatteryData) {
-        lastBatteryData.updateFrom(battery)
+    private fun updateBattery(state: BatteryState) {
+        lastBatteryData = lastBatteryData.merge(
+            state.chargeRemainingInPercent,
+            state.voltage,
+            state.current,
+            state.fullChargeCapacity,
+            state.chargeRemaining,
+            state.temperature
+        )
     }
 
     @Synchronized
-    private fun updateBatteryCellVoltages(cellVoltage: IntArray) {
-        lastBatteryData.voltageCells = cellVoltage.clone()
+    private fun updateBatteryCellVoltages(cellVoltage: List<Int>) {
+        lastBatteryData = lastBatteryData.merge(voltageCells = cellVoltage)
     }
 
     @Synchronized
@@ -85,22 +85,11 @@ object AircraftManager {
 
     private fun startBatteryListeners() {
         logger.d { "Starting Battery updates" }
-        batteryInstance?.setStateCallback { batteryState: BatteryState ->
-            updateBattery(
-                BatteryData(
-                    batteryState.chargeRemainingInPercent,
-                    batteryState.voltage,
-                    batteryState.current,
-                    batteryState.fullChargeCapacity,
-                    batteryState.chargeRemaining,
-                    batteryState.temperature
-                )
-            )
-        }
+        batteryInstance?.setStateCallback { state -> updateBattery(state) }
 
         batteryInstance?.getCellVoltages(object : CompletionCallbackWith<Array<Int>> {
             override fun onSuccess(p0: Array<Int>) {
-                updateBatteryCellVoltages(p0.toIntArray())
+                updateBatteryCellVoltages(p0.toList())
                 logger.d { "getCellVoltages $p0" }
             }
 

--- a/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
@@ -9,7 +9,6 @@ import dji.common.util.CommonCallbacks
 import dji.sdk.camera.Camera
 import dji.sdk.camera.VideoFeeder
 import dji.sdk.codec.DJICodecManager
-import dji.sdk.sdkmanager.DJISDKManager
 import io.getstream.log.taggedLogger
 import java.nio.ByteBuffer
 import kotlin.coroutines.resume
@@ -28,17 +27,17 @@ object CameraManager {
         private set
     var cameraStreamID: String? = null
         private set
-    var frameWidth: Int = -1
+    var frameWidth = -1
         private set
-    var frameHeight: Int = -1
+    var frameHeight = -1
         private set
-    var frameRate: Float = -1f
+    var frameRate = -1f
         private set
     var serialNumber: String? = null
         private set
     var fwVersion: String? = null
-    var cameraMode: SettingsDefinitions.CameraMode = SettingsDefinitions.CameraMode.UNKNOWN
-    var captureMode: SettingsDefinitions.ShootPhotoMode = SettingsDefinitions.ShootPhotoMode.UNKNOWN
+    var cameraMode = SettingsDefinitions.CameraMode.UNKNOWN
+    var captureMode = SettingsDefinitions.ShootPhotoMode.UNKNOWN
 
     @Synchronized
     fun init(camera: Camera) {
@@ -65,13 +64,10 @@ object CameraManager {
         onResult: (String, Boolean) -> Unit
     ): CommonCallbacks.CompletionCallbackWith<String> =
         object : CommonCallbacks.CompletionCallbackWith<String> {
-            override fun onSuccess(value: String) {
-                onResult(value, true)
-            }
+            override fun onSuccess(value: String) = onResult(value, true)
 
-            override fun onFailure(p0: DJIError?) {
+            override fun onFailure(p0: DJIError?) =
                 onResult(p0?.description ?: "Unknown error", false)
-            }
         }
 
     suspend fun retrieveFirmwareVersion(): String? = suspendCancellableCoroutine { cont ->
@@ -102,14 +98,10 @@ object CameraManager {
         suspendCancellableCoroutine { cont ->
             mInstance?.getMode(
                 object : CommonCallbacks.CompletionCallbackWith<SettingsDefinitions.CameraMode> {
-
-                    override fun onSuccess(mode: SettingsDefinitions.CameraMode?) {
+                    override fun onSuccess(mode: SettingsDefinitions.CameraMode?) =
                         cont.resume(mode)
-                    }
 
-                    override fun onFailure(error: DJIError?) {
-                        cont.resume(null)
-                    }
+                    override fun onFailure(error: DJIError?) = cont.resume(null)
                 }
             ) ?: cont.resume(null)
         }
@@ -119,15 +111,11 @@ object CameraManager {
             mInstance?.getShootPhotoMode(
                 object :
                     CommonCallbacks.CompletionCallbackWith<SettingsDefinitions.ShootPhotoMode> {
-
-                    override fun onSuccess(mode: SettingsDefinitions.ShootPhotoMode?) {
+                    override fun onSuccess(mode: SettingsDefinitions.ShootPhotoMode?) =
                         cont.resume(mode)
-                    }
 
                     override fun onFailure(error: DJIError?) {
-                        if (error !=
-                            null
-                        ) {
+                        if (error != null) {
                             logger.d { "Error in reading CameraMode: ${error.description}" }
                         }
                         cont.resume(null)
@@ -137,22 +125,13 @@ object CameraManager {
         }
 
     suspend fun retrieveMetadata() {
-        if (mInstance == null) {
-            return
-        }
+        if (mInstance == null) return
 
         fwVersion = retrieveFirmwareVersion()
         serialNumber = retrieveSerialNumber()
 
-        val cameraMode = retrieveCameraMode()
-        if (cameraMode != null) {
-            this.cameraMode = cameraMode
-        }
-
-        val captureMode = retrieveCaptureMode()
-        if (captureMode != null) {
-            this.captureMode = captureMode
-        }
+        retrieveCameraMode()?.let { this.cameraMode = it }
+        retrieveCaptureMode()?.let { this.captureMode = it }
     }
 
     fun updateStreamID(id: String) {
@@ -163,10 +142,10 @@ object CameraManager {
     @Synchronized
     fun isConnected(): Boolean = mInstance != null
 
-    override fun toString(): String = if (mInstance == null) {
-        "No Camera to manage"
-    } else {
+    override fun toString(): String = if (isConnected()) {
         "Managing: $cameraName $frameWidth x $frameHeight @ $frameRate"
+    } else {
+        "No Camera to manage"
     }
 
     fun startCodecWithCallback(
@@ -279,7 +258,7 @@ object CameraManager {
 
     fun isSingleShoot() = captureMode == SettingsDefinitions.ShootPhotoMode.SINGLE
 
-    fun canRecordVideo() = mInstance?.isCaptureInVideoSupported ?: false
+    fun canRecordVideo() = mInstance?.isCaptureInVideoSupported == true
 
     suspend fun requestPhotoShoot(): String? {
         val camera = mInstance ?: return "Camera instance is null"

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -70,14 +70,15 @@ object FCManager {
     @Synchronized
     fun isConnected(): Boolean = fcInstance != null
 
-    override fun toString(): String = if (!isConnected()) {
-        if (serialNumber != null && fwVersion != null) {
-            "FlightController SN: ${(serialNumber ?: "N/A")} - FW: ${(fwVersion ?: "N/A")}"
-        } else {
+    override fun toString(): String {
+        val isConnected = isConnected()
+        return if (isConnected && serialNumber != null && fwVersion != null) {
+            "FlightController SN: $serialNumber - FW: $fwVersion"
+        } else if (isConnected) {
             "Reading FlightController"
+        } else {
+            "No FlightController"
         }
-    } else {
-        "No FlightController"
     }
 
     fun state2telemetry(state: FlightControllerState): TelemetryData = TelemetryData(

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -102,19 +102,14 @@ object FCManager {
         gpsLevel = SDKUtils.gpsSignalLevelFlags(state.gpsSignalLevel)
     )
 
-    fun registerStateCallback(stateCallback: (FlightControllerState) -> Unit) {
+    fun registerStateCallback(stateCallback: (FlightControllerState) -> Unit) =
         fcInstance?.setStateCallback(stateCallback)
-    }
 
-    fun unregisterStateCallback() {
-        fcInstance?.setStateCallback(null)
-    }
+    fun unregisterStateCallback() = fcInstance?.setStateCallback(null)
 
     fun getHomePosition(): Coordinates3D? {
         val flightState = fcInstance!!.state
-        if (!flightState.isHomeLocationSet) {
-            return null
-        }
+        if (!flightState.isHomeLocationSet) return null
 
         val homeLocation = flightState.homeLocation
         return Coordinates3D(
@@ -145,14 +140,11 @@ object FCManager {
 
     fun needLandingConfirmation() = fcInstance?.state?.isLandingConfirmationNeeded == true
 
-    fun startTakeoff() {
-        fcInstance?.startTakeoff { }
-    }
+    fun startTakeoff() = fcInstance?.startTakeoff { }
 
-    fun confirmLanding(onResult: (String?) -> Unit) {
+    fun confirmLanding(onResult: (String?) -> Unit) =
         // for somehow these kind of actions does not return anything, possibly is a thread issue.
         fcInstance?.confirmLanding { SDKUtils.createCompletionCallback(onResult) }
-    }
 
     fun areMotorsArmed(): Boolean = fcInstance?.state?.areMotorsOn() == true
 

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -81,7 +81,7 @@ object FCManager {
         }
     }
 
-    fun state2telemetry(state: FlightControllerState): TelemetryData = TelemetryData(
+    fun state2Telemetry(state: FlightControllerState): TelemetryData = TelemetryData(
         roll = state.attitude.roll,
         pitch = state.attitude.pitch,
         yaw = state.attitude.yaw,
@@ -99,7 +99,7 @@ object FCManager {
         isFlying = state.isFlying,
         motorsOn = state.areMotorsOn(),
         satelliteCount = state.satelliteCount,
-        gpsLevel = SDKUtils.getGPSSignalLevelArray(state.gpsSignalLevel)
+        gpsLevel = SDKUtils.gpsSignalLevelFlags(state.gpsSignalLevel)
     )
 
     fun registerStateCallback(stateCallback: (FlightControllerState) -> Unit) {

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -190,57 +190,52 @@ object FCManager {
     fun registerIMUState(onSensor: (AppIMUState) -> Unit) {
         val nSensors = fcInstance?.imuCount ?: 0
         logger.d { "Listening sensor: $nSensors IMU(s)" }
-        val state = AppIMUState()
-        if (nSensors > 0) {
-            fcInstance?.setIMUStateCallback { p0 ->
-                // The callback is executed one time per sensor, with -1 indicating the list's end
-                if (p0.index != -1) {
-                    // assumes same number gyros and accel
-                    if (state.gyroscope.getOrNull(p0.index) == null) {
-                        state.gyroscope.add(sensorState(p0.gyroscopeState))
-                    } else {
-                        state.gyroscope[p0.index] = sensorState(p0.gyroscopeState)
-                    }
 
-                    if (state.accelerometer.getOrNull(p0.index) == null) {
-                        state.accelerometer.add(sensorState(p0.accelerometerState))
-                    } else {
-                        state.accelerometer[p0.index] = sensorState(p0.accelerometerState)
-                    }
-                } else {
-                    // Publish a copy after receiving the entire list
-                    onSensor(
-                        AppIMUState().copy(
-                            gyroscope = state.gyroscope,
-                            accelerometer = state.accelerometer
-                        )
-                    )
-                }
-            }
-        } else {
+        if (nSensors <= 0) {
             logger.i { "No IMU sensor found!" }
+            return
+        }
+
+        val state = AppIMUState(
+            MutableList(nSensors) { AppSensorState.BOOT },
+            MutableList(nSensors) { AppSensorState.BOOT }
+        )
+
+        fcInstance?.setIMUStateCallback { p0 ->
+            // The callback is executed one time per sensor, with -1 indicating the list's end
+            if (p0.index == -1) {
+                // Publish a copy after receiving the entire list
+                onSensor(
+                    AppIMUState().copy(
+                        gyroscope = state.gyroscope,
+                        accelerometer = state.accelerometer
+                    )
+                )
+                return@setIMUStateCallback
+            }
+
+            // assumes same number gyros and accel
+            state.gyroscope[p0.index] = sensorState(p0.gyroscopeState)
+            state.accelerometer[p0.index] = sensorState(p0.accelerometerState)
         }
     }
 
     fun unregisterIMUState() {
         logger.d { "Stop listening sensor: ${fcInstance?.imuCount} IMU(s)" }
-        if ((fcInstance?.imuCount ?: 0) > 0) {
-            fcInstance?.setIMUStateCallback(null)
-        }
+        fcInstance?.setIMUStateCallback(null)
     }
 
     fun compassOk(): Boolean {
         val nSensors = fcInstance?.compassCount ?: 0
-        var compassOk = false
         logger.d { "Reading sensor: $nSensors compasses" }
-        if (nSensors > 0) {
-            val hasError = fcInstance?.compass?.hasError() ?: true
-            val calState = fcInstance?.compass?.calibrationState
-            compassOk = !hasError && calState == CompassCalibrationState.NOT_CALIBRATING
-        } else {
+
+        if (nSensors <= 0) {
             logger.i { "No Compass sensor found!" }
+            return false
         }
 
-        return compassOk
+        val compass = fcInstance?.compass
+        return compass?.hasError() != true &&
+            compass?.calibrationState == CompassCalibrationState.NOT_CALIBRATING
     }
 }

--- a/app/src/main/java/org/WenuLink/sdk/MissionActionManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/MissionActionManager.kt
@@ -22,13 +22,12 @@ import org.WenuLink.adapters.aircraft.Coordinates3D
  * class related to https://developer.dji.com/api-reference/android-api/Components/Missions/TimelineMission.html
  */
 object MissionActionManager {
-
     data class ActionCallbackKey(
         val actionClass: KClass<out TimelineElement>,
         val event: TimelineEvent
     )
 
-    private val logger by taggedLogger("MissionActionManager")
+    private val logger by taggedLogger(MissionActionManager::class.java.simpleName)
 
     private val missionControl: MissionControl
         get() = MissionControl.getInstance()
@@ -43,21 +42,13 @@ object MissionActionManager {
         stopListener()
     }
 
-    fun start() {
-        missionControl.startTimeline()
-    }
+    fun start() = missionControl.startTimeline()
 
-    fun stop() {
-        missionControl.stopTimeline()
-    }
+    fun stop() = missionControl.stopTimeline()
 
-    fun pause() {
-        missionControl.pauseTimeline()
-    }
+    fun pause() = missionControl.pauseTimeline()
 
-    fun resume() {
-        missionControl.resumeTimeline()
-    }
+    fun resume() = missionControl.resumeTimeline()
 
     // ---- Actions ----
 
@@ -74,19 +65,17 @@ object MissionActionManager {
         return missionControl.scheduleElement(action)
     }
 
-    fun scheduleLand(autoConfirm: Boolean = true): DJIError? {
-        val land = LandAction().apply {
+    fun scheduleLand(autoConfirm: Boolean = true): DJIError? = missionControl.scheduleElement(
+        LandAction().apply {
             autoConfirmLandingEnabled = autoConfirm
         }
-        return missionControl.scheduleElement(land)
-    }
+    )
 
-    fun scheduleGoHome(autoConfirm: Boolean = true): DJIError? {
-        val goHome = GoHomeAction().apply {
+    fun scheduleGoHome(autoConfirm: Boolean = true): DJIError? = missionControl.scheduleElement(
+        GoHomeAction().apply {
             autoConfirmLandingEnabled = autoConfirm
         }
-        return missionControl.scheduleElement(goHome)
-    }
+    )
 
     // ---- Listener and callbacks ----
 
@@ -94,10 +83,7 @@ object MissionActionManager {
         actionClass: KClass<T>,
         event: TimelineEvent,
         callback: () -> Unit
-    ) {
-        val key = ActionCallbackKey(actionClass, event)
-        callbacks.getOrPut(key) { mutableListOf() }.add(callback)
-    }
+    ) = callbacks.getOrPut(ActionCallbackKey(actionClass, event)) { mutableListOf() }.add(callback)
 
     fun onFinish(action: KClass<out TimelineElement>, callback: () -> Unit) =
         registerCallback(action, TimelineEvent.FINISHED, callback)

--- a/app/src/main/java/org/WenuLink/sdk/MissionManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/MissionManager.kt
@@ -210,7 +210,6 @@ object MissionManager {
         logger.d { "addListeners" }
         removeListener()
         listener = object : WaypointMissionOperatorListener {
-
             override fun onUploadUpdate(p0: WaypointMissionUploadEvent) {
             }
 

--- a/app/src/main/java/org/WenuLink/sdk/RCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/RCManager.kt
@@ -1,16 +1,14 @@
 package org.WenuLink.sdk
 
-import dji.common.remotecontroller.BatteryState
 import dji.sdk.remotecontroller.RemoteController
 import io.getstream.log.taggedLogger
-import kotlin.math.round
 import org.WenuLink.adapters.aircraft.BatteryData
 import org.WenuLink.adapters.aircraft.RCData
 
 object RCManager {
     private val logger by taggedLogger(RCManager::class.java.simpleName)
     private var lastData: RCData? = null
-    private val lastBatteryData: BatteryData = BatteryData()
+    private var lastBatteryData = BatteryData()
     private var rcInstance: RemoteController? = null
 
     @Synchronized
@@ -20,7 +18,7 @@ object RCManager {
     }
 
     @Synchronized
-    fun isUpdated(): Boolean = lastData != null && lastBatteryData.percentCharge > -1
+    fun isUpdated(): Boolean = lastData != null && lastBatteryData.percentCharge != null
 
     @Synchronized
     fun isRCConnected(): Boolean = rcInstance != null
@@ -47,14 +45,15 @@ object RCManager {
     }
 
     @Synchronized
-    private fun updateBatteryData(battery: BatteryData) {
-        if (battery.voltageCells == null) {
-            battery.voltageCells = IntArray(1)
-        }
-        battery.voltage = 7400
-        battery.current = 6
-        battery.voltageCells!![0] = round(7.4 * battery.percentCharge).toInt()
-        lastBatteryData.updateFrom(battery)
+    private fun updateBatteryData(percentCharge: Int) {
+        // simulated 2S LiPo, equal cell distribution
+        val cellVoltage = 3700 * percentCharge / 100
+        lastBatteryData = lastBatteryData.merge(
+            percentCharge = percentCharge,
+            voltage = 7400,
+            current = 6,
+            voltageCells = listOf(cellVoltage, cellVoltage)
+        )
     }
 
     private fun startHardwareListener() {
@@ -84,16 +83,14 @@ object RCManager {
 
     private fun startBatteryListener() {
         logger.d { "Starting RC BatteryListener" }
-        rcInstance?.setChargeRemainingCallback { batteryState: BatteryState ->
-            updateBatteryData(
-                BatteryData(batteryState.remainingChargeInPercent)
-            )
+        rcInstance?.setChargeRemainingCallback { state ->
+            updateBatteryData(state.remainingChargeInPercent)
         }
     }
 
     private fun stopBatteryListener() {
         logger.d { "Stopping RC BatteryListener" }
-        rcInstance?.setChargeRemainingCallback { null }
-        updateBatteryData(BatteryData())
+        rcInstance?.setChargeRemainingCallback { }
+        lastBatteryData = BatteryData()
     }
 }

--- a/app/src/main/java/org/WenuLink/sdk/RCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/RCManager.kt
@@ -77,7 +77,7 @@ object RCManager {
 
     private fun stopHardwareListener() {
         logger.d { "Stoping RC HardwareListener" }
-        rcInstance?.setHardwareStateCallback { null }
+        rcInstance?.setHardwareStateCallback { }
         updateData(null)
     }
 

--- a/app/src/main/java/org/WenuLink/sdk/RegistrationHandler.kt
+++ b/app/src/main/java/org/WenuLink/sdk/RegistrationHandler.kt
@@ -20,14 +20,13 @@ import io.getstream.log.taggedLogger
 object RegistrationHandler {
     private val logger by taggedLogger(RegistrationHandler::class.java.simpleName)
     private val loggerC by taggedLogger(DJISDKManager.SDKManagerCallback::class.java.simpleName)
-    private var registrationInProgress: Boolean = false
-    private var registered: Boolean = false
+    private var registrationInProgress = false
+    var registered = false
+        private set
     private var successCallback: ((Boolean, String?) -> Unit)? = null
     private var productCallback: ((Boolean) -> Unit)? = null
     private var activationStateListener: AppActivationStateListener? = null
     private var bindingStateListener: AircraftBindingStateListener? = null
-
-    fun isRegistered(): Boolean = registered
 
     fun setSuccessCallback(callback: (Boolean, String?) -> Unit) {
         successCallback = callback
@@ -67,16 +66,12 @@ object RegistrationHandler {
     }
 
     fun tearDownListener() {
-        if (activationStateListener != null) {
+        activationStateListener?.let {
             // Example of removing listeners
-            SDKUtils.getAppActivationManager()?.removeAppActivationStateListener(
-                activationStateListener as AppActivationStateListener
-            )
+            SDKUtils.getAppActivationManager()?.removeAppActivationStateListener(it)
         }
-        if (bindingStateListener != null) {
-            SDKUtils.getAppActivationManager()?.removeAircraftBindingStateListener(
-                bindingStateListener as AircraftBindingStateListener
-            )
+        bindingStateListener?.let {
+            SDKUtils.getAppActivationManager()?.removeAircraftBindingStateListener(it)
         }
     }
 
@@ -88,8 +83,7 @@ object RegistrationHandler {
         DJISDKManager.getInstance().destroy()
     }
 
-    private val sdkManagerCallback: DJISDKManager.SDKManagerCallback = object :
-        DJISDKManager.SDKManagerCallback {
+    private val sdkManagerCallback = object : DJISDKManager.SDKManagerCallback {
         override fun onRegister(djiError: DJIError) {
             if (djiError == DJISDKError.REGISTRATION_SUCCESS) {
                 DJISDKManager.getInstance().startConnectionToProduct()
@@ -132,22 +126,26 @@ object RegistrationHandler {
             newComponent?.setComponentListener { isConnected ->
                 loggerC.d { "onComponentConnectivityChanged: $isConnected" }
             }
+
             loggerC.d {
                 "onComponentChange key: $componentKey, " +
                     "oldComponent: $oldComponent, " +
                     "newComponent: $newComponent"
             }
-            if (componentKey == BaseProduct.ComponentKey.REMOTE_CONTROLLER) {
-                RCManager.init(newComponent as RemoteController)
-            }
-            if (componentKey == BaseProduct.ComponentKey.AIR_LINK) {
-                AircraftManager.initAirLink(newComponent as AirLink)
-            }
-            if (componentKey == BaseProduct.ComponentKey.FLIGHT_CONTROLLER) {
-                FCManager.init(newComponent as FlightController)
-            }
-            if (componentKey == BaseProduct.ComponentKey.CAMERA) {
-                CameraManager.init(newComponent as Camera)
+
+            when (componentKey) {
+                BaseProduct.ComponentKey.REMOTE_CONTROLLER ->
+                    RCManager.init(newComponent as RemoteController)
+
+                BaseProduct.ComponentKey.AIR_LINK ->
+                    AircraftManager.initAirLink(newComponent as AirLink)
+
+                BaseProduct.ComponentKey.FLIGHT_CONTROLLER ->
+                    FCManager.init(newComponent as FlightController)
+
+                BaseProduct.ComponentKey.CAMERA -> CameraManager.init(newComponent as Camera)
+
+                else -> loggerC.d { "Unknown component key: $componentKey" }
             }
         }
 

--- a/app/src/main/java/org/WenuLink/sdk/SDKManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SDKManager.kt
@@ -6,8 +6,7 @@ import androidx.multidex.MultiDex
 import com.cySdkyc.clx.Helper
 
 object SDKManager {
-    private val TAG: String = SDKManager::class.java.simpleName
-    var isContextAttached: Boolean = false
+    var isContextAttached = false
     var aircraftBindingState: String? = "Idle"
         private set
     var appActivationState: String? = "Idle"
@@ -21,29 +20,24 @@ object SDKManager {
 
     fun getIntentAction(): String = SDKUtils.getUsbAction()
 
-    fun isRegistered(): Boolean = RegistrationHandler.isRegistered()
+    fun isRegistered(): Boolean = RegistrationHandler.registered
 
-    fun setActivationCallback(callback: (Boolean, String?) -> Unit) {
+    fun setActivationCallback(callback: (Boolean, String?) -> Unit) =
         RegistrationHandler.setActivationCallback(callback)
-    }
 
-    fun setBindingCallback(callback: (Boolean, String?) -> Unit) {
+    fun setBindingCallback(callback: (Boolean, String?) -> Unit) =
         RegistrationHandler.setBindingCallback(callback)
-    }
 
-    fun setProductChangeCallback(callback: (Boolean) -> Unit) {
+    fun setProductChangeCallback(callback: (Boolean) -> Unit) =
         RegistrationHandler.setProductChangeCallback(callback)
-    }
 
     fun startRegistration(context: Context, callback: (Boolean, String?) -> Unit) {
         RegistrationHandler.setSuccessCallback(callback)
         RegistrationHandler.initialize(context)
     }
 
-    fun destroy(context: Context) {
-        // TODO: unload everything
+    fun destroy(context: Context) = // TODO: unload everything
         RegistrationHandler.destroy()
-    }
 
     fun getAircraftModel(): String =
         SDKUtils.getAircraftInstance()?.model?.displayName ?: "No Aircraft Detected"

--- a/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
@@ -39,11 +39,9 @@ object SDKUtils {
         onResult: (String?) -> Unit
     ): CommonCallbacks.CompletionCallback<DJIError> =
         CommonCallbacks.CompletionCallback<DJIError> { error ->
-            if (error == null) {
-                onResult(null)
-            } else {
+            if (error != null) {
                 logger.e { "CompletionCallback onFailure $error" }
-                onResult(error.description)
             }
+            onResult(error?.description)
         }
 }

--- a/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
@@ -32,17 +32,8 @@ object SDKUtils {
     fun getAppActivationManager(): AppActivationManager? =
         DJISDKManager.getInstance().appActivationManager
 
-    fun getGPSSignalLevelArray(inputLevel: GPSSignalLevel): BooleanArray {
-        // Create a boolean array with the same size as the number of enum constants
-        val result = BooleanArray(GPSSignalLevel.entries.size)
-
-        // Iterate through the enum constants and set the corresponding index to true if it matches the input level
-        for (i in GPSSignalLevel.entries.indices) {
-            result[i] = GPSSignalLevel.entries[i] == inputLevel
-        }
-
-        return result
-    }
+    fun gpsSignalLevelFlags(inputLevel: GPSSignalLevel): List<Boolean> =
+        GPSSignalLevel.entries.map { it == inputLevel }
 
     fun createCompletionCallback(
         onResult: (String?) -> Unit

--- a/app/src/main/java/org/WenuLink/sdk/SimManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SimManager.kt
@@ -12,14 +12,14 @@ import org.WenuLink.adapters.aircraft.TelemetryData
 object SimManager {
     private val logger by taggedLogger(SimManager::class.java.simpleName)
 
-    private var hasCallback: Boolean = false
+    private var hasCallback = false
     var simInstance: Simulator? = null
         private set
-    private var satelliteCount: Int = -1
-    private var takeOffAltitude: Float = 0F
-    private var initStamp: Long = 0L
-    private var takeOffStamp: Long = 0L
-    private var landStamp: Long = 0L
+    private var satelliteCount = -1
+    private var takeOffAltitude = 0f
+    private var initStamp = 0L
+    private var takeOffStamp = 0L
+    private var landStamp = 0L
 
     @Synchronized
     fun init(flightController: FlightController) {
@@ -53,9 +53,9 @@ object SimManager {
             positionX = state.positionX,
             positionY = state.positionY,
             positionZ = state.positionZ,
-            velocityX = 0F,
-            velocityY = 0F,
-            velocityZ = 0F,
+            velocityX = 0f,
+            velocityY = 0f,
+            velocityZ = 0f,
             flightTime = 0,
             takeOffAltitude = takeOffAltitude,
             relativeAltitude = state.positionZ,
@@ -68,13 +68,14 @@ object SimManager {
         if (previousData == null) return data
 
         // perform updates comparing previous and current state
-        if (data.isFlying) {
-            if (!previousData.isFlying) takeOffStamp = data.timestamp
+        if (data.isFlying && !previousData.isFlying) {
+            takeOffStamp = data.timestamp
+        } else if (data.isFlying) {
             landStamp = data.timestamp
         }
 
         // compute velocities
-        val dT = (data.timestamp - previousData.timestamp).toFloat() / 1000F // to seconds
+        val dT = (data.timestamp - previousData.timestamp).toFloat() / 1000f // to seconds
         return data.copy(
             flightTime = (landStamp - takeOffStamp).toInt(),
             velocityX = (data.positionX - previousData.positionX) / dT,
@@ -86,7 +87,7 @@ object SimManager {
     fun run(
         lat: Double = -8.066478642777481,
         long: Double = -34.98744367551871,
-        alt: Float = 24.0F,
+        alt: Float = 24.0f,
         updateFrequency: Int = 10,
         satelliteCount: Int = 8,
         onResult: (String?) -> Unit

--- a/app/src/main/java/org/WenuLink/sdk/SimManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SimManager.kt
@@ -43,7 +43,7 @@ object SimManager {
     }
 
     @Synchronized
-    fun state2telemetry(state: SimulatorState, previousData: TelemetryData? = null): TelemetryData {
+    fun state2Telemetry(state: SimulatorState, previousData: TelemetryData? = null): TelemetryData {
         val data = TelemetryData(
             roll = state.roll.toDouble(),
             pitch = state.pitch.toDouble(),
@@ -62,7 +62,7 @@ object SimManager {
             isFlying = state.isFlying,
             motorsOn = state.areMotorsOn(),
             satelliteCount = satelliteCount,
-            gpsLevel = SDKUtils.getGPSSignalLevelArray(GPSSignalLevel.LEVEL_7)
+            gpsLevel = SDKUtils.gpsSignalLevelFlags(GPSSignalLevel.LEVEL_7)
         )
         // complete data from previous one
         if (previousData == null) return data

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -20,12 +20,12 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
 
     private var thisApp = (getApplication() as WenuLinkApp)
 
-    private val aircraft: AircraftHandler = AircraftHandler.getInstance()
+    private val aircraft = AircraftHandler.getInstance()
 
     private val _isServiceRunning = MutableStateFlow(false)
     val isServiceRunning: StateFlow<Boolean> = _isServiceRunning
 
-    val isDataFlowing: StateFlow<Boolean> = aircraft.telemetry.isBroadcasting
+    val isDataFlowing = aircraft.telemetry.isBroadcasting
 
     private val _telemetryData = MutableLiveData<TelemetryData?>()
     val telemetryData: LiveData<TelemetryData?> = _telemetryData
@@ -54,7 +54,7 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
 
     fun isSimulationReady(): Boolean = aircraft.telemetry.isSimulationAvailable
 
-    fun isServiceReady(): Boolean = thisApp.wenuLinkService?.isReady() ?: false
+    fun isServiceReady(): Boolean = thisApp.wenuLinkService?.isReady() == true
 
     fun startService() {
         thisApp.launchWenulinkService()

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCClient.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCClient.kt
@@ -51,7 +51,7 @@ class WebRTCClient(serverAddress: String) {
         ICE // to send and receive ice candidates
     }
 
-    private val logger by taggedLogger("SignalingClient")
+    private val logger by taggedLogger(WebRTCClient::class.java.simpleName)
     private val signalingScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val client = OkHttpClient()
     private val request = Request

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCClient.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCClient.kt
@@ -116,7 +116,7 @@ class WebRTCClient(serverAddress: String) {
         }
     }
 
-    fun message2eventData(textMessage: String): Pair<String, String> {
+    fun message2EventData(textMessage: String): Pair<String, String> {
         var event = ""
         var dataString = ""
         try {
@@ -143,7 +143,7 @@ class WebRTCClient(serverAddress: String) {
     private inner class SignalingWebSocketListener : WebSocketListener() {
         override fun onMessage(webSocket: WebSocket, text: String) {
             logger.d { "onMessage $text" }
-            val (event, rawData) = message2eventData(text)
+            val (event, rawData) = message2EventData(text)
 
             if (event == "client_id") emitReadyState()
 

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -27,6 +27,10 @@ import org.webrtc.VideoCapturer
 import org.webrtc.VideoSource
 import org.webrtc.VideoTrack
 
+data class SignalingEndpoint(val host: String, val port: Int, val protocol: String = "ws") {
+    fun toUrl(): String = "$protocol://$host:$port"
+}
+
 class WebRTCService {
     companion object {
         private var mInstance: WebRTCService? = null
@@ -54,8 +58,8 @@ class WebRTCService {
     private lateinit var surfaceTextureHelper: SurfaceTextureHelper
 
     // Signaling configuration
-    private var signalingServer = "ws://192.168.1.220:8090"
     var isServiceUp: Boolean = false
+    private var signalingEndpoint = SignalingEndpoint("192.168.1.220", 8090)
         private set
     var isStreaming: Boolean = false
         private set
@@ -86,8 +90,8 @@ class WebRTCService {
     lateinit var mediaOptions: CameraCapturer.MediaMetadata
     private var offer: String? = null
 
-    fun updateServerAddress(serverAddress: String) {
-        signalingServer = serverAddress
+    fun updateServerAddress(endpoint: SignalingEndpoint) {
+        signalingEndpoint = endpoint
     }
 
     private val peerConnection: StreamPeerConnection by lazy {
@@ -117,10 +121,10 @@ class WebRTCService {
 
         this.serviceScope = serviceScope
 
-        logger.i { "Connecting WebRTC client to $signalingServer" }
+        logger.i { "Connecting WebRTC client to ${signalingEndpoint.toUrl()}" }
         if (::webRTCClient.isInitialized) return
 
-        webRTCClient = WebRTCClient(signalingServer)
+        webRTCClient = WebRTCClient(signalingEndpoint.toUrl())
         peerConnectionFactory = StreamPeerConnectionFactory(context)
         surfaceTextureHelper = SurfaceTextureHelper.create(
             "SurfaceTextureHelperThread",

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -83,7 +83,7 @@ class WebRTCService {
 
     // getting front camera
     private val videoCapturer: VideoCapturer by lazy { CameraCapturer() }
-    val mediaOptions = CameraCapturer.MediaMetadata()
+    lateinit var mediaOptions: CameraCapturer.MediaMetadata
     private var offer: String? = null
 
     fun updateServerAddress(serverAddress: String) {
@@ -109,6 +109,12 @@ class WebRTCService {
             logger.i { "Unable to start client, WebRTC not enabled." }
             return
         }
+
+        mediaOptions = CameraCapturer.MediaMetadata.fromCameraManager() ?: run {
+            logger.e { "CameraManager not ready, cannot start WebRTC" }
+            return
+        }
+
         this.serviceScope = serviceScope
 
         logger.i { "Connecting WebRTC client to $signalingServer" }
@@ -138,21 +144,23 @@ class WebRTCService {
             return
         }
         runningJob = serviceScope.launch {
-            webRTCClient.signalingCommandFlow.collect { commandToValue ->
-                logger.d { "signalingCommandFlow ${commandToValue.first}" }
-                when (commandToValue.first) {
-                    WebRTCClient.CommandType.OFFER -> {
-                        createVideoTrack(context)
-                        handleOffer(commandToValue.second)
-                    }
-
-                    WebRTCClient.CommandType.ANSWER -> handleAnswer(commandToValue.second)
-
-                    WebRTCClient.CommandType.ICE -> handleIce(commandToValue.second)
-
-                    else -> Unit
-                }
+            webRTCClient.signalingCommandFlow.collect { (command, value) ->
+                handleSignalingCommand(command, value, context)
             }
+        }
+    }
+
+    private suspend fun handleSignalingCommand(
+        command: WebRTCClient.CommandType,
+        value: String,
+        context: Context
+    ) {
+        logger.d { "signalingCommandFlow $command" }
+        when (command) {
+            WebRTCClient.CommandType.OFFER -> handleOffer(value, context)
+            WebRTCClient.CommandType.ANSWER -> handleAnswer(value)
+            WebRTCClient.CommandType.ICE -> handleIce(value)
+            else -> Unit
         }
     }
 
@@ -162,9 +170,9 @@ class WebRTCService {
             peerConnectionFactory.makeVideoSource(videoCapturer.isScreencast).apply {
                 videoCapturer.initialize(surfaceTextureHelper, context, this.capturerObserver)
                 videoCapturer.startCapture(
-                    mediaOptions.VIDEO_RESOLUTION_WIDTH,
-                    mediaOptions.VIDEO_RESOLUTION_HEIGHT,
-                    mediaOptions.FPS
+                    mediaOptions.videoResolutionWidth,
+                    mediaOptions.videoResolutionHeight,
+                    mediaOptions.fps
                 )
                 isStreaming = true
             }
@@ -177,7 +185,7 @@ class WebRTCService {
     }
 
     fun onAnswerReady() {
-        peerConnection.connection.addTrack(localVideoTrack, listOf(mediaOptions.MEDIA_STREAM_ID))
+        peerConnection.connection.addTrack(localVideoTrack, listOf(mediaOptions.mediaStreamId))
         serviceScope.launch {
             // sending local video track to show local video from start
             _localVideoTrackFlow.emit(localVideoTrack)
@@ -192,9 +200,9 @@ class WebRTCService {
         if (enabled && !isStreaming) {
             isStreaming = true
             videoCapturer.startCapture(
-                mediaOptions.VIDEO_RESOLUTION_WIDTH,
-                mediaOptions.VIDEO_RESOLUTION_HEIGHT,
-                mediaOptions.FPS
+                mediaOptions.videoResolutionWidth,
+                mediaOptions.videoResolutionHeight,
+                mediaOptions.fps
             )
         } else {
             isStreaming = false
@@ -252,8 +260,9 @@ class WebRTCService {
         logger.d { "[SDP] send answer: ${answer.stringify()}" }
     }
 
-    private fun handleOffer(sdp: String) {
+    private fun handleOffer(sdp: String, context: Context) {
         logger.d { "[SDP] handle offer: $sdp" }
+        createVideoTrack(context)
         offer = webRTCClient.valueFromKey(sdp, "sdp")!!
         onAnswerReady()
     }

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -34,7 +34,7 @@ data class SignalingEndpoint(val host: String, val port: Int, val protocol: Stri
 class WebRTCService {
     companion object {
         private var mInstance: WebRTCService? = null
-        var isEnabled: Boolean = true
+        var isEnabled = true
             private set
 
         fun getInstance(): WebRTCService {
@@ -58,10 +58,10 @@ class WebRTCService {
     private lateinit var surfaceTextureHelper: SurfaceTextureHelper
 
     // Signaling configuration
-    var isServiceUp: Boolean = false
     private var signalingEndpoint = SignalingEndpoint("192.168.1.220", 8090)
+    var isServiceUp = false
         private set
-    var isStreaming: Boolean = false
+    var isStreaming = false
         private set
 
     private val _isRunning = MutableStateFlow(false)
@@ -133,20 +133,15 @@ class WebRTCService {
 
         isRunning.distinctUntilChangedBy { it }
             .onEach {
-                if (it) {
-                    run(context)
-                } else {
-                    disconnect()
-                }
+                if (it) run(context) else disconnect()
                 logger.d { "isRunning: $it" }
             }
             .launchIn(this.serviceScope)
     }
 
     fun run(context: Context) {
-        if (isServiceUp) {
-            return
-        }
+        if (isServiceUp) return
+
         runningJob = serviceScope.launch {
             webRTCClient.signalingCommandFlow.collect { (command, value) ->
                 handleSignalingCommand(command, value, context)
@@ -170,8 +165,8 @@ class WebRTCService {
 
     fun createVideoTrack(context: Context) {
         logger.d { "mediaOptions: $mediaOptions" }
-        videoSource =
-            peerConnectionFactory.makeVideoSource(videoCapturer.isScreencast).apply {
+        videoSource = peerConnectionFactory.makeVideoSource(videoCapturer.isScreencast)
+            .apply {
                 videoCapturer.initialize(surfaceTextureHelper, context, this.capturerObserver)
                 videoCapturer.startCapture(
                     mediaOptions.videoResolutionWidth,
@@ -181,11 +176,10 @@ class WebRTCService {
                 isStreaming = true
             }
 
-        localVideoTrack =
-            peerConnectionFactory.makeVideoTrack(
-                source = videoSource,
-                trackId = "Video${UUID.randomUUID()}"
-            )
+        localVideoTrack = peerConnectionFactory.makeVideoTrack(
+            source = videoSource,
+            trackId = "Video${UUID.randomUUID()}"
+        )
     }
 
     fun onAnswerReady() {
@@ -194,9 +188,7 @@ class WebRTCService {
             // sending local video track to show local video from start
             _localVideoTrackFlow.emit(localVideoTrack)
 
-            if (offer != null) {
-                sendAnswer()
-            }
+            if (offer != null) sendAnswer()
         }
     }
 
@@ -215,18 +207,14 @@ class WebRTCService {
     }
 
     fun disconnect() {
-        if (!isServiceUp) {
-            return
-        }
+        if (!isServiceUp) return
 
         try {
             runningJob?.cancel()
             runningJob = null
             // dispose video tracks
             localVideoTrackFlow.replayCache.forEach { it.dispose() }
-            if (::localVideoTrack.isInitialized) {
-                localVideoTrack.dispose()
-            }
+            if (::localVideoTrack.isInitialized) localVideoTrack.dispose()
 
             // stop capturer
             try {
@@ -237,9 +225,7 @@ class WebRTCService {
             videoCapturer.dispose()
 
             // release surfaceTextureHelper
-            if (::surfaceTextureHelper.isInitialized) {
-                surfaceTextureHelper.dispose()
-            }
+            if (::surfaceTextureHelper.isInitialized) surfaceTextureHelper.dispose()
 
             // close peer connection
             peerConnection.connection.close()

--- a/app/src/main/java/org/WenuLink/webrtc/peer/StreamPeerConnection.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/peer/StreamPeerConnection.kt
@@ -63,7 +63,6 @@ class StreamPeerConnection(
     private val onIceCandidate: ((IceCandidate, StreamPeerType) -> Unit)?,
     private val onVideoTrack: ((RtpTransceiver?) -> Unit)?
 ) : PeerConnection.Observer {
-
     private val typeTag = type.stringify()
 
     private val logger by taggedLogger(StreamPeerConnection::class.java.simpleName)

--- a/app/src/main/java/org/WenuLink/webrtc/peer/StreamPeerConnectionFactory.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/peer/StreamPeerConnectionFactory.kt
@@ -37,7 +37,7 @@ import org.webrtc.SoftwareVideoEncoderFactory
 import org.webrtc.VideoSource
 import org.webrtc.VideoTrack
 
-class StreamPeerConnectionFactory constructor(private val context: Context) {
+class StreamPeerConnectionFactory(private val context: Context) {
     private val webRtcLogger by taggedLogger("Call:WebRTC")
 
     val eglBaseContext: EglBase.Context by lazy {
@@ -81,27 +81,22 @@ class StreamPeerConnectionFactory constructor(private val context: Context) {
             PeerConnectionFactory.InitializationOptions.builder(context)
                 .setInjectableLogger({ message, severity, label ->
                     when (severity) {
-                        Logging.Severity.LS_VERBOSE -> {
+                        Logging.Severity.LS_VERBOSE ->
                             webRtcLogger.v { "[onLogMessage] label: $label, message: $message" }
-                        }
 
-                        Logging.Severity.LS_INFO -> {
+                        Logging.Severity.LS_INFO ->
                             webRtcLogger.i { "[onLogMessage] label: $label, message: $message" }
-                        }
 
-                        Logging.Severity.LS_WARNING -> {
+                        Logging.Severity.LS_WARNING ->
                             webRtcLogger.w { "[onLogMessage] label: $label, message: $message" }
-                        }
 
-                        Logging.Severity.LS_ERROR -> {
+                        Logging.Severity.LS_ERROR ->
                             webRtcLogger.e { "[onLogMessage] label: $label, message: $message" }
-                        }
 
-                        Logging.Severity.LS_NONE -> {
+                        Logging.Severity.LS_NONE ->
                             webRtcLogger.d { "[onLogMessage] label: $label, message: $message" }
-                        }
 
-                        else -> {}
+                        else -> { }
                     }
                 }, Logging.Severity.LS_VERBOSE)
                 .createInitializationOptions()
@@ -138,17 +133,17 @@ class StreamPeerConnectionFactory constructor(private val context: Context) {
         onVideoTrack: ((RtpTransceiver?) -> Unit)? = null
     ): StreamPeerConnection {
         val peerConnection = StreamPeerConnection(
-            coroutineScope = coroutineScope,
-            type = type,
-            mediaConstraints = mediaConstraints,
-            onStreamAdded = onStreamAdded,
-            onNegotiationNeeded = onNegotiationNeeded,
-            onIceCandidate = onIceCandidateRequest,
-            onVideoTrack = onVideoTrack
+            coroutineScope,
+            type,
+            mediaConstraints,
+            onStreamAdded,
+            onNegotiationNeeded,
+            onIceCandidateRequest,
+            onVideoTrack
         )
         val connection = makePeerConnectionInternal(
-            configuration = configuration,
-            observer = peerConnection
+            configuration,
+            peerConnection
         )
         return peerConnection.apply { initialize(connection) }
     }

--- a/app/src/main/java/org/WenuLink/webrtc/utils/SDPUtils.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/utils/SDPUtils.kt
@@ -25,7 +25,6 @@ suspend inline fun createValue(
     crossinline call: (SdpObserver) -> Unit
 ): Result<SessionDescription> = suspendCoroutine {
     val observer = object : SdpObserver {
-
         /**
          * Handling of create values.
          */

--- a/app/src/main/java/org/WenuLink/webrtc/utils/VideoCapturerUtils.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/utils/VideoCapturerUtils.kt
@@ -7,7 +7,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
 import org.webrtc.JavaI420Buffer
 import org.webrtc.NV12Buffer
-import org.webrtc.VideoCapturer
 import org.webrtc.VideoFrame
 
 fun getBufferNV12(
@@ -68,7 +67,7 @@ fun getBufferI420(
     )
 }
 
-fun VideoCapturer.videoBuffer2VideoFrame(
+fun videoBuffer2VideoFrame(
     mediaFormat: MediaFormat,
     videoBuffer: ByteBuffer,
     width: Int,


### PR DESCRIPTION
## Summary

This PR consolidates a batch of code quality improvements across the
codebase. Changes are separated into focused commits so each can be
reviewed independently. No new features are introduced.

## Motivation

Several patterns were inconsistent with idiomatic Kotlin and made the
codebase harder to follow:

- The use of `-1` values made null states implicit and caused null-safety
  to be bypassed with `?: false` guards
- Mutable data class fields allowed untracked in-place mutation
- Raw `String` and `IntArray` types were used where named types would
  make intent clearer, also caused compile warnings
- Some method names mixed conventions (`state2telemetry`,
  `VIDEO_CAMERA_NAME`, `getGPSSignalLevelArray`)
- Two genuine bugs were found during the cleanup

## Commits

| # | Commit | Type |
| --- | --- | --- |
| 1 | Fix typo in CONTRIBUTING.md | fix |
| 2 | Fix inverted `isConnected` in `FCManager.toString` | fix |
| 3 | Replace sentinel `-1` battery values with nullable types, introduce `BatteryMapper` | refactor |
| 4 | Replace `IntArray` airlink signal with `SignalQuality` type | refactor |
| 5 | Make `MediaMetadata` immutable with null-safe `fromCameraManager()` factory | refactor |
| 6 | Replace raw address strings with `Endpoint`/`SignalingEndpoint` types | refactor |
| 7 | Pre-allocate IMU state list in `registerIMUState`, fix `compassOk` null handling | refactor |
| 8 | Rename methods to follow Kotlin naming conventions | style |
| 9 | Extract `unhandledCommand`/`unhandledRequest` helpers in `MAVLinkController` | refactor |
| 10 | Idiomatic Kotlin cleanup across codebase | style |

## Notable changes worth reviewing

**Bug fixes (commit 2):**
`FCManager.toString()` had a negated condition so it returned the SN/FW
string when disconnected and "No FlightController" when connected.

**Operator precedence fix (commit 3):**
`sensorsHealth` in `ConnectionController` was missing parentheses around
the `or` expression, so the `.inv()` masks only applied to
`SENSOR_PROXIMITY` rather than to the full combined value.

**`BatteryData` (commit 3):**
`updateFrom()` mutated fields in place on a `var`-field data class.
Replaced with immutable `val` fields and a `merge()` method that returns
a new instance via `copy()`. Sentinel `-1` values replaced with nullable
types throughout.

**`MediaMetadata` (commit 5):**
Previously initialised directly from `CameraManager` at construction
time, which could produce stale or invalid data. The `fromCameraManager()`
factory now returns `null` if any required state is absent, letting
`WebRTCService.start()` fail early with a logged error.