### PR TITLE
feature: fix takeoff not using the correct altitude

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -90,12 +90,13 @@ data class RequestTakeoff(
                     cont.resume(error)
                     return@dispatchCommand
                 }
+
+                val coordinates = ctx.aircraft.currentCoordinates
+                    ?: return@dispatchCommand cont.resume("No aircraft position available")
+
                 ctx.dispatchCommand(
                     WenuLinkCommand.Mission(
-                        RepositionAction(
-                            ctx.aircraft.getCurrentCoordinates()!!.copy(alt = altitude),
-                            speed
-                        )
+                        RepositionAction(coordinates.copy(alt = altitude), speed)
                     ),
                     cont::resume
                 )

--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -9,10 +9,13 @@ import org.WenuLink.adapters.aircraft.DisarmCommand
 import org.WenuLink.adapters.aircraft.FlyingTransition
 import org.WenuLink.adapters.aircraft.LandTransition
 import org.WenuLink.adapters.aircraft.StateTransition
+import org.WenuLink.adapters.aircraft.TakeoffCommand
+import org.WenuLink.adapters.aircraft.TakeoffTransition
 import org.WenuLink.adapters.camera.CameraCommand
 import org.WenuLink.adapters.mission.LandAction
 import org.WenuLink.adapters.mission.MissionActionCommand
 import org.WenuLink.adapters.mission.MissionCommand
+import org.WenuLink.adapters.mission.RepositionAction
 import org.WenuLink.adapters.mission.ReturnAction
 import org.WenuLink.adapters.mission.StartWaypointMission
 import org.WenuLink.commands.ICommand
