### PR TITLE
Replace String? success/failure pattern with CommandResult

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -18,7 +18,9 @@ import org.WenuLink.adapters.mission.MissionCommand
 import org.WenuLink.adapters.mission.RepositionAction
 import org.WenuLink.adapters.mission.ReturnAction
 import org.WenuLink.adapters.mission.StartWaypointMission
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.ICommand
+import org.WenuLink.commands.UnitResult
 
 sealed interface WenuLinkCommand {
     data class Aircraft(val command: AircraftCommand) : WenuLinkCommand
@@ -28,38 +30,40 @@ sealed interface WenuLinkCommand {
 }
 
 sealed interface RequestCommand : ICommand<WenuLinkHandler> {
-    override fun validate(ctx: WenuLinkHandler): String?
-    override suspend fun execute(ctx: WenuLinkHandler): String?
+    override fun validate(ctx: WenuLinkHandler): UnitResult
+    override suspend fun execute(ctx: WenuLinkHandler): UnitResult
     override suspend fun onStop(ctx: WenuLinkHandler)
 }
 
 open class RequestTransition(open val transition: StateTransition) : RequestCommand {
-    override fun validate(ctx: WenuLinkHandler): String? =
+    override fun validate(ctx: WenuLinkHandler): UnitResult =
         ctx.aircraft.canDispatchTransition(transition)
 
-    override suspend fun execute(ctx: WenuLinkHandler): String? {
+    override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         val prevState = ctx.aircraft.state.copy()
         ctx.aircraft.dispatchTransition(transition)
-        return if (prevState == ctx.aircraft.state) "State not changed" else null
+        return if (prevState != ctx.aircraft.state) {
+            CommandResult.ok
+        } else {
+            CommandResult.error("State not changed")
+        }
     }
 
-    override suspend fun onStop(ctx: WenuLinkHandler) {
-        ctx.manualControl()
-    }
+    override suspend fun onStop(ctx: WenuLinkHandler) = ctx.manualControl()
 }
 
 data class RequestLand(val withLandingConfirmation: Boolean = true) :
     RequestTransition(LandTransition) {
-    override suspend fun execute(ctx: WenuLinkHandler): String? {
-        val transitionError = super.execute(ctx)
-        if (transitionError != null) return transitionError
+    override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
+        val transitionResult = super.execute(ctx)
+        if (transitionResult is CommandResult.Failure) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
 
         return suspendCancellableCoroutine { cont ->
-            ctx.dispatchCommand(WenuLinkCommand.Mission(LandAction(true))) { error ->
-                if (error != null) {
-                    cont.resume(error)
+            ctx.dispatchCommand(WenuLinkCommand.Mission(LandAction(true))) { result ->
+                if (result is CommandResult.Failure) {
+                    cont.resume(result)
                     return@dispatchCommand
                 }
                 ctx.dispatchCommand(
@@ -78,21 +82,23 @@ data class RequestTakeoff(
     val speed: Float = 2f,
     val timeout: Long = 15_000L
 ) : RequestTransition(TakeoffTransition) {
-    override suspend fun execute(ctx: WenuLinkHandler): String? {
-        val transitionError = super.execute(ctx)
-        if (transitionError != null) return transitionError
+    override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
+        val transitionResult = super.execute(ctx)
+        if (transitionResult is CommandResult.Failure) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
 
         return suspendCancellableCoroutine { cont ->
-            ctx.dispatchCommand(WenuLinkCommand.Aircraft(TakeoffCommand(timeout))) { error ->
-                if (error != null) {
-                    cont.resume(error)
+            ctx.dispatchCommand(WenuLinkCommand.Aircraft(TakeoffCommand(timeout))) { result ->
+                if (result is CommandResult.Failure) {
+                    cont.resume(result)
                     return@dispatchCommand
                 }
 
                 val coordinates = ctx.aircraft.currentCoordinates
-                    ?: return@dispatchCommand cont.resume("No aircraft position available")
+                    ?: return@dispatchCommand cont.resume(
+                        CommandResult.error("No aircraft position available")
+                    )
 
                 ctx.dispatchCommand(
                     WenuLinkCommand.Mission(
@@ -120,9 +126,9 @@ data class RequestStartMission(
         ArmTransition
     }
 ) {
-    override suspend fun execute(ctx: WenuLinkHandler): String? {
-        val transitionError = super.execute(ctx)
-        if (transitionError != null) return transitionError
+    override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
+        val transitionResult = super.execute(ctx)
+        if (transitionResult is CommandResult.Failure) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
 
@@ -144,9 +150,9 @@ data class RequestStartMission(
 
 open class RequestMissionAction(private val action: MissionActionCommand) :
     RequestTransition(FlyingTransition) {
-    override suspend fun execute(ctx: WenuLinkHandler): String? {
-        val transitionError = super.execute(ctx)
-        if (transitionError != null) return transitionError
+    override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
+        val transitionResult = super.execute(ctx)
+        if (transitionResult is CommandResult.Failure) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
 

--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -56,13 +56,13 @@ data class RequestLand(val withLandingConfirmation: Boolean = true) :
     RequestTransition(LandTransition) {
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         val transitionResult = super.execute(ctx)
-        if (transitionResult is CommandResult.Failure) return transitionResult
+        if (transitionResult.hasError) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
 
         return suspendCancellableCoroutine { cont ->
             ctx.dispatchCommand(WenuLinkCommand.Mission(LandAction(true))) { result ->
-                if (result is CommandResult.Failure) {
+                if (result.hasError) {
                     cont.resume(result)
                     return@dispatchCommand
                 }
@@ -84,13 +84,13 @@ data class RequestTakeoff(
 ) : RequestTransition(TakeoffTransition) {
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         val transitionResult = super.execute(ctx)
-        if (transitionResult is CommandResult.Failure) return transitionResult
+        if (transitionResult.hasError) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
 
         return suspendCancellableCoroutine { cont ->
             ctx.dispatchCommand(WenuLinkCommand.Aircraft(TakeoffCommand(timeout))) { result ->
-                if (result is CommandResult.Failure) {
+                if (result.hasError) {
                     cont.resume(result)
                     return@dispatchCommand
                 }
@@ -128,7 +128,7 @@ data class RequestStartMission(
 ) {
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         val transitionResult = super.execute(ctx)
-        if (transitionResult is CommandResult.Failure) return transitionResult
+        if (transitionResult.hasError) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
 
@@ -152,7 +152,7 @@ open class RequestMissionAction(private val action: MissionActionCommand) :
     RequestTransition(FlyingTransition) {
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         val transitionResult = super.execute(ctx)
-        if (transitionResult is CommandResult.Failure) return transitionResult
+        if (transitionResult.hasError) return transitionResult
 
         ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
 

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -157,7 +157,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         }
 
     suspend fun bootAircraft(): UnitResult {
-        val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10000L)))
+        val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10_000L)))
         if (bootResult.isOk) {
             manualControl()
             startTimestamp = System.currentTimeMillis()

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -25,7 +25,6 @@ import org.WenuLink.adapters.mission.ResumeActionCommand
 import org.WenuLink.adapters.mission.ResumeWaypointMission
 import org.WenuLink.adapters.mission.StopWaypointMission
 import org.WenuLink.commands.CommandHandler
-import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.UnitResult
 
 class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
@@ -159,7 +158,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
 
     suspend fun bootAircraft(): UnitResult {
         val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10000L)))
-        if (bootResult is CommandResult.Success) {
+        if (bootResult.isOk) {
             manualControl()
             startTimestamp = System.currentTimeMillis()
         }
@@ -184,8 +183,8 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         dispatchControlAuthority(ControlAuthorityType.REMOTE_CONTROLLER)
 
         val result = aircraft.requestMode(ArduCopterFlightMode.STABILIZE)
-        if (result is CommandResult.Failure) {
-            logger.w { "Manual control mode rejected: ${result.reason}" }
+        if (result.hasError) {
+            logger.w { "Manual control mode rejected: ${result.errorReason}" }
         }
     }
 
@@ -194,17 +193,17 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         when {
             controlAuthority.isWaypoint() ->
                 mission.dispatchCommand(PauseWaypointMission) { result ->
-                    if (result is CommandResult.Failure) {
+                    if (result.hasError) {
                         logger.i {
-                            "Unable to pause the mission at ${mission.state.currentSequence}: ${result.reason}"
+                            "Unable to pause the mission at ${mission.state.currentSequence}: ${result.errorReason}"
                         }
                     }
                 }
 
             controlAuthority.isCommand() ->
                 mission.dispatchCommand(PauseActionCommand) { result ->
-                    if (result is CommandResult.Failure) {
-                        logger.i { "Unable to pause the command: ${result.reason}" }
+                    if (result.hasError) {
+                        logger.i { "Unable to pause the command: ${result.errorReason}" }
                     }
                 }
         }
@@ -215,18 +214,18 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         when {
             controlAuthority.isWaypoint() ->
                 mission.dispatchCommand(ResumeWaypointMission) { result ->
-                    if (result is CommandResult.Failure) {
+                    if (result.hasError) {
                         logger.i {
-                            "Unable to resume the mission: ${result.reason}"
+                            "Unable to resume the mission: ${result.errorReason}"
                         }
                     }
                 }
 
             controlAuthority.isCommand() ->
                 mission.dispatchCommand(ResumeActionCommand) { result ->
-                    if (result is CommandResult.Failure) {
+                    if (result.hasError) {
                         logger.i {
-                            "Unable to resume the command: ${result.reason}"
+                            "Unable to resume the command: ${result.errorReason}"
                         }
                     }
                 }
@@ -239,9 +238,9 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
             controlAuthority.isWaypoint() -> mission.dispatchCommand(
                 StopWaypointMission
             ) { result ->
-                if (result is CommandResult.Failure) {
+                if (result.hasError) {
                     logger.i {
-                        "Unable to stop the mission: ${result.reason}"
+                        "Unable to stop the mission: ${result.errorReason}"
                     }
                 }
             }

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -25,6 +25,8 @@ import org.WenuLink.adapters.mission.ResumeActionCommand
 import org.WenuLink.adapters.mission.ResumeWaypointMission
 import org.WenuLink.adapters.mission.StopWaypointMission
 import org.WenuLink.commands.CommandHandler
+import org.WenuLink.commands.CommandResult
+import org.WenuLink.commands.UnitResult
 
 class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     companion object {
@@ -137,7 +139,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         }
     }
 
-    fun dispatchCommand(cmd: WenuLinkCommand, onResult: (String?) -> Unit = {}) {
+    fun dispatchCommand(cmd: WenuLinkCommand, onResult: (UnitResult) -> Unit = {}) {
         when (cmd) {
             is WenuLinkCommand.Aircraft -> aircraft.dispatchCommand(cmd.command, onResult)
             is WenuLinkCommand.Mission -> mission.dispatchCommand(cmd.command, onResult)
@@ -146,7 +148,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         }
     }
 
-    suspend fun dispatchAndAwait(cmd: WenuLinkCommand): String? =
+    suspend fun dispatchAndAwait(cmd: WenuLinkCommand): UnitResult =
         suspendCancellableCoroutine { cont ->
             dispatchCommand(cmd) { result ->
                 if (cont.isActive) {
@@ -155,13 +157,13 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
             }
         }
 
-    suspend fun bootAircraft(): String? {
-        val bootError = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10_000L)))
-        if (bootError == null) {
+    suspend fun bootAircraft(): UnitResult {
+        val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10_000L)))
+        if (bootResult.isOk) {
             manualControl()
             startTimestamp = System.currentTimeMillis()
         }
-        return bootError
+        return bootResult
     }
 
     fun setAuthority(authority: ControlAuthorityType): ControlAuthority {
@@ -181,28 +183,28 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     fun manualControl() {
         dispatchControlAuthority(ControlAuthorityType.REMOTE_CONTROLLER)
 
-        aircraft.requestMode(ArduCopterFlightMode.STABILIZE)
-            .onFailure {
-                logger.w { "Manual control mode rejected: ${it.message}" }
-            }
+        val result = aircraft.requestMode(ArduCopterFlightMode.STABILIZE)
+        if (result is CommandResult.Failure) {
+            logger.w { "Manual control mode rejected: ${result.reason}" }
+        }
     }
 
     fun missionPause() {
         logger.i { "Pause mission" }
         when {
             controlAuthority.isWaypoint() ->
-                mission.dispatchCommand(PauseWaypointMission) { error ->
-                    if (error != null) {
+                mission.dispatchCommand(PauseWaypointMission) { result ->
+                    if (result is CommandResult.Failure) {
                         logger.i {
-                            "Unable to pause the mission at ${mission.state.currentSequence}: $error"
+                            "Unable to pause the mission at ${mission.state.currentSequence}: ${result.reason}"
                         }
                     }
                 }
 
             controlAuthority.isCommand() ->
-                mission.dispatchCommand(PauseActionCommand) { error ->
-                    if (error != null) {
-                        logger.i { "Unable to pause the command: $error" }
+                mission.dispatchCommand(PauseActionCommand) { result ->
+                    if (result is CommandResult.Failure) {
+                        logger.i { "Unable to pause the command: ${result.reason}" }
                     }
                 }
         }
@@ -212,13 +214,21 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         logger.i { "Resume mission" }
         when {
             controlAuthority.isWaypoint() ->
-                mission.dispatchCommand(ResumeWaypointMission) { error ->
-                    if (error != null) logger.i { "Unable to resume the mission: $error" }
+                mission.dispatchCommand(ResumeWaypointMission) { result ->
+                    if (result is CommandResult.Failure) {
+                        logger.i {
+                            "Unable to resume the mission: ${result.reason}"
+                        }
+                    }
                 }
 
             controlAuthority.isCommand() ->
-                mission.dispatchCommand(ResumeActionCommand) { error ->
-                    if (error != null) logger.i { "Unable to resume the command: $error" }
+                mission.dispatchCommand(ResumeActionCommand) { result ->
+                    if (result is CommandResult.Failure) {
+                        logger.i {
+                            "Unable to resume the command: ${result.reason}"
+                        }
+                    }
                 }
         }
     }
@@ -226,8 +236,14 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     fun missionStop() {
         logger.d { "Stop mission" }
         when {
-            controlAuthority.isWaypoint() -> mission.dispatchCommand(StopWaypointMission) { error ->
-                if (error != null) logger.i { "Unable to stop the mission: $error" }
+            controlAuthority.isWaypoint() -> mission.dispatchCommand(
+                StopWaypointMission
+            ) { result ->
+                if (result is CommandResult.Failure) {
+                    logger.i {
+                        "Unable to stop the mission: ${result.reason}"
+                    }
+                }
             }
 
             controlAuthority.isCommand() -> mission.stopCommand()
@@ -247,7 +263,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         this.stopCommand()
     }
 
-    fun stopAndDispatch(command: RequestCommand, onResult: (String?) -> Unit = {}) {
+    fun stopAndDispatch(command: RequestCommand, onResult: (UnitResult) -> Unit = {}) {
         if (currentCommand == command) return
         missionStop()
         dispatchCommand(command, onResult)

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -25,6 +25,8 @@ import org.WenuLink.adapters.mission.ResumeActionCommand
 import org.WenuLink.adapters.mission.ResumeWaypointMission
 import org.WenuLink.adapters.mission.StopWaypointMission
 import org.WenuLink.commands.CommandHandler
+import org.WenuLink.commands.CommandResult
+import org.WenuLink.commands.UnitResult
 
 class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     companion object {
@@ -137,7 +139,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         }
     }
 
-    fun dispatchCommand(cmd: WenuLinkCommand, onResult: (String?) -> Unit = {}) {
+    fun dispatchCommand(cmd: WenuLinkCommand, onResult: (UnitResult) -> Unit = {}) {
         when (cmd) {
             is WenuLinkCommand.Aircraft -> aircraft.dispatchCommand(cmd.command, onResult)
             is WenuLinkCommand.Mission -> mission.dispatchCommand(cmd.command, onResult)
@@ -146,7 +148,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         }
     }
 
-    suspend fun dispatchAndAwait(cmd: WenuLinkCommand): String? =
+    suspend fun dispatchAndAwait(cmd: WenuLinkCommand): UnitResult =
         suspendCancellableCoroutine { cont ->
             dispatchCommand(cmd) { result ->
                 if (cont.isActive) {
@@ -155,13 +157,13 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
             }
         }
 
-    suspend fun bootAircraft(): String? {
-        val bootError = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10000L)))
-        if (bootError == null) {
+    suspend fun bootAircraft(): UnitResult {
+        val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10000L)))
+        if (bootResult is CommandResult.Success) {
             manualControl()
             startTimestamp = System.currentTimeMillis()
         }
-        return bootError
+        return bootResult
     }
 
     fun setAuthority(authority: ControlAuthorityType): ControlAuthority {
@@ -181,28 +183,28 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     fun manualControl() {
         dispatchControlAuthority(ControlAuthorityType.REMOTE_CONTROLLER)
 
-        aircraft.requestMode(ArduCopterFlightMode.STABILIZE)
-            .onFailure {
-                logger.w { "Manual control mode rejected: ${it.message}" }
-            }
+        val result = aircraft.requestMode(ArduCopterFlightMode.STABILIZE)
+        if (result is CommandResult.Failure) {
+            logger.w { "Manual control mode rejected: ${result.reason}" }
+        }
     }
 
     fun missionPause() {
         logger.i { "Pause mission" }
         when {
             controlAuthority.isWaypoint() ->
-                mission.dispatchCommand(PauseWaypointMission) { error ->
-                    if (error != null) {
+                mission.dispatchCommand(PauseWaypointMission) { result ->
+                    if (result is CommandResult.Failure) {
                         logger.i {
-                            "Unable to pause the mission at ${mission.state.currentSequence}: $error"
+                            "Unable to pause the mission at ${mission.state.currentSequence}: ${result.reason}"
                         }
                     }
                 }
 
             controlAuthority.isCommand() ->
-                mission.dispatchCommand(PauseActionCommand) { error ->
-                    if (error != null) {
-                        logger.i { "Unable to pause the command: $error" }
+                mission.dispatchCommand(PauseActionCommand) { result ->
+                    if (result is CommandResult.Failure) {
+                        logger.i { "Unable to pause the command: ${result.reason}" }
                     }
                 }
         }
@@ -212,13 +214,21 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         logger.i { "Resume mission" }
         when {
             controlAuthority.isWaypoint() ->
-                mission.dispatchCommand(ResumeWaypointMission) { error ->
-                    if (error != null) logger.i { "Unable to resume the mission: $error" }
+                mission.dispatchCommand(ResumeWaypointMission) { result ->
+                    if (result is CommandResult.Failure) {
+                        logger.i {
+                            "Unable to resume the mission: ${result.reason}"
+                        }
+                    }
                 }
 
             controlAuthority.isCommand() ->
-                mission.dispatchCommand(ResumeActionCommand) { error ->
-                    if (error != null) logger.i { "Unable to resume the command: $error" }
+                mission.dispatchCommand(ResumeActionCommand) { result ->
+                    if (result is CommandResult.Failure) {
+                        logger.i {
+                            "Unable to resume the command: ${result.reason}"
+                        }
+                    }
                 }
         }
     }
@@ -226,8 +236,14 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     fun missionStop() {
         logger.d { "Stop mission" }
         when {
-            controlAuthority.isWaypoint() -> mission.dispatchCommand(StopWaypointMission) { error ->
-                if (error != null) logger.i { "Unable to stop the mission: $error" }
+            controlAuthority.isWaypoint() -> mission.dispatchCommand(
+                StopWaypointMission
+            ) { result ->
+                if (result is CommandResult.Failure) {
+                    logger.i {
+                        "Unable to stop the mission: ${result.reason}"
+                    }
+                }
             }
 
             controlAuthority.isCommand() -> mission.stopCommand()
@@ -247,7 +263,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         this.stopCommand()
     }
 
-    fun stopAndDispatch(command: RequestCommand, onResult: (String?) -> Unit = {}) {
+    fun stopAndDispatch(command: RequestCommand, onResult: (UnitResult) -> Unit = {}) {
         if (currentCommand == command) return
         missionStop()
         dispatchCommand(command, onResult)

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -25,7 +25,6 @@ import org.WenuLink.adapters.mission.ResumeActionCommand
 import org.WenuLink.adapters.mission.ResumeWaypointMission
 import org.WenuLink.adapters.mission.StopWaypointMission
 import org.WenuLink.commands.CommandHandler
-import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.UnitResult
 
 class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
@@ -158,8 +157,8 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         }
 
     suspend fun bootAircraft(): UnitResult {
-        val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10_000L)))
-        if (bootResult.isOk) {
+        val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10000L)))
+        if (bootResult is CommandResult.Success) {
             manualControl()
             startTimestamp = System.currentTimeMillis()
         }
@@ -184,8 +183,8 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         dispatchControlAuthority(ControlAuthorityType.REMOTE_CONTROLLER)
 
         val result = aircraft.requestMode(ArduCopterFlightMode.STABILIZE)
-        if (result is CommandResult.Failure) {
-            logger.w { "Manual control mode rejected: ${result.reason}" }
+        if (result.hasError) {
+            logger.w { "Manual control mode rejected: ${result.errorReason}" }
         }
     }
 
@@ -194,17 +193,17 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         when {
             controlAuthority.isWaypoint() ->
                 mission.dispatchCommand(PauseWaypointMission) { result ->
-                    if (result is CommandResult.Failure) {
+                    if (result.hasError) {
                         logger.i {
-                            "Unable to pause the mission at ${mission.state.currentSequence}: ${result.reason}"
+                            "Unable to pause the mission at ${mission.state.currentSequence}: ${result.errorReason}"
                         }
                     }
                 }
 
             controlAuthority.isCommand() ->
                 mission.dispatchCommand(PauseActionCommand) { result ->
-                    if (result is CommandResult.Failure) {
-                        logger.i { "Unable to pause the command: ${result.reason}" }
+                    if (result.hasError) {
+                        logger.i { "Unable to pause the command: ${result.errorReason}" }
                     }
                 }
         }
@@ -215,18 +214,18 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         when {
             controlAuthority.isWaypoint() ->
                 mission.dispatchCommand(ResumeWaypointMission) { result ->
-                    if (result is CommandResult.Failure) {
+                    if (result.hasError) {
                         logger.i {
-                            "Unable to resume the mission: ${result.reason}"
+                            "Unable to resume the mission: ${result.errorReason}"
                         }
                     }
                 }
 
             controlAuthority.isCommand() ->
                 mission.dispatchCommand(ResumeActionCommand) { result ->
-                    if (result is CommandResult.Failure) {
+                    if (result.hasError) {
                         logger.i {
-                            "Unable to resume the command: ${result.reason}"
+                            "Unable to resume the command: ${result.errorReason}"
                         }
                     }
                 }
@@ -239,9 +238,9 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
             controlAuthority.isWaypoint() -> mission.dispatchCommand(
                 StopWaypointMission
             ) { result ->
-                if (result is CommandResult.Failure) {
+                if (result.hasError) {
                     logger.i {
-                        "Unable to stop the mission: ${result.reason}"
+                        "Unable to stop the mission: ${result.errorReason}"
                     }
                 }
             }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
@@ -1,23 +1,27 @@
 package org.WenuLink.adapters.aircraft
 
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.ICommand
+import org.WenuLink.commands.UnitResult
 
 sealed interface AircraftCommand : ICommand<AircraftHandler> {
-    override fun validate(ctx: AircraftHandler): String?
-    override suspend fun execute(ctx: AircraftHandler): String?
+    override fun validate(ctx: AircraftHandler): UnitResult
+    override suspend fun execute(ctx: AircraftHandler): UnitResult
     override suspend fun onStop(ctx: AircraftHandler)
 }
 
 data class BootCommand(val timeout: Long = 5000L) : AircraftCommand {
-    override fun validate(ctx: AircraftHandler): String? {
-        if (!ctx.isPowerOff) return "Already booted"
-        return ctx.canDispatchTransition(BootTransition)
+    override fun validate(ctx: AircraftHandler): UnitResult = when {
+        !ctx.isPowerOff -> CommandResult.error("Already booted")
+        else -> ctx.canDispatchTransition(BootTransition)
     }
 
-    override suspend fun execute(ctx: AircraftHandler): String? {
+    override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
         ctx.dispatchTransition(BootTransition)
         return ctx.boot(timeout)
+            ?.let { CommandResult.error(it) }
+            ?: CommandResult.ok
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {
@@ -26,26 +30,27 @@ data class BootCommand(val timeout: Long = 5000L) : AircraftCommand {
 }
 
 data class ArmCommand(val timeout: Long = 5000L) : AircraftCommand {
-    override fun validate(ctx: AircraftHandler): String? {
-        if (!ctx.sensorsHealthy) return "Sensors failing"
-        return ctx.canDispatchTransition(ArmTransition)
+    override fun validate(ctx: AircraftHandler): UnitResult = when {
+        !ctx.sensorsHealthy -> CommandResult.error("Sensors failing")
+        else -> ctx.canDispatchTransition(ArmTransition)
     }
 
-    override suspend fun execute(ctx: AircraftHandler): String? {
+    override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
         ctx.dispatchTransition(ArmTransition)
         // TODO: update according to each mode
         // https://ardupilot.org/copter/docs/arming_the_motors.html
-        val armed = if (ctx.state.flightMode == ArduCopterFlightMode.STABILIZE) {
+        if (ctx.state.flightMode == ArduCopterFlightMode.STABILIZE) {
             // Manual takeoff
             ctx.armMotors()
-            ctx.waitArmTransition(true, timeout)
+            if (!ctx.waitArmTransition(true, timeout)) {
+                return CommandResult.error("Unable to arm motors")
+            }
         } else {
-            // Automatic takeoff only must wait for state changes
-            true
+            // Automatic takeoff only. Must wait for state changes
         }
 
-        return if (armed) null else "Unable to arm motors"
+        return CommandResult.ok
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {
@@ -54,37 +59,37 @@ data class ArmCommand(val timeout: Long = 5000L) : AircraftCommand {
 }
 
 data class DisarmCommand(val timeout: Long = 5000L) : AircraftCommand {
-    override fun validate(ctx: AircraftHandler): String? =
+    override fun validate(ctx: AircraftHandler): UnitResult =
         ctx.canDispatchTransition(StandbyTransition)
 
-    override suspend fun execute(ctx: AircraftHandler): String? {
+    override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
         ctx.dispatchTransition(StandbyTransition)
         ctx.disarmMotors()
-        val disarmed = ctx.waitArmTransition(false, timeout)
-
-        return if (disarmed) null else "Unable to disarm motors"
+        return if (ctx.waitArmTransition(false, timeout)) {
+            CommandResult.ok
+        } else {
+            CommandResult.error("Unable to disarm motors")
+        }
     }
 
     override suspend fun onStop(ctx: AircraftHandler) { } // silently omit
 }
 
 data class TakeoffCommand(val timeout: Long = 15_000L) : AircraftCommand {
-    override fun validate(ctx: AircraftHandler): String? =
+    override fun validate(ctx: AircraftHandler): UnitResult =
         ctx.canDispatchTransition(TakeoffTransition)
 
-    override suspend fun execute(ctx: AircraftHandler): String? {
+    override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
         ctx.dispatchTransition(TakeoffTransition)
         ctx.takeOff()
-        val isFlying = ctx.awaitFlightState(true)
-
-        if (!isFlying) {
+        return if (ctx.waitFlightState(true, timeout)) {
+            CommandResult.ok
+        } else {
             ctx.dispatchCommand(DisarmCommand())
-            return "Unable to takeoff"
+            CommandResult.error("Unable to takeoff")
         }
-
-        return null
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {
@@ -93,16 +98,18 @@ data class TakeoffCommand(val timeout: Long = 15_000L) : AircraftCommand {
 }
 
 data class ShutdownCommand(val withTransitionCheck: Boolean = true) : AircraftCommand {
-    override fun validate(ctx: AircraftHandler): String? = when {
-        ctx.isPowerOff -> "Already power off"
-        !withTransitionCheck -> null
+    override fun validate(ctx: AircraftHandler): UnitResult = when {
+        ctx.isPowerOff -> CommandResult.error("Already power off")
+        !withTransitionCheck -> CommandResult.ok
         else -> ctx.canDispatchTransition(PowerOffTransition)
     }
 
-    override suspend fun execute(ctx: AircraftHandler): String? {
+    override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
         if (withTransitionCheck) ctx.dispatchTransition(PowerOffTransition)
         return ctx.shutdown()
+            ?.let { CommandResult.error(it) }
+            ?: CommandResult.ok
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -5,6 +5,8 @@ import kotlin.math.roundToLong
 import kotlinx.coroutines.CoroutineScope
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.commands.CommandHandler
+import org.WenuLink.commands.CommandResult
+import org.WenuLink.commands.UnitResult
 import org.WenuLink.parameters.ArduPilotParametersProvider
 import org.WenuLink.parameters.DJIParametersProvider
 import org.WenuLink.parameters.ParameterRegistry
@@ -47,12 +49,12 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         )
     }
 
-    fun requestMode(mode: ArduCopterFlightMode): Result<Unit> {
-        if (mode == state.flightMode) return Result.success(Unit)
+    fun requestMode(mode: ArduCopterFlightMode): UnitResult {
+        if (mode == state.flightMode) return CommandResult.ok
 
         if (!stateMachine.isModeAllowed(mode)) {
-            return Result.failure(
-                IllegalStateException("Mode $mode not allowed from ${state.flightMode}")
+            return CommandResult.error(
+                "Mode $mode not allowed from ${state.flightMode}"
             )
         }
 
@@ -60,7 +62,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
 
         stateMachine.updateFlightMode(mode)
 
-        return Result.success(Unit)
+        return CommandResult.ok
     }
 
     private fun enforceModeConsistency() {
@@ -82,9 +84,11 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         stateMachine.updateFlightMode(fallbackMode)
     }
 
-    fun canDispatchTransition(transition: StateTransition) = stateMachine.canDispatch(transition)
+    fun canDispatchTransition(transition: StateTransition): UnitResult =
+        stateMachine.canDispatch(transition)
 
-    fun dispatchTransition(transition: StateTransition) = stateMachine.dispatch(transition)
+    fun dispatchTransition(transition: StateTransition): AircraftState =
+        stateMachine.dispatch(transition)
 
     suspend fun syncState(sensorsInterval: Long = 1000L, homeInterval: Long = 5000L) {
         if (isPowerOff) return

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -5,6 +5,8 @@ import kotlin.math.roundToLong
 import kotlinx.coroutines.CoroutineScope
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.commands.CommandHandler
+import org.WenuLink.commands.CommandResult
+import org.WenuLink.commands.UnitResult
 import org.WenuLink.parameters.ArduPilotParametersProvider
 import org.WenuLink.parameters.DJIParametersProvider
 import org.WenuLink.parameters.ParameterRegistry
@@ -47,12 +49,12 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         )
     }
 
-    fun requestMode(mode: ArduCopterFlightMode): Result<Unit> {
-        if (mode == state.flightMode) return Result.success(Unit)
+    fun requestMode(mode: ArduCopterFlightMode): UnitResult {
+        if (mode == state.flightMode) return CommandResult.ok
 
         if (!stateMachine.isModeAllowed(mode)) {
-            return Result.failure(
-                IllegalStateException("Mode $mode not allowed from ${state.flightMode}")
+            return CommandResult.error(
+                "Mode $mode not allowed from ${state.flightMode}"
             )
         }
 
@@ -60,7 +62,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
 
         stateMachine.updateFlightMode(mode)
 
-        return Result.success(Unit)
+        return CommandResult.ok
     }
 
     private fun enforceModeConsistency() {
@@ -82,9 +84,11 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         stateMachine.updateFlightMode(fallbackMode)
     }
 
-    fun canDispatchTransition(transition: StateTransition): String? =
+    fun canDispatchTransition(transition: StateTransition): UnitResult =
         stateMachine.canDispatch(transition)
 
+    fun dispatchTransition(transition: StateTransition): AircraftState =
+        stateMachine.dispatch(transition)
     fun dispatchTransition(transition: StateTransition): AircraftState =
         stateMachine.dispatch(transition)
 

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
@@ -3,6 +3,8 @@ package org.WenuLink.adapters.aircraft
 import com.MAVLink.enums.MAV_LANDED_STATE
 import com.MAVLink.enums.MAV_MODE_FLAG
 import com.MAVLink.enums.MAV_STATE
+import org.WenuLink.commands.CommandResult
+import org.WenuLink.commands.UnitResult
 
 enum class ControlAuthorityType {
     NONE,
@@ -78,17 +80,17 @@ data class AircraftState(
 }
 
 sealed interface StateTransition {
-    fun canTransition(from: AircraftState): String?
+    fun canTransition(from: AircraftState): UnitResult
 
     fun reduce(from: AircraftState): AircraftState
 }
 
 object InitialTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
+    override fun canTransition(from: AircraftState): UnitResult = when {
         !(from.isBoot() || from.isPowerOff()) ->
-            "Cannot reset to initial from MAV_STATE=${from.mavlink}"
+            CommandResult.error("Cannot reset to initial from MAV_STATE=${from.mavlink}")
 
-        else -> null
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState =
@@ -96,9 +98,9 @@ object InitialTransition : StateTransition {
 }
 
 object BootTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        !from.isUninitialized() -> "Already initialized"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        !from.isUninitialized() -> CommandResult.error("Already initialized")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState =
@@ -106,9 +108,9 @@ object BootTransition : StateTransition {
 }
 
 object StandbyTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        from.isFlying() -> "Aircraft is flying"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        from.isFlying() -> CommandResult.error("Aircraft is flying")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState = from.copy(
@@ -118,9 +120,9 @@ object StandbyTransition : StateTransition {
 }
 
 object ArmTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        !from.isStandBy() -> "Not ready to arm"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        !from.isStandBy() -> CommandResult.error("Not ready to arm")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState =
@@ -128,10 +130,10 @@ object ArmTransition : StateTransition {
 }
 
 object TakeoffTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        !from.isArmed() -> "Not armed"
-        !from.isOnTheGround() -> "Not on the ground"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        !from.isArmed() -> CommandResult.error("Not armed")
+        !from.isOnTheGround() -> CommandResult.error("Not on the ground")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState =
@@ -139,9 +141,9 @@ object TakeoffTransition : StateTransition {
 }
 
 object FlyingTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        !from.isArmed() -> "Not armed"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        !from.isArmed() -> CommandResult.error("Not armed")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState =
@@ -149,10 +151,10 @@ object FlyingTransition : StateTransition {
 }
 
 object LandTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        !from.isArmed() -> "Not armed"
-        !from.isFlying() -> "Not flying"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        !from.isArmed() -> CommandResult.error("Not armed")
+        !from.isFlying() -> CommandResult.error("Not flying")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState = from.copy(
@@ -161,10 +163,10 @@ object LandTransition : StateTransition {
 }
 
 object FlightTerminationTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        !from.isArmed() -> "Not armed"
-        !from.isFlying() -> "Not flying"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        !from.isArmed() -> CommandResult.error("Not armed")
+        !from.isFlying() -> CommandResult.error("Not flying")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState = from.copy(
@@ -173,10 +175,10 @@ object FlightTerminationTransition : StateTransition {
 }
 
 object PowerOffTransition : StateTransition {
-    override fun canTransition(from: AircraftState): String? = when {
-        !from.isStandBy() -> "Still armed"
-        !from.isOnTheGround() -> "Still flying"
-        else -> null
+    override fun canTransition(from: AircraftState): UnitResult = when {
+        !from.isStandBy() -> CommandResult.error("Still armed")
+        !from.isOnTheGround() -> CommandResult.error("Still flying")
+        else -> CommandResult.ok
     }
 
     override fun reduce(from: AircraftState): AircraftState = from.copy(
@@ -192,7 +194,7 @@ class AircraftStateMachine {
     var state = AircraftState()
         private set
 
-    fun canDispatch(event: StateTransition): String? = event.canTransition(state)
+    fun canDispatch(event: StateTransition): UnitResult = event.canTransition(state)
 
     fun dispatch(event: StateTransition): AircraftState {
         state = event.reduce(state)

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
@@ -49,7 +49,7 @@ data class SetModeCommand(val newMode: Int, val cameraIdx: Int) : CameraCommand 
             else -> CommandResult.ok
         }
 
-        if (setModeResult is CommandResult.Success) {
+        if (setModeResult.isOk) {
             ctx.setMode(newMode, cameraIdx)
         }
         return setModeResult

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
@@ -2,67 +2,68 @@ package org.WenuLink.adapters.camera
 
 import com.MAVLink.enums.CAMERA_MODE
 import dji.common.camera.SettingsDefinitions
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.ICommand
+import org.WenuLink.commands.UnitResult
 import org.WenuLink.sdk.CameraManager
 
 sealed interface CameraCommand : ICommand<CameraHandler> {
-    override fun validate(ctx: CameraHandler): String? = null
-    override suspend fun execute(ctx: CameraHandler): String?
+    override fun validate(ctx: CameraHandler): UnitResult = CommandResult.ok
+    override suspend fun execute(ctx: CameraHandler): UnitResult
     override suspend fun onStop(ctx: CameraHandler) { }
 }
 
 data class SetModeCommand(val newMode: Int, val cameraIdx: Int) : CameraCommand {
-    override fun validate(ctx: CameraHandler): String? = when (newMode) {
-        CAMERA_MODE.CAMERA_MODE_IMAGE -> null
-        CAMERA_MODE.CAMERA_MODE_VIDEO -> null
-        else -> "Unrecognized mode: $newMode"
+    override fun validate(ctx: CameraHandler): UnitResult = when (newMode) {
+        CAMERA_MODE.CAMERA_MODE_IMAGE -> CommandResult.ok
+        CAMERA_MODE.CAMERA_MODE_VIDEO -> CommandResult.ok
+        else -> CommandResult.error("Unrecognized mode: $newMode")
     }
 
-    suspend fun setPhotoMode(cameraIdx: Int = 0): String? {
+    suspend fun setPhotoMode(cameraIdx: Int = 0): UnitResult {
         if (!CameraManager.isPhotoMode()) {
             val error = CameraManager.setPhotoMode()
             if (error != null) {
-                return "setPhotoMode error: $error"
+                return CommandResult.error("setPhotoMode error: $error")
             }
         }
 
-        return null
+        return CommandResult.ok
     }
 
-    suspend fun setVideoMode(cameraIdx: Int = 0): String? {
+    suspend fun setVideoMode(cameraIdx: Int = 0): UnitResult {
         if (!CameraManager.isVideoMode()) {
             val error = CameraManager.setVideoMode()
             if (error != null) {
-                return "setVideoMode error: $error"
+                return CommandResult.error("setVideoMode error: $error")
             }
         }
 
-        return null
+        return CommandResult.ok
     }
 
-    override suspend fun execute(ctx: CameraHandler): String? {
+    override suspend fun execute(ctx: CameraHandler): UnitResult {
         val setModeResult = when (newMode) {
             CAMERA_MODE.CAMERA_MODE_IMAGE -> setPhotoMode()
             CAMERA_MODE.CAMERA_MODE_VIDEO -> setVideoMode()
-            else -> null
+            else -> CommandResult.ok
         }
 
-        if (setModeResult != null) return "Unable to set mode: $newMode"
-
-        ctx.setMode(newMode, cameraIdx)
-
-        return null
+        if (setModeResult is CommandResult.Success) {
+            ctx.setMode(newMode, cameraIdx)
+        }
+        return setModeResult
     }
 }
 
 data class TakePhotoCommand(val cameraIdx: Int) : CameraCommand {
-    override fun validate(ctx: CameraHandler): String? = when {
-        !ctx.isPhotoMode(cameraIdx) -> "Not in photo mode!"
-        !ctx.captureIdle(cameraIdx) -> "Busy"
-        else -> null
+    override fun validate(ctx: CameraHandler): UnitResult = when {
+        !ctx.isPhotoMode(cameraIdx) -> CommandResult.error("Not in photo mode!")
+        !ctx.captureIdle(cameraIdx) -> CommandResult.error("Busy")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: CameraHandler): String? {
+    override suspend fun execute(ctx: CameraHandler): UnitResult {
         // mark IN_PROGRESS
         ctx.updateCaptureStatus(CameraCaptureStatus.IN_PROGRESS, cameraIdx)
         // Trigger camera and wait for photo to be taken
@@ -74,65 +75,73 @@ data class TakePhotoCommand(val cameraIdx: Int) : CameraCommand {
         // mark IDLE back
         ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
         return error
+            ?.let { CommandResult.error(it) }
+            ?: CommandResult.ok
     }
 }
 
 data class StartRecordCommand(val cameraIdx: Int) : CameraCommand {
-    override fun validate(ctx: CameraHandler): String? = when {
-        !ctx.isVideoMode(cameraIdx) -> "Not in video mode!"
-        !ctx.canRecordVideo(cameraIdx) -> "Unable to start recording"
-        !ctx.captureIdle(cameraIdx) -> "Busy"
-        else -> null
+    override fun validate(ctx: CameraHandler): UnitResult = when {
+        !ctx.isVideoMode(cameraIdx) -> CommandResult.error("Not in video mode!")
+        !ctx.canRecordVideo(cameraIdx) -> CommandResult.error("Unable to start recording")
+        !ctx.captureIdle(cameraIdx) -> CommandResult.error("Busy")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: CameraHandler): String? {
+    override suspend fun execute(ctx: CameraHandler): UnitResult {
         // mark IN_PROGRESS
         ctx.updateCaptureStatus(CameraCaptureStatus.IN_PROGRESS, cameraIdx)
         // Trigger camera and wait for photo to be taken
         val error = CameraManager.requestStartVideoRecording()
-        if (error == null) {
+        return if (error == null) {
             ctx.captureTimestamp = System.currentTimeMillis()
+            CommandResult.ok
         } else {
             ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+            CommandResult.error(error)
         }
-        return error
     }
 }
 
 data class StopRecordCommand(val cameraIdx: Int) : CameraCommand {
-    override fun validate(ctx: CameraHandler): String? = when {
-        !ctx.isVideoMode(cameraIdx) -> "Not in video mode!"
-        !ctx.captureInProgress(cameraIdx) -> "Record not started"
-        else -> null
+    override fun validate(ctx: CameraHandler): UnitResult = when {
+        !ctx.isVideoMode(cameraIdx) -> CommandResult.error("Not in video mode!")
+        !ctx.captureInProgress(cameraIdx) -> CommandResult.error("Record not started")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: CameraHandler): String? {
+    override suspend fun execute(ctx: CameraHandler): UnitResult {
         // Trigger camera and wait for photo to be taken
         val error = CameraManager.requestStopVideoRecording()
-        if (error == null) {
+        return if (error == null) {
             // mark IDLE back
             ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+            CommandResult.ok
+        } else {
+            CommandResult.error(error)
         }
-        return error
     }
 }
 
 data class StartIntervalShootCommand(val cameraIdx: Int, val intervalSeconds: Int) : CameraCommand {
-    override fun validate(ctx: CameraHandler): String? = when {
-        !ctx.isPhotoMode(cameraIdx) -> "Not in photo mode!"
-        !ctx.captureIdle(cameraIdx) -> "Busy"
-        else -> null
+    override fun validate(ctx: CameraHandler): UnitResult = when {
+        !ctx.isPhotoMode(cameraIdx) -> CommandResult.error("Not in photo mode!")
+        !ctx.captureIdle(cameraIdx) -> CommandResult.error("Busy")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: CameraHandler): String? {
+    override suspend fun execute(ctx: CameraHandler): UnitResult {
         val modeError = CameraManager.setCaptureMode(SettingsDefinitions.ShootPhotoMode.INTERVAL)
-        if (modeError != null) return modeError
+        if (modeError != null) return CommandResult.error(modeError)
 
         val intervalError = CameraManager.setIntervalSeconds(intervalSeconds)
-        if (intervalError != null) return intervalError
+        if (intervalError != null) return CommandResult.error(intervalError)
 
         ctx.updateCaptureStatus(CameraCaptureStatus.INTERVAL_PROGRESS, cameraIdx)
+
         return CameraManager.requestStartIntervalShoot()
+            ?.let { CommandResult.error(it) }
+            ?: CommandResult.ok
     }
 
     override suspend fun onStop(ctx: CameraHandler) {
@@ -142,20 +151,22 @@ data class StartIntervalShootCommand(val cameraIdx: Int, val intervalSeconds: In
 }
 
 data class StopIntervalShootCommand(val cameraIdx: Int) : CameraCommand {
-    override fun validate(ctx: CameraHandler): String? = when {
-        !ctx.isPhotoMode(cameraIdx) -> "Not in photo mode!"
+    override fun validate(ctx: CameraHandler): UnitResult = when {
+        !ctx.isPhotoMode(cameraIdx) -> CommandResult.error("Not in photo mode!")
 
         !ctx.checkCaptureStatus(CameraCaptureStatus.INTERVAL_PROGRESS, cameraIdx) ->
-            "Interval shoot not started"
+            CommandResult.error("Interval shoot not started")
 
-        else -> null
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: CameraHandler): String? {
+    override suspend fun execute(ctx: CameraHandler): UnitResult {
         val error = CameraManager.requestStopIntervalShoot()
-        if (error == null) {
+        return if (error == null) {
             ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+            CommandResult.ok
+        } else {
+            CommandResult.error(error)
         }
-        return error
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -18,13 +18,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.MessageUtils
 import org.WenuLink.adapters.aircraft.Coordinates3D
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.ICommand
+import org.WenuLink.commands.UnitResult
 import org.WenuLink.sdk.MissionActionManager
 import org.WenuLink.sdk.MissionManager
 
 sealed interface MissionCommand : ICommand<MissionHandler> {
-    override fun validate(ctx: MissionHandler): String?
-    override suspend fun execute(ctx: MissionHandler): String?
+    override fun validate(ctx: MissionHandler): UnitResult
+    override suspend fun execute(ctx: MissionHandler): UnitResult
     override suspend fun onStop(ctx: MissionHandler)
 }
 
@@ -32,15 +34,15 @@ data class UploadMissionCommand(
     private val assembler: MissionAssembler,
     private val flightSpeed: Float = 5f
 ) : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = when {
-        ctx.state.canCreateMission() -> null
-        else -> "Upload not ready"
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        ctx.state.canCreateMission() -> CommandResult.ok
+        else -> CommandResult.error("Upload not ready")
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? =
+    override suspend fun execute(ctx: MissionHandler): UnitResult =
         suspendCancellableCoroutine { cont ->
-            MissionManager.uploadMission(assembler.build(), flightSpeed) { success, error ->
-                cont.resume(error)
+            MissionManager.uploadMission(assembler.build(), flightSpeed) { _, error ->
+                cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
@@ -52,17 +54,17 @@ data class UploadMissionCommand(
 }
 
 data object StartWaypointMission : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = when {
-        ctx.state.canCreateMission() -> "No mission found"
-        ctx.state.isActive() -> "Already started"
-        ctx.state.canStartMission() -> null
-        else -> "Not ready"
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        ctx.state.canCreateMission() -> CommandResult.error("No mission found")
+        ctx.state.isActive() -> CommandResult.error("Already started")
+        ctx.state.canStartMission() -> CommandResult.ok
+        else -> CommandResult.error("Not ready")
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? =
+    override suspend fun execute(ctx: MissionHandler): UnitResult =
         suspendCancellableCoroutine { cont ->
             MissionManager.startMission { error ->
-                cont.resume(error)
+                cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
@@ -74,15 +76,15 @@ data object StartWaypointMission : MissionCommand {
 }
 
 data object PauseWaypointMission : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = when {
-        ctx.state.canPauseMission() -> null
-        else -> "Not started"
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        ctx.state.canPauseMission() -> CommandResult.ok
+        else -> CommandResult.error("Not started")
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? =
+    override suspend fun execute(ctx: MissionHandler): UnitResult =
         suspendCancellableCoroutine { cont ->
             MissionManager.pauseMission { error ->
-                cont.resume(error)
+                cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
@@ -94,15 +96,15 @@ data object PauseWaypointMission : MissionCommand {
 }
 
 data object ResumeWaypointMission : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = when {
-        ctx.state.canResumeMission() -> null
-        else -> "Already in execution"
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        ctx.state.canResumeMission() -> CommandResult.ok
+        else -> CommandResult.error("Already in execution")
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? =
+    override suspend fun execute(ctx: MissionHandler): UnitResult =
         suspendCancellableCoroutine { cont ->
             MissionManager.resumeMission { error ->
-                cont.resume(error)
+                cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
@@ -114,15 +116,15 @@ data object ResumeWaypointMission : MissionCommand {
 }
 
 data object StopWaypointMission : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = when {
-        !ctx.state.canCreateMission() -> null
-        else -> "Nothing to stop"
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        !ctx.state.canCreateMission() -> CommandResult.ok
+        else -> CommandResult.error("Nothing to stop")
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? =
+    override suspend fun execute(ctx: MissionHandler): UnitResult =
         suspendCancellableCoroutine { cont ->
             MissionManager.stopMission { error ->
-                cont.resume(error)
+                cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
@@ -134,38 +136,37 @@ data object StopWaypointMission : MissionCommand {
 }
 
 data object PauseActionCommand : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = when {
-        !MissionActionManager.isRunning -> "Timeline not running"
-        else -> null
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        !MissionActionManager.isRunning -> CommandResult.error("Timeline not running")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? {
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
         MissionActionManager.pause()
-        return null
+        return CommandResult.ok
     }
 
     override suspend fun onStop(ctx: MissionHandler) { }
 }
 
 data object ResumeActionCommand : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = when {
-        MissionActionManager.isRunning -> "Timeline already running"
-        else -> null
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        MissionActionManager.isRunning -> CommandResult.error("Timeline already running")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? {
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
         MissionActionManager.resume()
-        return null
+        return CommandResult.ok
     }
 
     override suspend fun onStop(ctx: MissionHandler) { }
 }
 
 interface MissionActionCommand : MissionCommand {
-    override fun validate(ctx: MissionHandler): String? = if (MissionActionManager.isRunning) {
-        "Busy"
-    } else {
-        null
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        MissionActionManager.isRunning -> CommandResult.error("Busy")
+        else -> CommandResult.ok
     }
 
     override suspend fun onStop(ctx: MissionHandler) = MissionActionManager.stop()
@@ -206,39 +207,38 @@ data class DelayAction(val timeMillis: Long) : MissionActionCommand {
         )
     }
 
-    override fun validate(ctx: MissionHandler): String? = if (ctx.state.isActive()) {
-        "Busy"
-    } else {
-        null
+    override fun validate(ctx: MissionHandler): UnitResult = when {
+        ctx.state.isActive() -> CommandResult.error("Busy")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: MissionHandler): String? {
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
         delay(timeMillis)
-        return null
+        return CommandResult.ok
     }
 
     override suspend fun onStop(ctx: MissionHandler) { }
 }
 
 open class ActionCommand(val action: MissionAction) : MissionActionCommand {
-    override suspend fun execute(ctx: MissionHandler): String? =
+    override suspend fun execute(ctx: MissionHandler): UnitResult =
         suspendCancellableCoroutine { cont ->
             MissionActionManager.clear()
 
             val error = MissionActionManager.schedule(action)
 
             if (error != null) {
-                cont.resume("Error in $action: ${error.description}")
+                cont.resume(CommandResult.error("Error in $action: ${error.description}"))
                 return@suspendCancellableCoroutine
             }
 
             val actionKey = MissionActionManager.onFinish(action::class) {
-                cont.resume(null)
+                cont.resume(CommandResult.ok)
             }
 
             MissionActionManager.startListener {
                 // onError
-                cont.resume("Action failed: $it")
+                cont.resume(CommandResult.error("Action failed: $it"))
             }
 
             MissionActionManager.start()

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.WenuLink.adapters.MessageUtils
 import org.WenuLink.commands.CommandHandler
+import org.WenuLink.commands.UnitResult
 import org.WenuLink.sdk.MissionActionManager
 import org.WenuLink.sdk.MissionManager
 
@@ -207,6 +208,6 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         logger.d { "Waypoint: ($coordinates) (Yaw=$deg deg) (Delay=$delay)" }
     }
 
-    fun uploadWaypoints(onResult: (String?) -> Unit) =
+    fun uploadWaypoints(onResult: (UnitResult) -> Unit) =
         dispatchCommand(UploadMissionCommand(state.assembler, flightSpeed), onResult)
 }

--- a/app/src/main/java/org/WenuLink/commands/CommandHandler.kt
+++ b/app/src/main/java/org/WenuLink/commands/CommandHandler.kt
@@ -11,11 +11,11 @@ import kotlinx.coroutines.launch
 
 open class CommandHandler<T : IHandler<T>> : IHandler<T> {
     private var requestJob: Job? = null
-    private var commandJob: Deferred<String?>? = null
+    private var commandJob: Deferred<UnitResult>? = null
     var currentCommand: ICommand<T>? = null
         private set
     private val commandChannel =
-        Channel<Pair<ICommand<T>, (String?) -> Unit>>(Channel.UNLIMITED)
+        Channel<Pair<ICommand<T>, (UnitResult) -> Unit>>(Channel.UNLIMITED)
 
     fun startCommandProcessor(scope: CoroutineScope, handler: T, logger: TaggedLogger) {
         requestJob?.cancel()
@@ -26,9 +26,9 @@ open class CommandHandler<T : IHandler<T>> : IHandler<T> {
                 currentCommand = cmd
 
                 try {
-                    val validationError = cmd.validate(handler)
-                    if (validationError != null) {
-                        onResult(validationError)
+                    val validationResult = cmd.validate(handler)
+                    if (validationResult is CommandResult.Failure) {
+                        onResult(validationResult)
                         continue
                     }
 
@@ -40,13 +40,13 @@ open class CommandHandler<T : IHandler<T>> : IHandler<T> {
 
                     val result = deferred.await()
                     onResult(result)
-                } catch (e: CancellationException) {
+                } catch (_: CancellationException) {
                     logger.w { "Command cancelled: ${cmd::class.simpleName}" }
                     cmd.onStop(handler)
-                    onResult(null)
+                    onResult(CommandResult.ok)
                 } catch (e: Exception) {
                     logger.d { "Command failed: ${cmd::class.simpleName}" }
-                    onResult(e.message)
+                    onResult(CommandResult.error(e.message ?: "Unknown error"))
                 } finally {
                     commandJob = null
                     currentCommand = null
@@ -57,18 +57,16 @@ open class CommandHandler<T : IHandler<T>> : IHandler<T> {
 
     override fun registerScope(scope: CoroutineScope) { } // nothing to do
 
-    fun dispatchCommand(cmd: ICommand<T>, onResult: (String?) -> Unit = {}) {
+    fun dispatchCommand(cmd: ICommand<T>, onResult: (UnitResult) -> Unit = {}) {
         val result = commandChannel.trySend(cmd to onResult)
         if (result.isFailure) {
-            onResult("Failed to enqueue command: ${cmd::class.java.simpleName}")
+            onResult(
+                CommandResult.error("Failed to enqueue command: ${cmd::class.java.simpleName}")
+            )
         }
     }
 
-    fun stopCommand(): String? {
-        val job = commandJob ?: return "No running command"
-        job.cancel(CancellationException("Stopped by user"))
-        return null
-    }
+    fun stopCommand() = commandJob?.cancel(CancellationException("Stopped by user"))
 
     override fun unload() {
         // Stop ongoing processes

--- a/app/src/main/java/org/WenuLink/commands/CommandHandler.kt
+++ b/app/src/main/java/org/WenuLink/commands/CommandHandler.kt
@@ -27,7 +27,7 @@ open class CommandHandler<T : IHandler<T>> : IHandler<T> {
 
                 try {
                     val validationResult = cmd.validate(handler)
-                    if (validationResult is CommandResult.Failure) {
+                    if (validationResult.hasError) {
                         onResult(validationResult)
                         continue
                     }

--- a/app/src/main/java/org/WenuLink/commands/CommandResult.kt
+++ b/app/src/main/java/org/WenuLink/commands/CommandResult.kt
@@ -4,6 +4,13 @@ sealed class CommandResult<out T> {
     data class Success<T>(val value: T) : CommandResult<T>()
     data class Failure(val reason: String) : CommandResult<Nothing>()
 
+    val isOk: Boolean
+        get() = this is Success
+    val hasError: Boolean
+        get() = this is Failure
+    val errorReason: String?
+        get() = (this as? Failure)?.reason
+
     companion object {
         val ok: UnitResult = Success(Unit)
         fun error(reason: String): CommandResult<Nothing> = Failure(reason)

--- a/app/src/main/java/org/WenuLink/commands/CommandResult.kt
+++ b/app/src/main/java/org/WenuLink/commands/CommandResult.kt
@@ -8,8 +8,8 @@ sealed class CommandResult<out T> {
         get() = this is Success
     val hasError: Boolean
         get() = this is Failure
-    val errorReason: String?
-        get() = (this as? Failure)?.reason
+    val errorReason: String
+        get() = (this as? Failure)?.reason ?: "errorReason accessed on Success"
 
     companion object {
         val ok: UnitResult = Success(Unit)

--- a/app/src/main/java/org/WenuLink/commands/CommandResult.kt
+++ b/app/src/main/java/org/WenuLink/commands/CommandResult.kt
@@ -1,0 +1,13 @@
+package org.WenuLink.commands
+
+sealed class CommandResult<out T> {
+    data class Success<T>(val value: T) : CommandResult<T>()
+    data class Failure(val reason: String) : CommandResult<Nothing>()
+
+    companion object {
+        val ok: UnitResult = Success(Unit)
+        fun error(reason: String): CommandResult<Nothing> = Failure(reason)
+    }
+}
+
+typealias UnitResult = CommandResult<Unit>

--- a/app/src/main/java/org/WenuLink/commands/ICommand.kt
+++ b/app/src/main/java/org/WenuLink/commands/ICommand.kt
@@ -1,7 +1,9 @@
 package org.WenuLink.commands
 
 interface ICommand<T : IHandler<T>> {
-    fun validate(ctx: T): String?
-    suspend fun execute(ctx: T): String?
+    fun validate(ctx: T): UnitResult
+
+    suspend fun execute(ctx: T): UnitResult
+
     suspend fun onStop(ctx: T)
 }

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
@@ -29,6 +29,7 @@ import org.WenuLink.mavlink.controllers.TelemetryController
  * - ParameterController: Parameter Protocol
  * - NavigationController: Mission Protocol
  * - TelemetryController: Message Protocol
+ * - CameraController: Camera Protocol
  */
 class MAVLinkController(private val handler: WenuLinkHandler) {
     private val logger by taggedLogger(MAVLinkController::class.java.simpleName)

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -29,7 +29,6 @@ import org.WenuLink.adapters.camera.StartRecordCommand
 import org.WenuLink.adapters.camera.StopIntervalShootCommand
 import org.WenuLink.adapters.camera.StopRecordCommand
 import org.WenuLink.adapters.camera.TakePhotoCommand
-import org.WenuLink.commands.CommandResult
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -135,7 +134,7 @@ class CameraController(
         handler.dispatchCommand(WenuLinkCommand.Camera(SetModeCommand(mode, index))) { result ->
             sendCommandAck(
                 commandLongMsg.command,
-                if (result is CommandResult.Success) {
+                if (result.isOk) {
                     MAV_RESULT.MAV_RESULT_ACCEPTED
                 } else {
                     MAV_RESULT.MAV_RESULT_FAILED
@@ -202,9 +201,9 @@ class CameraController(
         )
 
         handler.dispatchCommand(command) { result ->
-            if (result is CommandResult.Failure) {
+            if (result.hasError) {
                 logger.w {
-                    "requestStartCapture error: ${result.reason}"
+                    "requestStartCapture error: ${result.errorReason}"
                 }
             }
             if (totalPhotos == 1) handler.onImageCaptured = null
@@ -232,9 +231,9 @@ class CameraController(
         handler.dispatchCommand(
             WenuLinkCommand.Camera(StopIntervalShootCommand(cameraInfo.id))
         ) { result ->
-            if (result is CommandResult.Failure) {
+            if (result.hasError) {
                 logger.w {
-                    "requestStopCapture error: ${result.reason}"
+                    "requestStopCapture error: ${result.errorReason}"
                 }
             }
         }
@@ -266,8 +265,8 @@ class CameraController(
         handler.dispatchCommand(
             WenuLinkCommand.Camera(StartRecordCommand(cameraInfo.id))
         ) { result ->
-            if (result is CommandResult.Failure) {
-                logger.w { "Error in requestStartRecording: ${result.reason}" }
+            if (result.hasError) {
+                logger.w { "Error in requestStartRecording: ${result.errorReason}" }
             } else {
                 // setting messages frequency
                 onSetMessageRate(

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -29,6 +29,7 @@ import org.WenuLink.adapters.camera.StartRecordCommand
 import org.WenuLink.adapters.camera.StopIntervalShootCommand
 import org.WenuLink.adapters.camera.StopRecordCommand
 import org.WenuLink.adapters.camera.TakePhotoCommand
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -131,10 +132,10 @@ class CameraController(
         val index = commandLongMsg.param1.toInt()
         val mode = commandLongMsg.param2.toInt()
 
-        handler.dispatchCommand(WenuLinkCommand.Camera(SetModeCommand(mode, index))) { error ->
+        handler.dispatchCommand(WenuLinkCommand.Camera(SetModeCommand(mode, index))) { result ->
             sendCommandAck(
                 commandLongMsg.command,
-                if (error == null) {
+                if (result is CommandResult.Success) {
                     MAV_RESULT.MAV_RESULT_ACCEPTED
                 } else {
                     MAV_RESULT.MAV_RESULT_FAILED
@@ -200,8 +201,12 @@ class CameraController(
             )
         )
 
-        handler.dispatchCommand(command) { error ->
-            if (error != null) logger.w { "requestStartCapture error: $error" }
+        handler.dispatchCommand(command) { result ->
+            if (result is CommandResult.Failure) {
+                logger.w {
+                    "requestStartCapture error: ${result.reason}"
+                }
+            }
             if (totalPhotos == 1) handler.onImageCaptured = null
         }
     }
@@ -226,8 +231,12 @@ class CameraController(
         handler.onImageCaptured = null
         handler.dispatchCommand(
             WenuLinkCommand.Camera(StopIntervalShootCommand(cameraInfo.id))
-        ) { error ->
-            if (error != null) logger.w { "requestStopCapture error: $error" }
+        ) { result ->
+            if (result is CommandResult.Failure) {
+                logger.w {
+                    "requestStopCapture error: ${result.reason}"
+                }
+            }
         }
     }
 
@@ -256,10 +265,9 @@ class CameraController(
 
         handler.dispatchCommand(
             WenuLinkCommand.Camera(StartRecordCommand(cameraInfo.id))
-        ) { error ->
-            val captureOk = error == null
-            if (!captureOk) {
-                logger.w { "Error in requestStartRecording: $error" }
+        ) { result ->
+            if (result is CommandResult.Failure) {
+                logger.w { "Error in requestStartRecording: ${result.reason}" }
             } else {
                 // setting messages frequency
                 onSetMessageRate(

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -18,6 +18,7 @@ import org.WenuLink.adapters.aircraft.ArmCommand
 import org.WenuLink.adapters.aircraft.DisarmCommand
 import org.WenuLink.adapters.mission.DelayAction
 import org.WenuLink.adapters.mission.RotateAction
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -112,13 +113,11 @@ class CommandController(override var client: MAVLinkClient, override val handler
             return
         }
 
-        handler.aircraft.requestMode(customMode)
-            .onSuccess {
-                sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
-            }
-            .onFailure {
-                sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
-            }
+        if (handler.aircraft.requestMode(customMode) is CommandResult.Success) {
+            sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
+        } else {
+            sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
+        }
     }
 
     fun processArmDisarm(commandMsg: msg_command_long) {
@@ -154,22 +153,20 @@ class CommandController(override var client: MAVLinkClient, override val handler
 
     fun processLanding(commandMsg: msg_command_long) {
         logger.d { "processLanding: $commandMsg" }
-        val result = if (handler.aircraft.requestMode(ArduCopterFlightMode.LAND).isSuccess) {
-            MAV_RESULT.MAV_RESULT_ACCEPTED
+        if (handler.aircraft.requestMode(ArduCopterFlightMode.LAND) is CommandResult.Success) {
+            sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
         } else {
-            MAV_RESULT.MAV_RESULT_DENIED
+            sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
         }
-        sendCommandAck(commandMsg.command, result)
     }
 
     fun processReturn(commandMsg: msg_command_long) {
         logger.d { "processReturn: $commandMsg" }
-        val result = if (handler.aircraft.requestMode(ArduCopterFlightMode.RTL).isSuccess) {
-            MAV_RESULT.MAV_RESULT_ACCEPTED
+        if (handler.aircraft.requestMode(ArduCopterFlightMode.RTL) is CommandResult.Success) {
+            sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
         } else {
-            MAV_RESULT.MAV_RESULT_DENIED
+            sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
         }
-        sendCommandAck(commandMsg.command, result)
     }
 
     fun processDelay(commandMsg: msg_command_long) {

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -18,7 +18,6 @@ import org.WenuLink.adapters.aircraft.ArmCommand
 import org.WenuLink.adapters.aircraft.DisarmCommand
 import org.WenuLink.adapters.mission.DelayAction
 import org.WenuLink.adapters.mission.RotateAction
-import org.WenuLink.commands.CommandResult
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -113,7 +112,7 @@ class CommandController(override var client: MAVLinkClient, override val handler
             return
         }
 
-        if (handler.aircraft.requestMode(customMode) is CommandResult.Success) {
+        if (handler.aircraft.requestMode(customMode).isOk) {
             sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
         } else {
             sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
@@ -153,7 +152,7 @@ class CommandController(override var client: MAVLinkClient, override val handler
 
     fun processLanding(commandMsg: msg_command_long) {
         logger.d { "processLanding: $commandMsg" }
-        if (handler.aircraft.requestMode(ArduCopterFlightMode.LAND) is CommandResult.Success) {
+        if (handler.aircraft.requestMode(ArduCopterFlightMode.LAND).isOk) {
             sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
         } else {
             sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)
@@ -162,7 +161,7 @@ class CommandController(override var client: MAVLinkClient, override val handler
 
     fun processReturn(commandMsg: msg_command_long) {
         logger.d { "processReturn: $commandMsg" }
-        if (handler.aircraft.requestMode(ArduCopterFlightMode.RTL) is CommandResult.Success) {
+        if (handler.aircraft.requestMode(ArduCopterFlightMode.RTL).isOk) {
             sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
         } else {
             sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_DENIED)

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -33,7 +33,6 @@ import org.WenuLink.adapters.WenuLinkCommand
 import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.adapters.mission.MissionNode
 import org.WenuLink.adapters.mission.RepositionAction
-import org.WenuLink.commands.CommandResult
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -233,9 +232,9 @@ class NavigationController(
         } else {
             // reached the end of the handler.mission items
             handler.mission.uploadWaypoints { result ->
-                if (result is CommandResult.Failure) {
+                if (result.hasError) {
                     sendStatusText(
-                        result.reason,
+                        result.errorReason,
                         MAV_SEVERITY.MAV_SEVERITY_ERROR
                     )
                 }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -33,6 +33,7 @@ import org.WenuLink.adapters.WenuLinkCommand
 import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.adapters.mission.MissionNode
 import org.WenuLink.adapters.mission.RepositionAction
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.mavlink.MAVLinkClient
 
 /**
@@ -231,8 +232,13 @@ class NavigationController(
             requestMissionItem(expectedSeq + 1)
         } else {
             // reached the end of the handler.mission items
-            handler.mission.uploadWaypoints { error ->
-                if (error != null) sendStatusText(error, MAV_SEVERITY.MAV_SEVERITY_ERROR)
+            handler.mission.uploadWaypoints { result ->
+                if (result is CommandResult.Failure) {
+                    sendStatusText(
+                        result.reason,
+                        MAV_SEVERITY.MAV_SEVERITY_ERROR
+                    )
+                }
             }
             sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED)
         }


### PR DESCRIPTION
Closes #40 

Introduce a sealed class CommandResult<T> with Success and Failure variants, replacing the anti-pattern of null meaning success and a non-null String meaning failure. Also adds a UnitResult typealias for the common CommandResult<Unit> case.

Affected: ICommand, CommandHandler, all command implementations (AircraftCommands, MissionCommands, CameraCommands), AircraftState transitions, AircraftHandler, WenuLinkHandler, RequestCommand, and all MAVLink controller call sites.

The sdk layer (CameraManager, FCManager, MissionManager) intentionally retains String? as it reflects the DJI SDK error type directly.