### PR TITLE
refactor: method return types and number separators:

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,8 +215,9 @@ Code style is enforced via **ktlint**, additionally the following conventions ar
 
 #### Type Inference
 
-- Omit explicit types when they are obvious from the right-hand side.
-- Keep type annotations where they improve readability or clarity.
+- Omit explicit attribute types when they are obvious from the right-hand side.
+- Keep attribute type annotations where they improve readability or clarity.
+- Always declare function return types explicitly unless they are of type `Unit` or very basic Boolean expressions
 
 #### Null Safety
 

--- a/app/src/main/java/org/WenuLink/MainActivity.kt
+++ b/app/src/main/java/org/WenuLink/MainActivity.kt
@@ -130,7 +130,7 @@ class MainActivity : ComponentActivity() {
         // Logs
         var logMessages by remember { mutableStateOf(listOf<String>()) }
 
-        fun buttonLabel(isRunning: Boolean) = if (isRunning) "Stop" else "Start"
+        fun buttonLabel(isRunning: Boolean): String = if (isRunning) "Stop" else "Start"
 
         // UI code here using telemetry and status
         Column(

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -156,7 +156,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         }
 
     suspend fun bootAircraft(): String? {
-        val bootError = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10000L)))
+        val bootError = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10_000L)))
         if (bootError == null) {
             manualControl()
             startTimestamp = System.currentTimeMillis()

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -167,7 +167,7 @@ class WenuLinkService : Service() {
         }
     }
 
-    fun isWebRTCUp(): Boolean = if (isWebRTCReady()) webRTC.isServiceUp else false
+    fun isWebRTCUp() = isWebRTCReady() && webRTC.isServiceUp
 
     fun isMAVLinkReady() = ::mavlink.isInitialized
 