@@ -55,14 +58,47 @@ data class RequestLand(val withLandingConfirmation: Boolean = true) :
 
         return suspendCancellableCoroutine { cont ->
             ctx.dispatchCommand(WenuLinkCommand.Mission(LandAction(true))) { error ->
-                if (error == null) {
-                    ctx.dispatchCommand(
-                        WenuLinkCommand.Aircraft(DisarmCommand()),
-                        cont::resume
-                    )
-                } else {
+                if (error != null) {
                     cont.resume(error)
+                    return@dispatchCommand
                 }
+                ctx.dispatchCommand(
+                    WenuLinkCommand.Aircraft(DisarmCommand()),
+                    cont::resume
+                )
+            }
+
+            cont.invokeOnCancellation { ctx.manualControl() }
+        }
+    }
+}
+
+data class RequestTakeoff(
+    val altitude: Float = 2f,
+    val speed: Float = 2f,
+    val timeout: Long = 15_000L
+) : RequestTransition(TakeoffTransition) {
+    override suspend fun execute(ctx: WenuLinkHandler): String? {
+        val transitionError = super.execute(ctx)
+        if (transitionError != null) return transitionError
+
+        ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
+
+        return suspendCancellableCoroutine { cont ->
+            ctx.dispatchCommand(WenuLinkCommand.Aircraft(TakeoffCommand(timeout))) { error ->
+                if (error != null) {
+                    cont.resume(error)
+                    return@dispatchCommand
+                }
+                ctx.dispatchCommand(
+                    WenuLinkCommand.Mission(
+                        RepositionAction(
+                            ctx.aircraft.getCurrentCoordinates()!!.copy(alt = altitude),
+                            speed
+                        )
+                    ),
+                    cont::resume
+                )
             }
 
             cont.invokeOnCancellation {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
@@ -69,7 +69,7 @@ data class DisarmCommand(val timeout: Long = 5000L) : AircraftCommand {
     override suspend fun onStop(ctx: AircraftHandler) { } // silently omit
 }
 
-data class TakeoffCommand(val initialAltitude: Float = 2f) : AircraftCommand {
+data class TakeoffCommand(val timeout: Long = 15_000L) : AircraftCommand {
     override fun validate(ctx: AircraftHandler): String? =
         ctx.canDispatchTransition(TakeoffTransition)
 
@@ -84,7 +84,7 @@ data class TakeoffCommand(val initialAltitude: Float = 2f) : AircraftCommand {
             return "Unable to takeoff"
         }
 
-        return ctx.goToAltitude(initialAltitude)
+        return null
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
@@ -76,7 +76,7 @@ data class TakeoffCommand(val initialAltitude: Float = 2f) : AircraftCommand {
     override suspend fun execute(ctx: AircraftHandler): String? {
         // TODO: check if compatible with CancellableCoroutine
         ctx.dispatchTransition(TakeoffTransition)
-        ctx.takeOff() // ctx.takeOff(initialAltitude)
+        ctx.takeOff()
         val isFlying = ctx.awaitFlightState(true)
 
         if (!isFlying) {
@@ -84,7 +84,7 @@ data class TakeoffCommand(val initialAltitude: Float = 2f) : AircraftCommand {
             return "Unable to takeoff"
         }
 
-        return null
+        return ctx.goToAltitude(initialAltitude)
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -1,14 +1,19 @@
 package org.WenuLink.adapters.aircraft
 
+import dji.common.model.LocationCoordinate2D
+import dji.sdk.mission.timeline.actions.GoToAction
 import io.getstream.log.taggedLogger
+import kotlin.coroutines.resume
 import kotlin.math.roundToLong
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.commands.CommandHandler
 import org.WenuLink.parameters.ArduPilotParametersProvider
 import org.WenuLink.parameters.DJIParametersProvider
 import org.WenuLink.parameters.ParameterRegistry
 import org.WenuLink.sdk.FCManager
+import org.WenuLink.sdk.MissionActionManager
 
 class AircraftHandler : CommandHandler<AircraftHandler>() {
     companion object {
@@ -270,6 +275,42 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     fun takeOff() {
         logger.d { "Aircraft taking off" }
         FCManager.startTakeoff()
+    }
+
+    suspend fun goToAltitude(altitude: Float, speed: Float = 2f): String? {
+        val location = FCManager.fcInstance?.state?.aircraftLocation
+            ?: return "No aircraft location"
+
+        return suspendCancellableCoroutine { cont ->
+            MissionActionManager.clear() // ok since takeoff happens before any mission
+
+            val action = GoToAction(
+                LocationCoordinate2D(location.latitude, location.longitude),
+                altitude
+            )
+                .apply { flightSpeed = speed }
+
+            val error = MissionActionManager.schedule(action)
+            if (error != null) {
+                cont.resume("GoTo failed: ${error.description}")
+                return@suspendCancellableCoroutine
+            }
+
+            val key = MissionActionManager.onFinish(GoToAction::class) {
+                cont.resume(null)
+            }
+
+            MissionActionManager.startListener { errorMsg ->
+                cont.resume("GoTo error: $errorMsg")
+            }
+
+            MissionActionManager.start()
+
+            cont.invokeOnCancellation {
+                MissionActionManager.removeCallback(key)
+                MissionActionManager.stop()
+            }
+        }
     }
 
     suspend fun awaitFlightState(takingOff: Boolean): Boolean {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -277,42 +277,6 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         FCManager.startTakeoff()
     }
 
-    suspend fun goToAltitude(altitude: Float, speed: Float = 2f): String? {
-        val location = FCManager.fcInstance?.state?.aircraftLocation
-            ?: return "No aircraft location"
-
-        return suspendCancellableCoroutine { cont ->
-            MissionActionManager.clear() // ok since takeoff happens before any mission
-
-            val action = GoToAction(
-                LocationCoordinate2D(location.latitude, location.longitude),
-                altitude
-            )
-                .apply { flightSpeed = speed }
-
-            val error = MissionActionManager.schedule(action)
-            if (error != null) {
-                cont.resume("GoTo failed: ${error.description}")
-                return@suspendCancellableCoroutine
-            }
-
-            val key = MissionActionManager.onFinish(GoToAction::class) {
-                cont.resume(null)
-            }
-
-            MissionActionManager.startListener { errorMsg ->
-                cont.resume("GoTo error: $errorMsg")
-            }
-
-            MissionActionManager.start()
-
-            cont.invokeOnCancellation {
-                MissionActionManager.removeCallback(key)
-                MissionActionManager.stop()
-            }
-        }
-    }
-
     suspend fun awaitFlightState(takingOff: Boolean): Boolean {
         logger.d { "Waiting for ${if (takingOff) "taking off" else "touching ground"}" }
         fun flyingMatchesTarget(): Boolean = takingOff == state.isFlying()

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -1,19 +1,14 @@
 package org.WenuLink.adapters.aircraft
 
-import dji.common.model.LocationCoordinate2D
-import dji.sdk.mission.timeline.actions.GoToAction
 import io.getstream.log.taggedLogger
-import kotlin.coroutines.resume
 import kotlin.math.roundToLong
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.commands.CommandHandler
 import org.WenuLink.parameters.ArduPilotParametersProvider
 import org.WenuLink.parameters.DJIParametersProvider
 import org.WenuLink.parameters.ParameterRegistry
 import org.WenuLink.sdk.FCManager
-import org.WenuLink.sdk.MissionActionManager
 
 class AircraftHandler : CommandHandler<AircraftHandler>() {
     companion object {
@@ -36,6 +31,10 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     var sensorsHealthy = false
         private set
     val telemetry = TelemetryHandler.getInstance()
+    val currentCoordinates: Coordinates3D?
+        get() = telemetry.getData()?.let {
+            Coordinates3D(it.latitude, it.longitude, it.relativeAltitude)
+        }
     var isPowerOff = true
     val parameters by lazy {
         ParameterRegistry(
@@ -256,20 +255,6 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         }
 
         return motorsUpdated
-    }
-
-    fun getCurrentCoordinates(): Coordinates3D? {
-        logger.d { "getCurrentCoordinates" }
-
-        val location = FCManager.fcInstance?.state?.aircraftLocation ?: return null
-        val takeoffAltitude = FCManager.fcInstance?.state?.takeoffLocationAltitude
-
-        logger.d {
-            "getCurrentCoordinates: currentAltitude: ${location.altitude}, " +
-                "takeoffAltitude: $takeoffAltitude"
-        }
-
-        return Coordinates3D(location.longitude, location.latitude, location.altitude)
     }
 
     fun takeOff() {

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -261,12 +261,11 @@ data class RepositionAction(private val target: Coordinates3D, private val speed
     companion object {
         fun fromCommandInt(commandIntMsg: msg_command_int): RepositionAction {
             // DO_REPOSITION
-            val targetCoordinates =
-                MessageUtils.xyzMAVLink2Coordinates(
-                    commandIntMsg.x,
-                    commandIntMsg.y,
-                    commandIntMsg.z
-                )
+            val targetCoordinates = MessageUtils.xyzMAVLink2Coordinates(
+                commandIntMsg.x,
+                commandIntMsg.y,
+                commandIntMsg.z
+            )
             val flightSpeed = if (commandIntMsg.param1 == -1f) 1f else commandIntMsg.param1
 
             return RepositionAction(targetCoordinates, flightSpeed)

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -151,7 +151,10 @@ class CommandController(override var client: MAVLinkClient) : IController {
 
     fun processTakeoff(commandMsg: msg_command_long, handler: WenuLinkHandler) {
         logger.d { "processTakeoff: $commandMsg" }
-        handler.dispatchCommand(WenuLinkCommand.Aircraft(TakeoffCommand())) { error ->
+        handler.dispatchCommand(
+            // TODO: also handle param4 (yaw), param5 (lat), and param6 (long)
+            WenuLinkCommand.Aircraft(TakeoffCommand(commandMsg.param7))
+        ) { error ->
             logger.d { "processTakeoff: $error" }
         }
         sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -10,12 +10,12 @@ import com.MAVLink.enums.MAV_RESULT
 import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.MessageUtils
 import org.WenuLink.adapters.RequestMissionAction
+import org.WenuLink.adapters.RequestTakeoff
 import org.WenuLink.adapters.WenuLinkCommand
 import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.adapters.aircraft.ArduCopterFlightMode
 import org.WenuLink.adapters.aircraft.ArmCommand
 import org.WenuLink.adapters.aircraft.DisarmCommand
-import org.WenuLink.adapters.aircraft.TakeoffCommand
 import org.WenuLink.adapters.mission.DelayAction
 import org.WenuLink.adapters.mission.RotateAction
 import org.WenuLink.mavlink.MAVLinkClient
@@ -151,10 +151,7 @@ class CommandController(override var client: MAVLinkClient) : IController {
 
     fun processTakeoff(commandMsg: msg_command_long, handler: WenuLinkHandler) {
         logger.d { "processTakeoff: $commandMsg" }
-        handler.dispatchCommand(
-            // TODO: also handle param4 (yaw), param5 (lat), and param6 (long)
-            WenuLinkCommand.Aircraft(TakeoffCommand(commandMsg.param7))
-        ) { error ->
+        handler.dispatchCommand(WenuLinkCommand.Request(RequestTakeoff())) { error ->
             logger.d { "processTakeoff: $error" }
         }
         sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)


### PR DESCRIPTION
Closes #36 

### `CommandController`:
Passes `commandMsg.param7` (altitude) to `TakeoffCommand`. Other values might follow later

### `AircraftCommand`:
Calls `AircraftHandler.goToAltitude(initialAltitude)` after successful takeoff

### `AircraftHandler`:
Adds a `goToAltitude(altitude, speed)` method called after `takeOff()` and `isFlying` is established.