### PR TITLE
Refactor/numeric type casts

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.aircraft.AircraftCommand
 import org.WenuLink.adapters.aircraft.ArmTransition
 import org.WenuLink.adapters.aircraft.ControlAuthorityType
-import org.WenuLink.adapters.aircraft.Coordinates3D
 import org.WenuLink.adapters.aircraft.DisarmCommand
 import org.WenuLink.adapters.aircraft.FlyingTransition
 import org.WenuLink.adapters.aircraft.LandTransition
@@ -14,7 +13,6 @@ import org.WenuLink.adapters.camera.CameraCommand
 import org.WenuLink.adapters.mission.LandAction
 import org.WenuLink.adapters.mission.MissionActionCommand
 import org.WenuLink.adapters.mission.MissionCommand
-import org.WenuLink.adapters.mission.RepositionAction
 import org.WenuLink.adapters.mission.ReturnAction
 import org.WenuLink.adapters.mission.StartWaypointMission
 import org.WenuLink.commands.ICommand

--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -31,7 +31,6 @@ sealed interface RequestCommand : ICommand<WenuLinkHandler> {
 }
 
 open class RequestTransition(open val transition: StateTransition) : RequestCommand {
-
     override fun validate(ctx: WenuLinkHandler): String? =
         ctx.aircraft.canDispatchTransition(transition)
 
@@ -48,7 +47,6 @@ open class RequestTransition(open val transition: StateTransition) : RequestComm
 
 data class RequestLand(val withLandingConfirmation: Boolean = true) :
     RequestTransition(LandTransition) {
-
     override suspend fun execute(ctx: WenuLinkHandler): String? {
         val transitionError = super.execute(ctx)
         if (transitionError != null) return transitionError

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -2,7 +2,6 @@ package org.WenuLink.adapters
 
 import io.getstream.log.taggedLogger
 import kotlin.coroutines.resume
-import kotlin.getValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.WenuLink.MainActivity

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
@@ -43,7 +43,7 @@ object MessageUtils {
     fun coordinateDJI2MAVLink(value: Double): Int = (10_000_000 * value).roundToInt()
 
     // deg E7 to float
-    fun coordinateMAVLink2DJI(value: Int): Double = value.toDouble() / 10_000_000.0
+    fun coordinateMAVLink2DJI(value: Int): Double = value / 10_000_000.0
 
     // meters to millimeters
     fun altitudeDJI2MAVLink(value: Float): Int = (value * 1_000).roundToInt()

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -128,7 +128,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     }
 
     suspend fun sensorChecks(timeout: Long = 10000L): Boolean {
-        val perSensorTime = (timeout.toFloat() / 3).roundToLong()
+        val perSensorTime = (timeout / 3f).roundToLong()
         logger.i { "Waiting sensors data" }
 
         if (!AsyncUtils.waitTimeout(100L, timeout, telemetry::isReadingSensors)) {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -1,7 +1,6 @@
 package org.WenuLink.adapters.aircraft
 
 import dji.common.remotecontroller.HardwareState.FlightModeSwitch
-import kotlin.Int
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 import org.WenuLink.adapters.MessageUtils

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -83,11 +83,11 @@ data class RCData(
 ) {
     private fun stickValue2Percent(value: Int): Int =
         // transform from DJI range [-660, 660] => [0, 100]
-        (((value + 660).toFloat() / 1320f) * 100).roundToInt()
+        (((value + 660) / 1320f) * 100).roundToInt()
 
     private fun stickValue2RcValue(value: Int): Int =
         // transform from DJI range [-660, 660] => [1000, 2000]
-        ((value.toFloat() / 660) * 500).roundToInt() + 1500
+        ((value / 660f) * 500).roundToInt() + 1500
 
     fun toMAVLink(): RCData = this.copy(
         throttleSetting = stickValue2Percent(this.throttleSetting),
@@ -173,14 +173,14 @@ object BatteryMapper {
                 UNKNOWN_INT
             },
             temperature = source.temperature
-                ?.let { (it * 100.0).toInt().toShort() }
+                ?.let { (it * 100).toInt().toShort() }
                 ?: UNKNOWN_SHORT,
             voltages = source.voltageCells ?: emptyList(),
             currentBattery = source.current
                 ?.let { (it * 10).toShort() }
                 ?: UNKNOWN_INT.toShort(),
             batteryRemaining = if (fullCharge != null && remaining != null) {
-                (remaining.toFloat() / fullCharge * 100f).toInt().toByte()
+                ((remaining * 100f) / fullCharge).toInt().toByte()
             } else {
                 UNKNOWN_INT.toByte()
             },

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraCapturer.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraCapturer.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.media.MediaFormat
 import io.getstream.log.taggedLogger
 import java.nio.ByteBuffer
-import kotlin.math.round
+import kotlin.math.roundToInt
 import org.WenuLink.sdk.CameraManager
 import org.WenuLink.webrtc.utils.videoBuffer2VideoFrame
 import org.webrtc.CapturerObserver
@@ -34,7 +34,7 @@ class CameraCapturer : VideoCapturer {
                     cameraName,
                     CameraManager.frameWidth,
                     CameraManager.frameHeight,
-                    round(CameraManager.frameRate).toInt()
+                    CameraManager.frameRate.roundToInt()
                 )
             }
         }

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
@@ -3,7 +3,6 @@ package org.WenuLink.adapters.camera
 import com.MAVLink.enums.CAMERA_CAP_FLAGS
 import com.MAVLink.enums.CAMERA_MODE
 import io.getstream.log.taggedLogger
-import kotlin.getValue
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -32,7 +32,6 @@ data class UploadMissionCommand(
     private val assembler: MissionAssembler,
     private val flightSpeed: Float = 5f
 ) : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = when {
         ctx.state.canCreateMission() -> null
         else -> "Upload not ready"
@@ -53,7 +52,6 @@ data class UploadMissionCommand(
 }
 
 data object StartWaypointMission : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = when {
         ctx.state.canCreateMission() -> "No mission found"
         ctx.state.isActive() -> "Already started"
@@ -76,7 +74,6 @@ data object StartWaypointMission : MissionCommand {
 }
 
 data object PauseWaypointMission : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = when {
         ctx.state.canPauseMission() -> null
         else -> "Not started"
@@ -97,7 +94,6 @@ data object PauseWaypointMission : MissionCommand {
 }
 
 data object ResumeWaypointMission : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = when {
         ctx.state.canResumeMission() -> null
         else -> "Already in execution"
@@ -118,7 +114,6 @@ data object ResumeWaypointMission : MissionCommand {
 }
 
 data object StopWaypointMission : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = when {
         !ctx.state.canCreateMission() -> null
         else -> "Nothing to stop"
@@ -139,7 +134,6 @@ data object StopWaypointMission : MissionCommand {
 }
 
 data object PauseActionCommand : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = when {
         !MissionActionManager.isRunning -> "Timeline not running"
         else -> null
@@ -154,7 +148,6 @@ data object PauseActionCommand : MissionCommand {
 }
 
 data object ResumeActionCommand : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = when {
         MissionActionManager.isRunning -> "Timeline already running"
         else -> null
@@ -169,7 +162,6 @@ data object ResumeActionCommand : MissionCommand {
 }
 
 interface MissionActionCommand : MissionCommand {
-
     override fun validate(ctx: MissionHandler): String? = if (MissionActionManager.isRunning) {
         "Busy"
     } else {
@@ -180,7 +172,6 @@ interface MissionActionCommand : MissionCommand {
 }
 
 data class DelayAction(val timeMillis: Long) : MissionActionCommand {
-
     companion object {
         fun fromParameters(
             param1: Float,
@@ -230,7 +221,6 @@ data class DelayAction(val timeMillis: Long) : MissionActionCommand {
 }
 
 open class ActionCommand(val action: MissionAction) : MissionActionCommand {
-
     override suspend fun execute(ctx: MissionHandler): String? =
         suspendCancellableCoroutine { cont ->
             MissionActionManager.clear()

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -30,7 +30,7 @@ sealed interface MissionCommand : ICommand<MissionHandler> {
 
 data class UploadMissionCommand(
     private val assembler: MissionAssembler,
-    private val flightSpeed: Float = 5.0f
+    private val flightSpeed: Float = 5f
 ) : MissionCommand {
 
     override fun validate(ctx: MissionHandler): String? = when {

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -76,7 +76,7 @@ class MissionHandler : CommandHandler<MissionHandler>() {
     }
 
     private val logger by taggedLogger(MissionHandler::class.java.simpleName)
-    var flightSpeed = 5.0f
+    var flightSpeed = 5f
         private set
     var state = MissionState()
         private set
@@ -196,7 +196,7 @@ class MissionHandler : CommandHandler<MissionHandler>() {
 
         // Delay (seconds)
         if (delay > 0) {
-            state.assembler.addActionToLast(DelayAction(delay.toLong() * 1000))
+            state.assembler.addActionToLast(DelayAction(delay * 1000L))
         }
 
         // Yaw

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
@@ -1,6 +1,5 @@
 package org.WenuLink.mavlink
 
-import com.MAVLink.MAVLinkPacket
 import com.MAVLink.Messages.MAVLinkMessage
 import com.MAVLink.Parser
 import com.MAVLink.enums.MAV_COMPONENT.MAV_COMP_ID_AUTOPILOT1

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -188,7 +188,7 @@ class CameraController(
         handler: WenuLinkHandler,
         cameraInfo: CameraMetadata
     ) {
-        val intervalMillis = (commandLongMsg.param2 * 1000).toLong() // milliseconds
+        val intervalMillis = commandLongMsg.param2.toLong() * 1000 // milliseconds
         val totalPhotos = commandLongMsg.param3.toInt()
         val initSequence = commandLongMsg.param4.toInt()
 
@@ -394,10 +394,10 @@ class CameraController(
             storage_id = 1
             storage_count = 1
             status = STORAGE_STATUS.STORAGE_STATUS_READY.toShort()
-            total_capacity = 4096F // MB
-            used_capacity = 0F // MB
-            read_speed = 0F // MB/s
-            write_speed = 0F // MB/s
+            total_capacity = 4096f // MB
+            used_capacity = 0f // MB
+            read_speed = 0f // MB/s
+            write_speed = 0f // MB/s
             type = STORAGE_TYPE.STORAGE_TYPE_MICROSD.toShort()
             name = "FakeSDCard".toByteArray()
             storage_usage = STORAGE_USAGE_FLAG.STORAGE_USAGE_FLAG_PHOTO.toShort()
@@ -422,7 +422,7 @@ class CameraController(
             image_interval = imageInterval
             recording_time_ms = videoTime
             // TODO: read true value
-            available_capacity = 4000F
+            available_capacity = 4000f
             image_count = 0
             camera_device_id = cameraInfo.id.toShort()
         }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -9,8 +9,6 @@ import com.MAVLink.enums.MAV_PROTOCOL_CAPABILITY
 import com.MAVLink.enums.MAV_RESULT
 import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.MessageUtils
-import org.WenuLink.adapters.RequestGoHome
-import org.WenuLink.adapters.RequestLand
 import org.WenuLink.adapters.RequestMissionAction
 import org.WenuLink.adapters.WenuLinkCommand
 import org.WenuLink.adapters.WenuLinkHandler
@@ -19,7 +17,6 @@ import org.WenuLink.adapters.aircraft.ArmCommand
 import org.WenuLink.adapters.aircraft.DisarmCommand
 import org.WenuLink.adapters.aircraft.TakeoffCommand
 import org.WenuLink.adapters.mission.DelayAction
-import org.WenuLink.adapters.mission.ReturnAction
 import org.WenuLink.adapters.mission.RotateAction
 import org.WenuLink.mavlink.MAVLinkClient
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
@@ -20,7 +20,6 @@ import com.MAVLink.enums.MAV_SYS_STATUS_SENSOR
 import com.MAVLink.enums.MAV_TYPE
 import com.MAVLink.enums.MAV_VTOL_STATE
 import com.MAVLink.minimal.msg_heartbeat
-import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 import org.WenuLink.adapters.MessageUtils
@@ -212,9 +211,9 @@ class ConnectionController(override val client: MAVLinkClient) : IController {
         // Mavlink: Current airspeed in m/s
         // DJI: unclear whether getState() returns airspeed or groundspeed
         msg.airspeed = sqrt(
-            telemetryData.velocityX.toDouble().pow(2.0) +
-                telemetryData.velocityY.toDouble().pow(2.0)
-        ).toFloat()
+            telemetryData.velocityX * telemetryData.velocityX +
+                telemetryData.velocityY * telemetryData.velocityY
+        )
         // Mavlink: Current ground speed in m/s. For now, just echoing airspeed.
         msg.groundspeed = msg.airspeed
         // yaw angle

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -31,7 +31,6 @@ import org.WenuLink.adapters.RequestMissionAction
 import org.WenuLink.adapters.RequestStartMission
 import org.WenuLink.adapters.WenuLinkCommand
 import org.WenuLink.adapters.WenuLinkHandler
-import org.WenuLink.adapters.aircraft.Coordinates3D
 import org.WenuLink.adapters.aircraft.TelemetryHandler
 import org.WenuLink.adapters.mission.MissionHandler
 import org.WenuLink.adapters.mission.MissionNode

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
@@ -200,7 +200,7 @@ class TelemetryController(override val client: MAVLinkClient) : IController {
                 1_000_000
             } // Hz to micro seconds if must start
             else {
-                ((1.0 / timeInterval.toFloat()) * 1_000_000).roundToInt()
+                ((1.0 / timeInterval) * 1_000_000).roundToInt()
             }
         }
 

--- a/app/src/main/java/org/WenuLink/parameters/DJIParameters.kt
+++ b/app/src/main/java/org/WenuLink/parameters/DJIParameters.kt
@@ -239,7 +239,6 @@ class DJIYawModeControlModeParameter(
  */
 
 class DJIParametersProvider(private val fc: FlightController) : ParameterProvider {
-
     override fun provide(): List<ParameterSpec> = listOf(
         DJIBooleanParameter(
             "DJI_SPIN_ENABLED",

--- a/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
@@ -12,7 +12,6 @@ import dji.sdk.codec.DJICodecManager
 import io.getstream.log.taggedLogger
 import java.nio.ByteBuffer
 import kotlin.coroutines.resume
-import kotlin.getValue
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.AsyncUtils
 

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -8,7 +8,6 @@ import dji.common.model.LocationCoordinate2D
 import dji.common.util.CommonCallbacks
 import dji.sdk.flightcontroller.FlightController
 import io.getstream.log.taggedLogger
-import kotlin.getValue
 import org.WenuLink.adapters.aircraft.Coordinates3D
 import org.WenuLink.adapters.aircraft.IMUState as AppIMUState
 import org.WenuLink.adapters.aircraft.SensorState as AppSensorState

--- a/app/src/main/java/org/WenuLink/sdk/SimManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SimManager.kt
@@ -75,7 +75,7 @@ object SimManager {
         }
 
         // compute velocities
-        val dT = (data.timestamp - previousData.timestamp).toFloat() / 1000f // to seconds
+        val dT = (data.timestamp - previousData.timestamp) / 1000f // to seconds
         return data.copy(
             flightTime = (landStamp - takeOffStamp).toInt(),
             velocityX = (data.positionX - previousData.positionX) / dT,
@@ -87,7 +87,7 @@ object SimManager {
     fun run(
         lat: Double = -8.066478642777481,
         long: Double = -34.98744367551871,
-        alt: Float = 24.0f,
+        alt: Float = 24f,
         updateFrequency: Int = 10,
         satelliteCount: Int = 8,
         onResult: (String?) -> Unit


### PR DESCRIPTION
I noticed some redundant type conversions during my last review.
Kotlin allows implicit widening through operator overloading `Int / Float = Float`, I hope this makes some expressions easier to read.
No changes in behaviour