@@ -215,7 +215,7 @@ class WenuLinkService : Service() {
         webRTCStopJob?.join()
         mavlinkStopJob?.join()
         handler.unload()
-        AsyncUtils.waitTimeout(1000L, 20000L) { !handler.isAircraftPowerOn }
+        AsyncUtils.waitTimeout(1000L, 20_000L) { !handler.isAircraftPowerOn }
         thisApp.isAircraftBoot.value = false
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
@@ -13,8 +13,8 @@ import org.WenuLink.adapters.aircraft.Quaternion
 
 object AsyncUtils {
     suspend fun waitTimeout(
-        intervalTime: Long = 100,
-        timeout: Long = 2000,
+        intervalTime: Long = 100L,
+        timeout: Long = 2000L,
         isReady: () -> Boolean
     ): Boolean {
         val startTime = System.currentTimeMillis()
@@ -29,7 +29,7 @@ object AsyncUtils {
         return isReady()
     }
 
-    suspend fun waitReady(intervalTime: Long = 10, isReady: () -> Boolean) {
+    suspend fun waitReady(intervalTime: Long = 10L, isReady: () -> Boolean) {
         while (!isReady()) {
             delay(intervalTime) // Wait for the next check
         }
@@ -37,7 +37,7 @@ object AsyncUtils {
 }
 
 object MessageUtils {
-    fun getMicroTime(): Long = System.currentTimeMillis() * 1_000
+    fun getMicroTime(): Long = System.currentTimeMillis() * 1000
 
     // float deg to deg E7
     fun coordinateDJI2MAVLink(value: Double): Int = (10_000_000 * value).roundToInt()
@@ -46,7 +46,7 @@ object MessageUtils {
     fun coordinateMAVLink2DJI(value: Int): Double = value / 10_000_000.0
 
     // meters to millimeters
-    fun altitudeDJI2MAVLink(value: Float): Int = (value * 1_000).roundToInt()
+    fun altitudeDJI2MAVLink(value: Float): Int = (value * 1000).roundToInt()
 
     fun packVersion(major: Int, minor: Int, patch: Int, type: Int): Long = (
         (major shl 24) or
@@ -83,7 +83,7 @@ object MessageUtils {
             }
         }
 
-    fun xyzMAVLink2Coordinates(x: Int, y: Int, z: Float) = Coordinates3D(
+    fun xyzMAVLink2Coordinates(x: Int, y: Int, z: Float): Coordinates3D = Coordinates3D(
         coordinateMAVLink2DJI(x),
         coordinateMAVLink2DJI(y),
         z

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -82,9 +82,11 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         stateMachine.updateFlightMode(fallbackMode)
     }
 
-    fun canDispatchTransition(transition: StateTransition) = stateMachine.canDispatch(transition)
+    fun canDispatchTransition(transition: StateTransition): String? =
+        stateMachine.canDispatch(transition)
 
-    fun dispatchTransition(transition: StateTransition) = stateMachine.dispatch(transition)
+    fun dispatchTransition(transition: StateTransition): AircraftState =
+        stateMachine.dispatch(transition)
 
     suspend fun syncState(sensorsInterval: Long = 1000L, homeInterval: Long = 5000L) {
         if (isPowerOff) return
@@ -130,7 +132,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return AsyncUtils.waitTimeout(timeout, 1000L, parameters::isLoaded)
     }
 
-    suspend fun sensorChecks(timeout: Long = 10000L): Boolean {
+    suspend fun sensorChecks(timeout: Long = 10_000L): Boolean {
         val perSensorTime = (timeout / 3f).roundToLong()
         logger.i { "Waiting sensors data" }
 
@@ -177,7 +179,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return state.isHomeSet()
     }
 
-    suspend fun waitHomeSet(timeout: Long = 10000L): Boolean {
+    suspend fun waitHomeSet(timeout: Long = 10_000L): Boolean {
         if (state.isHomeSet()) return true
 
         return AsyncUtils.waitTimeout(

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
@@ -203,7 +203,7 @@ class AircraftStateMachine {
         state = target
     }
 
-    fun hasStateChanged(target: AircraftState): Boolean = state.mavlink != target.mavlink ||
+    fun hasStateChanged(target: AircraftState) = state.mavlink != target.mavlink ||
         state.landed != target.landed
 
     fun updateHomePosition(homeCoordinates: Coordinates3D): AircraftState {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -46,7 +46,7 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
     val isBroadcasting: StateFlow<Boolean> = _isBroadcasting.asStateFlow()
 
     @Synchronized
-    fun hasData(): Boolean = lastTelemetryData != null
+    fun hasData() = lastTelemetryData != null
 
     @Synchronized
     fun getData(): TelemetryData? = lastTelemetryData
@@ -162,7 +162,7 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
     }
 
     @Synchronized
-    fun isCompassOk() = FCManager.compassOk()
+    fun isCompassOk(): Boolean = FCManager.compassOk()
 
     @Synchronized
     fun isAccelerometerOk() = lastIMUState?.accelerometer?.all { it == SensorState.OK } == true

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
@@ -134,7 +134,7 @@ class CameraHandler : CommandHandler<CameraHandler>() {
         }
     }
 
-    fun checkCaptureStatus(status: CameraCaptureStatus, cameraIdx: Int = 0): Boolean =
+    fun checkCaptureStatus(status: CameraCaptureStatus, cameraIdx: Int = 0) =
         getCamera(cameraIdx)?.state?.captureStatus == status
 
     fun captureInProgress(cameraIdx: Int = 0): Boolean = checkCaptureStatus(
@@ -147,7 +147,7 @@ class CameraHandler : CommandHandler<CameraHandler>() {
         cameraIdx
     )
 
-    fun checkCameraMode(mode: Int, cameraIdx: Int = 0): Boolean =
+    fun checkCameraMode(mode: Int, cameraIdx: Int = 0) =
         getCamera(cameraIdx)?.state?.mavlinkMode == mode
 
     fun isPhotoMode(cameraIdx: Int = 0): Boolean = checkCameraMode(

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
@@ -8,7 +8,7 @@ class MissionAssembler {
     var nWaypoints = 0
         private set
 
-    fun getNode(nId: Int) = nodes[nId]
+    fun getNode(nId: Int): MissionNode = nodes[nId]
 
     fun hasNodes() = !nodes.isEmpty()
 

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -19,7 +19,7 @@ data class MissionState(
     val assembler: MissionAssembler = MissionAssembler(),
     val unvisitedSequence: Boolean = false
 ) {
-    fun totalNodes() = assembler.size()
+    fun totalNodes(): Int = assembler.size()
 
     fun isActive() = mavlink == MISSION_STATE.MISSION_STATE_ACTIVE
 
@@ -33,18 +33,18 @@ data class MissionState(
 
     fun isComplete() = mavlink == MISSION_STATE.MISSION_STATE_COMPLETE
 
-    fun setStartSequence(sequence: Int) = copy(startSequence = sequence)
+    fun setStartSequence(sequence: Int): MissionState = copy(startSequence = sequence)
 
-    fun updateItemSequence(sequence: Int?) =
+    fun updateItemSequence(sequence: Int?): MissionState =
         copy(currentSequence = sequence, unvisitedSequence = true)
 
-    fun nextItemSequence() = updateItemSequence(currentSequence?.plus(1))
+    fun nextItemSequence(): MissionState = updateItemSequence(currentSequence?.plus(1))
 
-    fun setComplete() = copy(mavlink = MISSION_STATE.MISSION_STATE_COMPLETE)
+    fun setComplete(): MissionState = copy(mavlink = MISSION_STATE.MISSION_STATE_COMPLETE)
 
-    fun markVisited() = copy(unvisitedSequence = false)
+    fun markVisited(): MissionState = copy(unvisitedSequence = false)
 
-    fun fromMissionManager() = copy(
+    fun fromMissionManager(): MissionState = copy(
         mavlink = when {
             MissionManager.isWaitingMission() -> MISSION_STATE.MISSION_STATE_NO_MISSION
             MissionManager.isMissionReady() -> MISSION_STATE.MISSION_STATE_NOT_STARTED
@@ -126,9 +126,9 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         if (speed !in range) logger.w { "Clipped speed $speed to [$range]" }
     }
 
-    fun getWaypointNode(index: Int) = state.assembler.getNode(index)
+    fun getWaypointNode(index: Int): MissionNode = state.assembler.getNode(index)
 
-    fun hasWaypointNodes() = state.assembler.hasNodes()
+    fun hasWaypointNodes(): Boolean = state.assembler.hasNodes()
 
     fun clear() {
         state = state.reset()

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
@@ -84,7 +84,7 @@ class MAVLinkClient(
         logger.d { "Sending end" }
     }
 
-    fun mustProcessMessages(): Boolean = mustReceiveMessages.get() || mustSendMessages.get()
+    fun mustProcessMessages() = mustReceiveMessages.get() || mustSendMessages.get()
 
     fun sendMessage(msg: MAVLinkMessage) {
         if (socket.isClosed) {

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
@@ -180,7 +180,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
         return isStationConnected()
     }
 
-    suspend fun waitServicesRequest(timeout: Long = 30000L): Boolean {
+    suspend fun waitServicesRequest(timeout: Long = 30_000L): Boolean {
         // https://docs.qgroundcontrol.com/master/en/qgc-dev-guide/communication_flow.html
         if (!isStationConnected()) return false
 
@@ -205,7 +205,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
 
     suspend fun waitHomePosition(): Boolean {
         // Wait for home position to send GPS_GLOBAL_ORIGIN and periodic HOME_POSITION
-        val isHomeSet = handler.aircraft.waitHomeSet(360000) // 5min
+        val isHomeSet = handler.aircraft.waitHomeSet(360_000L) // 6min
 
         if (!isHomeSet) return false
 

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -40,14 +40,14 @@ class MAVLinkService(handler: WenuLinkHandler) {
         groundControlStation = ServiceAddress(ip, port.toInt(), "UDP")
     }
 
-    fun clientExists(): Boolean = client != null
+    fun clientExists() = client != null
 
-    fun isServiceRunning(): Boolean =
-        clientExists() && (listeningJob?.isActive == true || sendingJob?.isActive == true)
+    fun isServiceRunning() = clientExists() &&
+        (listeningJob?.isActive == true || sendingJob?.isActive == true)
 
-    fun clientCanStart(): Boolean = clientExists() && !isServiceRunning()
+    fun clientCanStart() = clientExists() && !isServiceRunning()
 
-    fun isServiceStop(): Boolean = listeningJob == null && sendingJob == null
+    fun isServiceStop() = listeningJob == null && sendingJob == null
 
     fun createClient() {
         if (clientExists()) {
@@ -101,7 +101,7 @@ class MAVLinkService(handler: WenuLinkHandler) {
         }
 
         // Wait for station's heartbeat or shutdown if no received after a while
-        val currentStationConnected = controller.waitGroundStation(30000L)
+        val currentStationConnected = controller.waitGroundStation(30_000L)
         if (!currentStationConnected) {
             onResult("No ground control station found, stoping")
             stopService()
@@ -118,7 +118,7 @@ class MAVLinkService(handler: WenuLinkHandler) {
         // Wait for parameters and mission items request
         messagesScope?.launch {
             // TODO: move timeout to a UserPreference due to user's local network latency
-            isReady = controller.waitServicesRequest(30000L)
+            isReady = controller.waitServicesRequest(30_000L)
 
             logger.d {
                 "MAVLinkService (ready?=$isReady) " +

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -264,7 +264,7 @@ class CameraController(
                 // setting messages frequency
                 onSetMessageRate(
                     msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
-                    ((1f / statusFreq) * 1_000).roundToLong()
+                    ((1f / statusFreq) * 1000).roundToLong()
                 )
             }
         }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
@@ -135,7 +135,7 @@ class ConnectionController(
     fun msgSystemTime(): MAVLinkMessage {
         val currentStamp = System.currentTimeMillis()
         val msg = msg_system_time()
-        msg.time_unix_usec = currentStamp * 1_000
+        msg.time_unix_usec = currentStamp * 1000
         msg.time_boot_ms = currentStamp - handler.startTimestamp
         return msg
     }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ParameterController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ParameterController.kt
@@ -7,6 +7,7 @@ import com.MAVLink.common.msg_param_set
 import com.MAVLink.common.msg_param_value
 import io.getstream.log.taggedLogger
 import kotlin.math.round
+import kotlin.math.roundToInt
 import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.mavlink.MAVLinkClient
 import org.WenuLink.parameters.ParamValue
@@ -93,7 +94,7 @@ class ParameterController(
             return
         }
 
-        val value = param.spec.fromMavlink(round(paramMsg.param_value).toInt())
+        val value = param.spec.fromMavlink(paramMsg.param_value.roundToInt())
 
         param.spec.write(value) { error ->
             if (error == null) {

--- a/app/src/main/java/org/WenuLink/parameters/ArduPilotParametersProvider.kt
+++ b/app/src/main/java/org/WenuLink/parameters/ArduPilotParametersProvider.kt
@@ -25,25 +25,25 @@ object ArduPilotParametersProvider : ParameterProvider {
             cb(null)
         }
 
-        fun intParam(name: String, initial: Int) = numberParam(
+        fun intParam(name: String, initial: Int): SimpleParameter = numberParam(
             name,
             MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT32,
             SemanticType.INT
         ) { cb -> cb(values[name] ?: ParamValue.IntVal(initial)) }
 
-        fun floatParam(name: String, initial: Float) = numberParam(
+        fun floatParam(name: String, initial: Float): SimpleParameter = numberParam(
             name,
             MAV_PARAM_TYPE.MAV_PARAM_TYPE_REAL32,
             SemanticType.FLOAT
         ) { cb -> cb(values[name] ?: ParamValue.FloatVal(initial)) }
 
-        fun int8Param(name: String, initial: Int) = numberParam(
+        fun int8Param(name: String, initial: Int): SimpleParameter = numberParam(
             name,
             MAV_PARAM_TYPE.MAV_PARAM_TYPE_INT8,
             SemanticType.INT
         ) { cb -> cb(values[name] ?: ParamValue.IntVal(initial)) }
 
-        fun boolParam(name: String, initial: Boolean) = SimpleParameter(
+        fun boolParam(name: String, initial: Boolean): SimpleParameter = SimpleParameter(
             name,
             MAV_PARAM_TYPE.MAV_PARAM_TYPE_UINT8,
             SemanticType.BOOL,

--- a/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
@@ -40,7 +40,7 @@ object AircraftManager {
         (!useAirLink || (downlinkQuality != null && uplinkQuality != null))
 
     @Synchronized
-    fun isAircraftConnected(): Boolean = aircraftInstance != null
+    fun isAircraftConnected() = aircraftInstance != null
 
     fun startListeners() {
         startBatteryListeners()

--- a/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
@@ -141,7 +141,7 @@ object CameraManager {
     }
 
     @Synchronized
-    fun isConnected(): Boolean = mInstance != null
+    fun isConnected() = mInstance != null
 
     override fun toString(): String = if (isConnected()) {
         "Managing: $cameraName $frameWidth x $frameHeight @ $frameRate"
@@ -192,7 +192,7 @@ object CameraManager {
         codecManager = null
     }
 
-    fun isCodecStarted(): Boolean = codecManager != null
+    fun isCodecStarted() = codecManager != null
 
     fun registerStateCallback(callback: (SystemState) -> Unit) =
         mInstance?.setSystemStateCallback(callback)

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -67,7 +67,7 @@ object FCManager {
     }
 
     @Synchronized
-    fun isConnected(): Boolean = fcInstance != null
+    fun isConnected() = fcInstance != null
 
     override fun toString(): String {
         val isConnected = isConnected()
@@ -135,9 +135,9 @@ object FCManager {
         }
     }
 
-    fun isFlying(): Boolean = fcInstance?.state?.isFlying == true
+    fun isFlying() = fcInstance?.state?.isFlying == true
 
-    fun needLandingConfirmation(): Boolean = fcInstance?.state?.isLandingConfirmationNeeded == true
+    fun needLandingConfirmation() = fcInstance?.state?.isLandingConfirmationNeeded == true
 
     fun getAltitude(): Float = fcInstance?.state?.aircraftLocation?.altitude ?: Float.MAX_VALUE
 
@@ -147,7 +147,7 @@ object FCManager {
         // for somehow these kind of actions does not return anything, possibly is a thread issue.
         fcInstance?.confirmLanding { SDKUtils.createCompletionCallback(onResult) }
 
-    fun areMotorsArmed(): Boolean = fcInstance?.state?.areMotorsOn() == true
+    fun areMotorsArmed() = fcInstance?.state?.areMotorsOn() == true
 
     fun armMotors() {
         logger.d { "Arming motors" }

--- a/app/src/main/java/org/WenuLink/sdk/RCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/RCManager.kt
@@ -18,10 +18,10 @@ object RCManager {
     }
 
     @Synchronized
-    fun isUpdated(): Boolean = lastData != null && lastBatteryData.percentCharge != null
+    fun isUpdated() = lastData != null && lastBatteryData.percentCharge != null
 
     @Synchronized
-    fun isRCConnected(): Boolean = rcInstance != null
+    fun isRCConnected() = rcInstance != null
 
     fun startListeners() {
         startHardwareListener()

--- a/app/src/main/java/org/WenuLink/sdk/SimManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SimManager.kt
@@ -27,9 +27,9 @@ object SimManager {
         logger.i { "Simulation init" }
     }
 
-    fun isAvailable(): Boolean = simInstance != null
+    fun isAvailable() = simInstance != null
 
-    fun isActive(): Boolean = simInstance?.isSimulatorActive == true
+    fun isActive() = simInstance?.isSimulatorActive == true
 
     fun registerStateCallback(stateCallback: (SimulatorState) -> Unit) {
         if (hasCallback) unregisterStateCallback()

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -104,7 +104,7 @@ class WebRTCService {
         )
     }
 
-    fun canStartClient(): Boolean = CameraCapturer.hasCameraPresent() && isEnabled
+    fun canStartClient() = CameraCapturer.hasCameraPresent() && isEnabled
 
     fun startClient(serviceScope: CoroutineScope, context: Context) {
         if (!isEnabled) {

--- a/app/src/main/java/org/WenuLink/webrtc/peer/StreamPeerConnection.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/peer/StreamPeerConnection.kt
@@ -341,7 +341,7 @@ class StreamPeerConnection(
         logger.i { "[onSelectedCandidatePairChanged] #sfu; #$typeTag; event: $event" }
     }
 
-    override fun onDataChannel(channel: DataChannel?): Unit = Unit
+    override fun onDataChannel(channel: DataChannel?) = Unit
 
     override fun toString(): String =
         "StreamPeerConnection(type='$typeTag', constraints=$mediaConstraints)"

--- a/app/src/main/java/org/WenuLink/webrtc/utils/StringUtils.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/utils/StringUtils.kt
@@ -40,7 +40,7 @@ fun JavaAudioDeviceModule.AudioSamples.stringify(): String =
     "AudioSamples(audioFormat=$audioFormat, channelCount=$channelCount, " +
         "sampleRate=$sampleRate, data.size=${data.size})"
 
-fun StreamPeerType.stringify() = when (this) {
+fun StreamPeerType.stringify(): String = when (this) {
     StreamPeerType.PUBLISHER -> "publisher"
     StreamPeerType.SUBSCRIBER -> "subscriber"
 }


### PR DESCRIPTION
Minor style changes, no functional changes.

**Standardize use of method return types aligning with android style guide:**
Always define the return type unless it is `Unit` or very basic Boolean expression. If the method is a delegating call, always write the return type.

**Consisten use of numeric literal separators for numbers with 5 or more digits**