### PR TITLE
Fix: Replace unbounded waitReady with waitTimeout in AircraftHandler

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -275,19 +275,18 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return flyingStateUpdated
     }
 
-    suspend fun waitAndConfirmLanding(timeout: Long = 30_000L) {
+    suspend fun waitAndConfirmLanding() {
         // https://developer.dji.com/api-reference/android-api/Components/FlightController/DJIFlightController.html#djiflightcontroller_confirmlanding_inline
         logger.d { "\tWaiting altitude of 0.3m" }
-        val confirmationNeeded = AsyncUtils.waitTimeout(
-            timeout,
-            100L,
-            FCManager::needLandingConfirmation
-        )
+        AsyncUtils.waitReady(100L) {
+            FCManager.needLandingConfirmation() ||
+                FCManager.getAltitude() < 0.5f
+        }
 
-        if (!confirmationNeeded) logger.w { "Landing confirmation timeout, attempting anyway" }
-
-        FCManager.confirmLanding {
-            logger.d { "\tLanding confirm" }
+        if (FCManager.needLandingConfirmation()) {
+            FCManager.confirmLanding { logger.d { "\tLanding confirmed" } }
+        } else {
+            logger.w { "Landing confirmation skipped: aircraft already on ground" }
         }
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -262,20 +262,20 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         FCManager.startTakeoff()
     }
 
-    suspend fun awaitFlightState(takingOff: Boolean): Boolean {
+    suspend fun waitFlightState(takingOff: Boolean, timeout: Long): Boolean {
         logger.d { "Waiting for ${if (takingOff) "taking off" else "touching ground"}" }
-        fun flyingMatchesTarget(): Boolean = takingOff == state.isFlying()
-        AsyncUtils.waitReady(100L, ::flyingMatchesTarget)
 
-        if (takingOff && state.isFlying()) {
-            logger.d { "Aircraft flying" }
+        val flyingStateUpdated = AsyncUtils.waitTimeout(100L, timeout) {
+            takingOff == state.isFlying()
         }
 
-        if (!takingOff && !state.isFlying()) {
-            logger.d { "Aircraft on the ground" }
+        if (flyingStateUpdated) {
+            logger.i { if (takingOff) "Aircraft flying" else "Aircraft on the ground" }
+        } else {
+            logger.w { "Timeout: ${if (takingOff) "takeoff" else "landing"} state not reached" }
         }
 
-        return flyingMatchesTarget()
+        return flyingStateUpdated
     }
 
     suspend fun waitAndConfirmLanding() {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -244,14 +244,12 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     }
 
     suspend fun waitArmTransition(mustArm: Boolean, timeout: Long): Boolean {
-        fun motorsMatchTarget(): Boolean = mustArm == state.isArmed()
-
-        val motorsUpdated = AsyncUtils.waitTimeout(timeout = timeout, isReady = ::motorsMatchTarget)
+        val motorsUpdated = AsyncUtils.waitTimeout(timeout = timeout) { mustArm == state.isArmed() }
 
         if (motorsUpdated) {
-            logger.i { "Aircraft armed" }
+            logger.i { if (mustArm) "Aircraft armed" else "Aircraft in standby" }
         } else {
-            logger.i { "Aircraft in standby" }
+            logger.w { "Timeout: ${if (mustArm) "armed" else "disarmed"} state not reached" }
         }
 
         return motorsUpdated

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -124,11 +124,10 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         enforceModeConsistency()
     }
 
-    suspend fun loadParameters(): Boolean {
+    suspend fun loadParameters(timeout: Long = 5000L): Boolean {
         logger.i { "Waiting for parameters" }
         parameters.load()
-        AsyncUtils.waitReady(1000L, parameters::isLoaded)
-        return parameters.isLoaded()
+        return AsyncUtils.waitTimeout(timeout, 1000L, parameters::isLoaded)
     }
 
     suspend fun sensorChecks(timeout: Long = 10000L): Boolean {
@@ -206,7 +205,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         sensorsHealthy = false
         logger.d { "Aircraft booting..." }
 
-        if (!loadParameters()) return "No parameters"
+        if (!loadParameters(timeout)) return "No parameters"
         logger.d { "\tLoading parameters: OK" }
 
         if (!startTelemetry(timeout)) return "No telemetry"
@@ -276,10 +275,16 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return flyingStateUpdated
     }
 
-    suspend fun waitAndConfirmLanding() {
+    suspend fun waitAndConfirmLanding(timeout: Long = 30_000L) {
         // https://developer.dji.com/api-reference/android-api/Components/FlightController/DJIFlightController.html#djiflightcontroller_confirmlanding_inline
         logger.d { "\tWaiting altitude of 0.3m" }
-        AsyncUtils.waitReady(100L, FCManager::needLandingConfirmation)
+        val confirmationNeeded = AsyncUtils.waitTimeout(
+            timeout,
+            100L,
+            FCManager::needLandingConfirmation
+        )
+
+        if (!confirmationNeeded) logger.w { "Landing confirmation timeout, attempting anyway" }
 
         FCManager.confirmLanding {
             logger.d { "\tLanding confirm" }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -278,15 +278,17 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     suspend fun waitAndConfirmLanding() {
         // https://developer.dji.com/api-reference/android-api/Components/FlightController/DJIFlightController.html#djiflightcontroller_confirmlanding_inline
         logger.d { "\tWaiting altitude of 0.3m" }
-        AsyncUtils.waitReady(100L) {
-            FCManager.needLandingConfirmation() ||
-                FCManager.getAltitude() < 0.5f
-        }
+        AsyncUtils.waitReady(100L) { FCManager.getAltitude() < 0.5f }
+        val confirmationNeeded = AsyncUtils.waitTimeout(
+            100L,
+            5000L,
+            FCManager::needLandingConfirmation
+        )
 
-        if (FCManager.needLandingConfirmation()) {
+        if (confirmationNeeded) {
             FCManager.confirmLanding { logger.d { "\tLanding confirmed" } }
         } else {
-            logger.w { "Landing confirmation skipped: aircraft already on ground" }
+            logger.w { "Landing confirmation timeout" }
         }
     }
 }

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -137,7 +137,9 @@ object FCManager {
 
     fun isFlying(): Boolean = fcInstance?.state?.isFlying == true
 
-    fun needLandingConfirmation() = fcInstance?.state?.isLandingConfirmationNeeded == true
+    fun needLandingConfirmation(): Boolean = fcInstance?.state?.isLandingConfirmationNeeded == true
+
+    fun getAltitude(): Float = fcInstance?.state?.aircraftLocation?.altitude ?: Float.MAX_VALUE
 
     fun startTakeoff() = fcInstance?.startTakeoff { }
 


### PR DESCRIPTION
`awaitFlightState`, `loadParameters`, and `waitAndConfirmLanding` previously used `AsyncUtils.waitReady`, which blocks indefinitely if the expected condition is never met. A stuck takeoff, failed parameter load, or missed landing confirmation threshold would hang the respective command permanently with no way to recover.
All three now use `waitTimeout` with explicit timeouts:

- `awaitFlightState`: 15s default, propagated from `TakeoffCommand`
- `loadParameters`: timeout propagated from `boot()`, consistent with other boot steps
- `waitAndConfirmLanding`: 30s default; on timeout, `confirmLanding` is still attempted since the drone is likely near the ground
