### PR TITLE
Fix init/shutdown sequence with split concerns

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         minSdk = 23
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.0.0-alpha"
 
         manifestPlaceholders["djiApiKey"] = localProps.getProperty("dji.api.key", "")
 

--- a/app/src/main/java/org/WenuLink/MainActivity.kt
+++ b/app/src/main/java/org/WenuLink/MainActivity.kt
@@ -124,7 +124,7 @@ class MainActivity : ComponentActivity() {
         val isSimulationReady by viewModel.isSimReady.collectAsState(false)
         val isAircraftUp by viewModel.isAircraftBoot.collectAsState(false)
         // services
-        val isDataFlowing by viewModel.telemetryStateFlow.collectAsState(false)
+        val isServiceUp by viewModel.isServiceUp.collectAsState(false)
         val isMAVLinkRunning by viewModel.isMAVLinkRunning.collectAsState(false)
         val isWebRTCRunning by viewModel.isWebRTCRunning.collectAsState(false)
         // Logs
@@ -144,9 +144,11 @@ class MainActivity : ComponentActivity() {
                 Spacer(Modifier.height(4.dp))
                 Text("SDK registered?: $isSDKOk")
                 Spacer(Modifier.height(2.dp))
-                Text("DataFlow active?: $isDataFlowing")
+                Text("Aircraft present?: $isAircraftPresent")
                 Spacer(Modifier.height(2.dp))
                 Text("Aircraft boot?: $isAircraftUp")
+                Spacer(Modifier.height(2.dp))
+                Text("Simulation ready?: $isSimulationReady")
                 Spacer(Modifier.height(2.dp))
                 Text("MAVLinkService up?: $isMAVLinkRunning")
                 Spacer(Modifier.height(2.dp))
@@ -159,20 +161,30 @@ class MainActivity : ComponentActivity() {
             if (isSDKOk && isAircraftPresent) {
                 Spacer(Modifier.height(8.dp))
                 Button(onClick = {
-                    servicesViewModel.runService(!isAircraftUp, false)
+                    servicesViewModel.loadAircraft(!isAircraftUp, false)
                 }) {
-                    Text("${buttonLabel(isAircraftUp)} WenuLink Service")
+                    Text(if (!isAircraftUp) "Connect" else "Disconnect" + " aircraft")
                 }
 
                 if (isSimulationReady && !isAircraftUp) {
+                    Spacer(Modifier.height(8.dp))
                     Button(onClick = {
-                        servicesViewModel.runService(run = true, simEnabled = true)
+                        servicesViewModel.loadAircraft(true, simEnabled = true)
                     }) {
-                        Text("Start SIM WenuLink Service")
+                        Text("Use simulation")
                     }
                 }
 
                 if (isAircraftUp) {
+                    HorizontalDivider()
+                    Button(onClick = {
+                        servicesViewModel.runService(!isServiceUp)
+                    }) {
+                        Text("${buttonLabel(isServiceUp)} WenuLink Service")
+                    }
+                }
+
+                if (isServiceUp) {
                     HorizontalDivider()
 
                     Button(onClick = {

--- a/app/src/main/java/org/WenuLink/MainActivity.kt
+++ b/app/src/main/java/org/WenuLink/MainActivity.kt
@@ -163,7 +163,7 @@ class MainActivity : ComponentActivity() {
                 Button(onClick = {
                     servicesViewModel.loadAircraft(!isAircraftUp, false)
                 }) {
-                    Text(if (!isAircraftUp) "Connect" else "Disconnect" + " aircraft")
+                    Text("${if (!isAircraftUp) "Connect" else "Disconnect"} aircraft")
                 }
 
                 if (isSimulationReady && !isAircraftUp) {

--- a/app/src/main/java/org/WenuLink/WenuLinkApp.kt
+++ b/app/src/main/java/org/WenuLink/WenuLinkApp.kt
@@ -242,7 +242,10 @@ class WenuLinkApp : Application() {
     }
 
     fun disconnectAircraft() {
+        if (connectJob?.isActive == true) return
+
         if (!::wenuLinkHandler.isInitialized) return
+
         appScope.launch {
             val shutdownResult = wenuLinkHandler.unloadComponents(false)
             if (shutdownResult.hasError) {

--- a/app/src/main/java/org/WenuLink/WenuLinkApp.kt
+++ b/app/src/main/java/org/WenuLink/WenuLinkApp.kt
@@ -13,8 +13,6 @@ import androidx.core.content.ContextCompat
 import androidx.multidex.MultiDex
 import com.cySdkyc.clx.Helper
 import io.getstream.log.AndroidStreamLogger
-import io.getstream.log.StreamLog
-import io.getstream.log.TaggedLogger
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -39,10 +37,12 @@ class WenuLinkApp : Application() {
     private var isContextAttached = false
     private var isConnectingAircraft = false
     var wenuLinkService: WenuLinkService? = null
+
     // Basic status reporting
     val isPermissionsGranted = MutableStateFlow(false)
     val workflowStatus = MutableStateFlow("Idle")
     val sdkStatus = MutableStateFlow("Idle")
+
     // SDK state handling
     val isRegistered = MutableStateFlow(false)
     val bindingString = MutableStateFlow("Idle")
@@ -207,7 +207,7 @@ class WenuLinkApp : Application() {
     private suspend fun waitComponentsAndStartHandler() {
         updateWorkflow("Waiting for components")
         val allComponentsPresent =
-            AsyncUtils.waitTimeout(100L, 30_000, APIManager::areComponentsPresent)
+            AsyncUtils.waitTimeout(100L, 30_000L, APIManager::areComponentsPresent)
 
         if (!allComponentsPresent) {
             updateWorkflow("No components found, try again...")
@@ -235,7 +235,9 @@ class WenuLinkApp : Application() {
             if (bootError == null) {
                 isAircraftBoot.value = true
                 updateWorkflow("Connected ready for service")
-            } else updateWorkflow("Boot error: $bootError")
+            } else {
+                updateWorkflow("Boot error: $bootError")
+            }
             isConnectingAircraft = false
         }
     }
@@ -245,8 +247,11 @@ class WenuLinkApp : Application() {
         appScope.launch {
             if (!::wenuLinkHandler.isInitialized) return@launch
             val shutdownError = wenuLinkHandler.unloadComponents(false)
-            if (shutdownError == null) isAircraftBoot.value = false
-            else logger.i { "Shutdown error: $shutdownError" }
+            if (shutdownError == null) {
+                isAircraftBoot.value = false
+            } else {
+                logger.i { "Shutdown error: $shutdownError" }
+            }
             wenuLinkHandler.enableSimulation(false)
         }
     }
@@ -255,9 +260,10 @@ class WenuLinkApp : Application() {
         logger.d { "onProductConnected $connected" }
         isAircraftPresent.value = connected
         if (connected) {
+            updateStatus("Aircraft present")
             initHandler()
         } else {
-            updateStatus("Aircraft disconnected")
+            updateStatus("No aircraft present")
             isSimulationReady.value = false
         }
     }

--- a/app/src/main/java/org/WenuLink/WenuLinkApp.kt
+++ b/app/src/main/java/org/WenuLink/WenuLinkApp.kt
@@ -34,10 +34,10 @@ class WenuLinkApp : Application() {
     }
     private val logger by taggedLogger(WenuLinkApp::class.java.simpleName)
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private var startingJob: Job? = null
+    private var initJob: Job? = null
+    private var connectJob: Job? = null
     private lateinit var wenuLinkHandler: WenuLinkHandler
     private var isContextAttached = false
-    private var isConnectingAircraft = false
     var wenuLinkService: WenuLinkService? = null
 
     // Basic status reporting
@@ -163,8 +163,6 @@ class WenuLinkApp : Application() {
             this::startService
         }
         startFunction(Intent(this, WenuLinkService::class.java))
-        wenuLinkService?.runServices()
-        isServiceUp.value = true
     }
 
     suspend fun stopWenulinkService() {
@@ -172,7 +170,6 @@ class WenuLinkApp : Application() {
 
         wenuLinkService?.terminate()
         stopService(Intent(this, WenuLinkService::class.java))
-        isServiceUp.value = false
     }
 
     private fun onRegistration(result: UnitResult) {
@@ -188,20 +185,20 @@ class WenuLinkApp : Application() {
     }
 
     private fun initHandler() {
-        if (startingJob != null) {
+        if (initJob != null) {
             logger.w { "Already initializing handler" }
             return
         }
 
         // Launches it
-        startingJob = appScope.launch {
+        initJob = appScope.launch {
             waitComponentsAndStartHandler()
         }
 
         // wait for termination to clear
         appScope.launch {
-            startingJob?.join()
-            startingJob = null
+            initJob?.join()
+            initJob = null
             updateWorkflow("WenuLink with ${wenuLinkHandler.aircraftModel}")
         }
     }
@@ -226,31 +223,30 @@ class WenuLinkApp : Application() {
     }
 
     fun connectAircraft(useSimulation: Boolean = false) {
-        if (isConnectingAircraft) return
-        appScope.launch {
-            if (!::wenuLinkHandler.isInitialized) return@launch
-            isConnectingAircraft = true
+        if (connectJob?.isActive == true) return
+
+        if (!::wenuLinkHandler.isInitialized) return
+
+        connectJob = appScope.launch {
             wenuLinkHandler.enableSimulation(useSimulation)
-            updateWorkflow("Connecting to Aircraft")
+            updateWorkflow("Connecting to ${wenuLinkHandler.aircraftModel}")
             // Wait Aircraft to boot
-            val bootError = wenuLinkHandler.loadComponents(appScope)
-            if (bootError is CommandResult.Failure) {
-                updateWorkflow("Boot error: $bootError.reason")
+            val bootResult = wenuLinkHandler.loadComponents(appScope)
+            if (bootResult.hasError) {
+                updateWorkflow("Boot error: ${bootResult.errorReason}")
             } else {
                 isAircraftBoot.value = true
-                updateWorkflow("Connected ready for service")
+                updateWorkflow("Connected and ready for services")
             }
-            isConnectingAircraft = false
         }
     }
 
     fun disconnectAircraft() {
-        if (isConnectingAircraft) return
+        if (!::wenuLinkHandler.isInitialized) return
         appScope.launch {
-            if (!::wenuLinkHandler.isInitialized) return@launch
-            val shutdownError = wenuLinkHandler.unloadComponents(false)
-            if (shutdownError is CommandResult.Failure) {
-                logger.i { "Shutdown error: ${shutdownError.reason}" }
+            val shutdownResult = wenuLinkHandler.unloadComponents(false)
+            if (shutdownResult.hasError) {
+                updateWorkflow("Shutdown error: ${shutdownResult.errorReason}")
             } else {
                 isAircraftBoot.value = false
             }
@@ -292,7 +288,7 @@ class WenuLinkApp : Application() {
     }
 
     fun apiDestroy() {
-        wenuLinkHandler.unload()
+        if (::wenuLinkHandler.isInitialized) wenuLinkHandler.unload()
         appScope.cancel()
         APIManager.destroy()
     }

--- a/app/src/main/java/org/WenuLink/WenuLinkApp.kt
+++ b/app/src/main/java/org/WenuLink/WenuLinkApp.kt
@@ -249,10 +249,10 @@ class WenuLinkApp : Application() {
         appScope.launch {
             if (!::wenuLinkHandler.isInitialized) return@launch
             val shutdownError = wenuLinkHandler.unloadComponents(false)
-            if (shutdownError == null) {
-                isAircraftBoot.value = false
+            if (shutdownError is CommandResult.Failure) {
+                logger.i { "Shutdown error: ${shutdownError.reason}" }
             } else {
-                logger.i { "Shutdown error: $shutdownError" }
+                isAircraftBoot.value = false
             }
             wenuLinkHandler.enableSimulation(false)
         }

--- a/app/src/main/java/org/WenuLink/WenuLinkApp.kt
+++ b/app/src/main/java/org/WenuLink/WenuLinkApp.kt
@@ -13,8 +13,16 @@ import androidx.core.content.ContextCompat
 import androidx.multidex.MultiDex
 import com.cySdkyc.clx.Helper
 import io.getstream.log.AndroidStreamLogger
+import io.getstream.log.StreamLog
+import io.getstream.log.TaggedLogger
 import io.getstream.log.taggedLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.adapters.WenuLinkService
@@ -25,20 +33,24 @@ class WenuLinkApp : Application() {
         val apiIntentAction: String get() = APIManager.getIntentAction()
     }
     private val logger by taggedLogger(WenuLinkApp::class.java.simpleName)
-
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var startingJob: Job? = null
+    private lateinit var wenuLinkHandler: WenuLinkHandler
+    private var isContextAttached = false
+    private var isConnectingAircraft = false
+    var wenuLinkService: WenuLinkService? = null
+    // Basic status reporting
+    val isPermissionsGranted = MutableStateFlow(false)
+    val workflowStatus = MutableStateFlow("Idle")
+    val sdkStatus = MutableStateFlow("Idle")
+    // SDK state handling
     val isRegistered = MutableStateFlow(false)
     val bindingString = MutableStateFlow("Idle")
     val activationString = MutableStateFlow("Idle")
     val isAircraftPresent = MutableStateFlow(false)
-    val isPermissionsGranted = MutableStateFlow(false)
-    val workflowStatus = MutableStateFlow("Idle")
-    val sdkStatus = MutableStateFlow("Idle")
     val isSimulationReady = MutableStateFlow(false)
     val isAircraftBoot = MutableStateFlow(false)
-
-    var wenuLinkService: WenuLinkService? = null
-    var wenuLinkHandler: WenuLinkHandler? = null
-    var isContextAttached: Boolean = false
+    val isServiceUp = MutableStateFlow(false)
 
     private val permissionsList by lazy {
         val permList = mutableListOf(
@@ -83,28 +95,32 @@ class WenuLinkApp : Application() {
     }
 
     private fun updateStatus(text: String) {
+        logger.i { "SDK status: $text" }
         sdkStatus.value = text
     }
 
     fun updateWorkflow(text: String) {
+        logger.i { "Workflow: $text" }
         workflowStatus.value = text
     }
 
     fun onPermissionsGranted() {
         logger.i { "All permissions granted" }
         updatePermission(true)
-        updateWorkflow("Waiting for SDK")
         apiStart()
     }
 
     fun onPermissionsDenied() {
-        logger.e { "Some permissions denied" }
+        logger.w { "Some permissions denied" }
         updatePermission(false)
         updateWorkflow("Missing permission(s), please restart the app.")
     }
 
     override fun attachBaseContext(paramContext: Context?) {
         super.attachBaseContext(paramContext)
+        // Attach logger first
+        AndroidStreamLogger.installOnDebuggableApp(this)
+        // Attach SDK
         MultiDex.install(this)
         Helper.install(this)
         isContextAttached = true
@@ -129,12 +145,15 @@ class WenuLinkApp : Application() {
         } else {
             registerReceiver(usbReceiver, filter)
         }
-
-        AndroidStreamLogger.installOnDebuggableApp(this)
     }
 
-    suspend fun launchWenulinkService() {
+    fun launchWenulinkService() {
         if (wenuLinkService != null) return
+
+        if (!wenuLinkHandler.isAircraftPowerOn) {
+            logger.w { "Unable to start, Aircraft's not ready." }
+            return
+        }
 
         val startFunction = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             this::startForegroundService
@@ -142,20 +161,16 @@ class WenuLinkApp : Application() {
             this::startService
         }
         startFunction(Intent(this, WenuLinkService::class.java))
-
-        AsyncUtils.waitReady(500L) { isAircraftBoot.value }
-
         wenuLinkService?.runServices()
+        isServiceUp.value = true
     }
 
     suspend fun stopWenulinkService() {
         if (wenuLinkService == null) return
 
         wenuLinkService?.terminate()
-        wenuLinkHandler?.enableSimulation(false) // always disable
-        stopService(
-            Intent(this, WenuLinkService::class.java)
-        )
+        stopService(Intent(this, WenuLinkService::class.java))
+        isServiceUp.value = false
     }
 
     private fun onRegistration(error: String?) {
@@ -170,14 +185,80 @@ class WenuLinkApp : Application() {
         }
     }
 
+    private fun initHandler() {
+        if (startingJob != null) {
+            logger.w { "Already initializing handler" }
+            return
+        }
+
+        // Launches it
+        startingJob = appScope.launch {
+            waitComponentsAndStartHandler()
+        }
+
+        // wait for termination to clear
+        appScope.launch {
+            startingJob?.join()
+            startingJob = null
+            updateWorkflow("WenuLink with ${wenuLinkHandler.aircraftModel}")
+        }
+    }
+
+    private suspend fun waitComponentsAndStartHandler() {
+        updateWorkflow("Waiting for components")
+        val allComponentsPresent =
+            AsyncUtils.waitTimeout(100L, 30_000, APIManager::areComponentsPresent)
+
+        if (!allComponentsPresent) {
+            updateWorkflow("No components found, try again...")
+            return
+        }
+        // check if simReady
+        isSimulationReady.value = APIManager.isSimulationAvailable
+
+        if (::wenuLinkHandler.isInitialized) return
+
+        updateWorkflow("Initializing handler")
+        wenuLinkHandler = WenuLinkHandler.getInstance()
+        wenuLinkHandler.registerScope(appScope)
+    }
+
+    fun connectAircraft(useSimulation: Boolean = false) {
+        if (isConnectingAircraft) return
+        appScope.launch {
+            if (!::wenuLinkHandler.isInitialized) return@launch
+            isConnectingAircraft = true
+            wenuLinkHandler.enableSimulation(useSimulation)
+            updateWorkflow("Connecting to Aircraft")
+            // Wait Aircraft to boot
+            val bootError = wenuLinkHandler.loadComponents(appScope)
+            if (bootError == null) {
+                isAircraftBoot.value = true
+                updateWorkflow("Connected ready for service")
+            } else updateWorkflow("Boot error: $bootError")
+            isConnectingAircraft = false
+        }
+    }
+
+    fun disconnectAircraft() {
+        if (isConnectingAircraft) return
+        appScope.launch {
+            if (!::wenuLinkHandler.isInitialized) return@launch
+            val shutdownError = wenuLinkHandler.unloadComponents(false)
+            if (shutdownError == null) isAircraftBoot.value = false
+            else logger.i { "Shutdown error: $shutdownError" }
+            wenuLinkHandler.enableSimulation(false)
+        }
+    }
+
     private fun onProductConnected(connected: Boolean) {
         logger.d { "onProductConnected $connected" }
         isAircraftPresent.value = connected
         if (connected) {
-            updateWorkflow("Initializing handler")
-            wenuLinkHandler = WenuLinkHandler.getInstance()
-            updateStatus("Connected to ${wenuLinkHandler!!.aircraftModel}.")
-            isSimulationReady.value = APIManager.isSimulationAvailable
+            initHandler()
+        } else {
+            updateStatus("Aircraft disconnected")
+            isSimulationReady.value = false
         }
     }
 
@@ -203,6 +284,8 @@ class WenuLinkApp : Application() {
     }
 
     fun apiDestroy() {
+        wenuLinkHandler.unload()
+        appScope.cancel()
         APIManager.destroy()
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -176,6 +176,8 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
             // Register listeners
             mission.registerScope(scope)
             camera.registerScope(scope)
+            // Wait for camera be initialized
+            AsyncUtils.waitTimeout(100L, 5000L) { camera.wasInitialized }
             startMonitorJob(scope)
         }
         return bootResult

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -126,6 +126,8 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
                             safetyChecks()
                         }
                     }
+                } catch (e: CancellationException) {
+                    logger.w { "Monitor loop cancelled: ${e.message}" }
                 } catch (e: Exception) {
                     logger.e { "Monitor loop error: ${e.message}" }
                     // emergency land? manual control?

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -2,6 +2,7 @@ package org.WenuLink.adapters
 
 import io.getstream.log.taggedLogger
 import kotlin.coroutines.resume
+import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
@@ -95,39 +96,44 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
 
     private fun startMonitorJob(scope: CoroutineScope) {
         monitorJob?.cancel()
-        var lastLoop = System.currentTimeMillis()
+        // tune this (100–500ms is reasonable)
+        val minimumDelay = 200L
 
         monitorJob = scope.launch {
             logger.d { "Starting monitor job" }
-            while (!aircraft.isPowerOff) try {
-                coroutineScope {
-                    // --- Sync real aircraft state ---
-                    launch {
-                        aircraft.syncState()
-                        modeHooks()
-                    }
+            var lastLoop = System.currentTimeMillis()
+            while (!aircraft.isPowerOff) {
+                try {
+                    coroutineScope {
+                        // --- Sync real aircraft state ---
+                        launch {
+                            aircraft.syncState()
+                            modeHooks()
+                        }
 
-                    launch {
-                        mission.syncState()
-                        missionHooks()
-                    }
+                        launch {
+                            mission.syncState()
+                            missionHooks()
+                        }
 
-                    launch {
-                        cameraHooks()
-                    }
+                        launch {
+                            cameraHooks()
+                        }
 
-                    launch {
-                        safetyChecks()
-                    }
-                }.join()
-            } catch (e: Exception) {
-                logger.e { "Monitor loop error: ${e.message}" }
-                // emergency land? manual control?
-            } finally {
-                delay(200L) // tune this (100–500ms is reasonable)
-                val loopTime = System.currentTimeMillis() - lastLoop
-                logger.d { "Monitor loop time: ${loopTime}ms" }
-                lastLoop = System.currentTimeMillis()
+                        launch {
+                            safetyChecks()
+                        }
+                    }.join()
+                } catch (e: Exception) {
+                    logger.e { "Monitor loop error: ${e.message}" }
+                    // emergency land? manual control?
+                } finally {
+                    // avoid delay for those cases where elapsed time > minimumDelay.
+                    val dTime = max(0, minimumDelay - (System.currentTimeMillis() - lastLoop))
+                    delay(dTime)
+                    logger.d { "Monitor loop time: ${System.currentTimeMillis() - lastLoop}ms" }
+                    lastLoop = System.currentTimeMillis()
+                }
             }
             logger.d { "Monitor job ended" }
         }
@@ -179,7 +185,8 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         camera.unload()
         onImageCaptured = null
         stopMonitor()
-        val shutdownError = dispatchAndAwait(WenuLinkCommand.Aircraft(ShutdownCommand(strictTransition)))
+        val shutdownError =
+            dispatchAndAwait(WenuLinkCommand.Aircraft(ShutdownCommand(strictTransition)))
         return shutdownError
     }
 

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -1,6 +1,7 @@
 package org.WenuLink.adapters
 
 import io.getstream.log.taggedLogger
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.resume
 import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
@@ -124,7 +125,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
                         launch {
                             safetyChecks()
                         }
-                    }.join()
+                    }
                 } catch (e: Exception) {
                     logger.e { "Monitor loop error: ${e.message}" }
                     // emergency land? manual control?

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -7,7 +7,9 @@ import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.aircraft.AircraftHandler
@@ -126,8 +128,9 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
                             safetyChecks()
                         }
                     }
-                } catch (e: CancellationException) {
-                    logger.w { "Monitor loop cancelled: ${e.message}" }
+                } catch (_: CancellationException) {
+                    logger.w { "Monitor loop CancellationException" }
+                    currentCoroutineContext().ensureActive()
                 } catch (e: Exception) {
                     logger.e { "Monitor loop error: ${e.message}" }
                     // emergency land? manual control?

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -131,7 +131,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
                     // avoid delay for those cases where elapsed time > minimumDelay.
                     val dTime = max(0, minimumDelay - (System.currentTimeMillis() - lastLoop))
                     delay(dTime)
-                    logger.d { "Monitor loop time: ${System.currentTimeMillis() - lastLoop}ms" }
+                    // logger.d { "Monitor loop time: ${System.currentTimeMillis() - lastLoop}ms" }
                     lastLoop = System.currentTimeMillis()
                 }
             }

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -4,9 +4,8 @@ import io.getstream.log.taggedLogger
 import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.aircraft.AircraftHandler
@@ -56,7 +55,6 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     val aircraftState: AircraftState get() = aircraft.state
     val aircraftModel: String get() = aircraft.telemetry.getAircraftModelName()
     val isTelemetryActive: Boolean get() = aircraft.telemetry.isActive()
-    val telemetryStateFlow: StateFlow<Boolean> get() = aircraft.telemetry.isBroadcasting
     val hasActiveJoystickInput: Boolean
         get() = aircraft.telemetry.getRCData()?.hasCenteredJoystick() == false
     val isAircraftPowerOn: Boolean get() = !aircraft.isPowerOff &&
@@ -67,19 +65,11 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
 
     override fun registerScope(scope: CoroutineScope) {
         aircraft.registerScope(scope)
-        mission.registerScope(scope)
-        camera.registerScope(scope)
-        startMonitorJob(scope)
         startCommandProcessor(scope, this@WenuLinkHandler, logger)
     }
 
     override fun unload() {
-        aircraft.dispatchCommand(ShutdownCommand(false)) {
-            // Stop monitor
-            monitorJob?.cancel()
-            monitorJob = null
-        }
-        onImageCaptured = null
+        aircraft.unload()
         super.unload()
     }
 
@@ -105,10 +95,12 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
 
     private fun startMonitorJob(scope: CoroutineScope) {
         monitorJob?.cancel()
+        var lastLoop = System.currentTimeMillis()
 
         monitorJob = scope.launch {
-            while (isActive) {
-                try {
+            logger.d { "Starting monitor job" }
+            while (!aircraft.isPowerOff) try {
+                coroutineScope {
                     // --- Sync real aircraft state ---
                     launch {
                         aircraft.syncState()
@@ -127,14 +119,25 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
                     launch {
                         safetyChecks()
                     }
-                } catch (e: Exception) {
-                    logger.e { "Guard loop error: ${e.message}" }
-                    // emergency land? manual control?
-                }
-
+                }.join()
+            } catch (e: Exception) {
+                logger.e { "Monitor loop error: ${e.message}" }
+                // emergency land? manual control?
+            } finally {
                 delay(200L) // tune this (100–500ms is reasonable)
+                val loopTime = System.currentTimeMillis() - lastLoop
+                logger.d { "Monitor loop time: ${loopTime}ms" }
+                lastLoop = System.currentTimeMillis()
             }
+            logger.d { "Monitor job ended" }
         }
+    }
+
+    private fun stopMonitor() {
+        logger.d { "Stop monitor job" }
+        // Stop monitor
+        monitorJob?.cancel()
+        monitorJob = null
     }
 
     fun dispatchCommand(cmd: WenuLinkCommand, onResult: (String?) -> Unit = {}) {
@@ -155,13 +158,29 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
             }
         }
 
-    suspend fun bootAircraft(): String? {
-        val bootError = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(10000L)))
+    suspend fun loadComponents(scope: CoroutineScope): String? {
+        // prevent cancel command when manualControl() after boot
+        dispatchControlAuthority(ControlAuthorityType.REMOTE_CONTROLLER)
+        val bootError = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(30000L)))
         if (bootError == null) {
             manualControl()
             startTimestamp = System.currentTimeMillis()
+            // Register listeners
+            mission.registerScope(scope)
+            camera.registerScope(scope)
+            startMonitorJob(scope)
         }
         return bootError
+    }
+
+    suspend fun unloadComponents(strictTransition: Boolean = false): String? {
+        stopAllCommands()
+        mission.unload()
+        camera.unload()
+        onImageCaptured = null
+        stopMonitor()
+        val shutdownError = dispatchAndAwait(WenuLinkCommand.Aircraft(ShutdownCommand(strictTransition)))
+        return shutdownError
     }
 
     fun setAuthority(authority: ControlAuthorityType): ControlAuthority {
@@ -224,13 +243,14 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     }
 
     fun missionStop() {
-        logger.d { "Stop mission" }
         when {
             controlAuthority.isWaypoint() -> mission.dispatchCommand(StopWaypointMission) { error ->
-                if (error != null) logger.i { "Unable to stop the mission: $error" }
+                if (error != null) logger.w { "Unable to stop the mission: $error" }
             }
 
-            controlAuthority.isCommand() -> mission.stopCommand()
+            controlAuthority.isCommand() -> mission.stopCommand()?.let {
+                logger.w { "Unable to stop command: $it" }
+            }
         }
     }
 
@@ -240,7 +260,6 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     }
 
     fun stopAllCommands() {
-        logger.d { "Attempting to cancel active command" }
         aircraft.stopCommand()
         missionStop()
         camera.stopCommand()

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -78,7 +78,7 @@ class WenuLinkService : Service() {
             contentText = "Sending periodic heartbeats to GCS\n"
         }
         if (::webRTC.isInitialized) {
-            contentText += "WebRTC streaming: ${webRTC.mediaOptions.videoCameraName}"
+            contentText += "WebRTC streaming"
         }
         // TODO: update according to each present service
         startForeground(

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -50,8 +50,6 @@ class WenuLinkService : Service() {
         if (MAVLinkService.isEnabled && !isMAVLinkReady()) {
             mavlink = MAVLinkService(handler)
         }
-
-        logger.i { "WenuLinkService created." }
     }
 
     private fun startForegroundServiceWithNotification() {
@@ -105,14 +103,17 @@ class WenuLinkService : Service() {
 
         // Start the foreground service if both services are initialized
         startForegroundServiceWithNotification()
-
+        runServices()
+        thisApp.isServiceUp.value = true
+        logger.i { "WenuLinkService started" }
         return START_STICKY // The service will continue running
     }
 
     override fun onDestroy() {
         thisApp.wenuLinkService = null // Clear the reference
         serviceScope.cancel()
-        logger.i { "WenuLinkService ended." }
+        thisApp.isServiceUp.value = false
+        logger.i { "WenuLinkService ended" }
         super.onDestroy()
     }
 

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -40,7 +40,6 @@ class WenuLinkService : Service() {
 
         // create the aircraft instance
         handler = WenuLinkHandler.getInstance()
-        handler.registerScope(serviceScope)
 
         // create WebRTC instance
         if (WebRTCService.isEnabled && !isWebRTCReady()) {
@@ -105,18 +104,6 @@ class WenuLinkService : Service() {
 
         // Start the foreground service if both services are initialized
         startForegroundServiceWithNotification()
-
-        // Wait Aircraft to boot
-        serviceScope.launch {
-            val bootError = handler.bootAircraft()
-            if (bootError != null) {
-                // No aircraft -> No service
-                terminate()
-                onDestroy()
-            } else {
-                thisApp.isAircraftBoot.value = true
-            }
-        }
 
         return START_STICKY // The service will continue running
     }
@@ -214,8 +201,5 @@ class WenuLinkService : Service() {
         val mavlinkStopJob = stopMAVLinkService()
         webRTCStopJob?.join()
         mavlinkStopJob?.join()
-        handler.unload()
-        AsyncUtils.waitTimeout(1000L, 20000L) { !handler.isAircraftPowerOn }
-        thisApp.isAircraftBoot.value = false
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
@@ -77,7 +77,7 @@ data class TakeoffCommand(val timeout: Long = 15_000L) : AircraftCommand {
         // TODO: check if compatible with CancellableCoroutine
         ctx.dispatchTransition(TakeoffTransition)
         ctx.takeOff()
-        val isFlying = ctx.awaitFlightState(true)
+        val isFlying = ctx.waitFlightState(true, 5_000)
 
         if (!isFlying) {
             ctx.dispatchCommand(DisarmCommand())
@@ -102,7 +102,9 @@ data class ShutdownCommand(val withTransitionCheck: Boolean = true) : AircraftCo
     override suspend fun execute(ctx: AircraftHandler): String? {
         // TODO: check if compatible with CancellableCoroutine
         if (withTransitionCheck) ctx.dispatchTransition(PowerOffTransition)
-        return ctx.shutdown()
+        ctx.shutdown()
+        ctx.dispatchTransition(InitialTransition)
+        return null
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -41,7 +41,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
             listOf(
                 ArduPilotParametersProvider,
                 DJIParametersProvider(
-                    FCManager.fcInstance ?: error("FlightController not available")
+                    FCManager.mInstance ?: error("FlightController not available")
                 )
             )
         )
@@ -86,20 +86,25 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
 
     fun dispatchTransition(transition: StateTransition) = stateMachine.dispatch(transition)
 
+    private fun syncHomePosition() {
+        if (state.isHomeSet()) return
+
+        // Check for home position
+        updateHomeCoordinatesFromAircraft()
+
+        FCManager.getHomePosition()?.let {
+            stateMachine.updateHomePosition(it)
+            logger.i { "Home Location acquired: $it" }
+        }
+    }
+
     suspend fun syncState(sensorsInterval: Long = 1000L, homeInterval: Long = 5000L) {
         if (isPowerOff) return
         val currentTimestamp = System.currentTimeMillis()
 
-        // Check for home position
-        val homePos = FCManager.getHomePosition()
         // only allow requests after homeInterval ms
         if ((currentTimestamp - homeTimestamp) >= homeInterval) {
-            if (homePos == null) {
-                val homeSet = waitHomeSet(100L)
-                if (!homeSet) logger.e { "Home Location still not set!" }
-            } else {
-                stateMachine.updateHomePosition(homePos)
-            }
+            syncHomePosition()
             homeTimestamp = currentTimestamp
         }
 
@@ -124,15 +129,14 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         enforceModeConsistency()
     }
 
-    suspend fun loadParameters(timeout: Long = 5000L): Boolean {
-        logger.i { "Waiting for parameters" }
+    private suspend fun loadParameters(timeout: Long = 5000L): Boolean {
+        logger.d { "Loading parameters" }
         parameters.load()
         return AsyncUtils.waitTimeout(timeout, 1000L, parameters::isLoaded)
     }
 
-    suspend fun sensorChecks(timeout: Long = 10000L): Boolean {
+    private suspend fun sensorChecks(timeout: Long = 10000L): Boolean {
         val perSensorTime = (timeout / 3f).roundToLong()
-        logger.i { "Waiting sensors data" }
 
         if (!AsyncUtils.waitTimeout(100L, timeout, telemetry::isReadingSensors)) {
             logger.e { "No sensor readings!" }
@@ -166,7 +170,8 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     }
 
     // check for home location and set
-    fun updateHomeCoordinatesFromAircraft(): Boolean {
+    private fun updateHomeCoordinatesFromAircraft(): Boolean {
+        if (FCManager.getHomePosition() != null) return true
         // Ask for home position
         logger.d { "Requesting home coordinates update with current aircraft's location." }
         FCManager.setHomePosition { error ->
@@ -174,27 +179,23 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
                 logger.w { "Error request: $error" }
             }
         }
-        return state.isHomeSet()
+        return FCManager.getHomePosition() != null
     }
 
-    suspend fun waitHomeSet(timeout: Long = 10000L): Boolean {
-        if (state.isHomeSet()) return true
+    suspend fun waitHomeSet(timeout: Long = 10000L): Boolean = AsyncUtils.waitTimeout(
+        100L,
+        timeout,
+        state::isHomeSet
+    )
 
-        return AsyncUtils.waitTimeout(
-            100L,
-            timeout,
-            ::updateHomeCoordinatesFromAircraft
-        )
-    }
-
-    suspend fun startTelemetry(timeout: Long = 5000L): Boolean {
+    private suspend fun startTelemetry(timeout: Long = 5000L): Boolean {
         // Start telemetry process
         telemetry.launchTelemetry(true)
         // Second wait to receive the data ready for broadcast
         return telemetry.waitDataReading(timeout)
     }
 
-    suspend fun stopTelemetry(delay: Long = 1000L): Boolean {
+    private suspend fun stopTelemetry(delay: Long = 1000L): Boolean {
         // Stop telemetry process
         telemetry.launchTelemetry(false)
         // Second wait to remove the existing data
@@ -206,10 +207,10 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         logger.d { "Aircraft booting..." }
 
         if (!loadParameters(timeout)) return "No parameters"
-        logger.d { "\tLoading parameters: OK" }
+        logger.d { "\tParameters: OK" }
 
         if (!startTelemetry(timeout)) return "No telemetry"
-        logger.d { "\tInit. telemetry: OK" }
+        logger.d { "\tTelemetry: OK" }
 
         sensorsHealthy = sensorChecks(timeout)
         logger.d { "\tSensors healthy?: $sensorsHealthy" }
@@ -222,6 +223,11 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     override fun registerScope(scope: CoroutineScope) {
         telemetry.registerScope(scope)
         startCommandProcessor(scope, this@AircraftHandler, logger)
+    }
+
+    override fun unload() {
+        telemetry.unload()
+        super.unload()
     }
 
     suspend fun shutdown(): String? {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -51,11 +51,9 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     fun requestMode(mode: ArduCopterFlightMode): UnitResult {
         if (mode == state.flightMode) return CommandResult.ok
 
-        if (!stateMachine.isModeAllowed(mode)) {
-            return CommandResult.error(
-                "Mode $mode not allowed from ${state.flightMode}"
-            )
-        }
+        val isAllowed = stateMachine.isModeAllowed(mode)
+
+        if (isAllowed is CommandResult.Failure) return isAllowed
 
         logger.d { "Mode change: ${state.flightMode} -> $mode" }
 
@@ -65,7 +63,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     }
 
     private fun enforceModeConsistency() {
-        if (!stateMachine.isModeAllowed(state.flightMode)) {
+        if (stateMachine.isModeAllowed(state.flightMode) is CommandResult.Failure) {
             stateMachine.syncArmState()
             return
         }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -153,7 +153,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return FCManager.getHomePosition() != null
     }
 
-    suspend fun waitHomeSet(timeout: Long = 10000L): Boolean = AsyncUtils.waitTimeout(
+    suspend fun waitHomeSet(timeout: Long = 10_000L): Boolean = AsyncUtils.waitTimeout(
         100L,
         timeout,
         state::isHomeSet

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -52,9 +52,11 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
 
         val isAllowed = stateMachine.isModeAllowed(mode)
 
-        if (isAllowed.hasError) return CommandResult.error(
-            "Mode $mode not allowed: ${isAllowed.errorReason}"
-        )
+        if (isAllowed.hasError) {
+            return CommandResult.error(
+                "Mode $mode not allowed: ${isAllowed.errorReason}"
+            )
+        }
 
         logger.d { "Mode change: ${state.flightMode} -> $mode" }
 
@@ -88,13 +90,13 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     fun dispatchTransition(transition: StateTransition): AircraftState =
         stateMachine.dispatch(transition)
 
-    suspend fun syncState(sensorsInterval: Long = 1000L) {
+    fun syncState(sensorsInterval: Long = 1000L) {
         if (isPowerOff) return
         val currentTimestamp = System.currentTimeMillis()
 
         // only allows check sensors after sensorsInterval ms
         if ((currentTimestamp - sensorsTimestamp) >= sensorsInterval) {
-            sensorsHealthy = sensorChecks(100L)
+            sensorsHealthy = sensorChecks()
             sensorsTimestamp = currentTimestamp
         }
 
@@ -110,7 +112,6 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         logger.w { "State reconciliation: $state -> $fcState" }
 
         stateMachine.forceSet(fcState)
-        enforceModeConsistency()
     }
 
     private suspend fun loadParameters(timeout: Long = 5000L): Boolean {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -1,7 +1,6 @@
 package org.WenuLink.adapters.aircraft
 
 import io.getstream.log.taggedLogger
-import kotlin.math.roundToLong
 import kotlinx.coroutines.CoroutineScope
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.commands.CommandHandler
@@ -98,7 +97,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         }
     }
 
-    suspend fun syncState(sensorsInterval: Long = 1000L, homeInterval: Long = 5000L) {
+    fun syncState(sensorsInterval: Long = 1000L, homeInterval: Long = 5000L) {
         if (isPowerOff) return
         val currentTimestamp = System.currentTimeMillis()
 
@@ -110,7 +109,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
 
         // only allows check sensors after sensorsInterval ms
         if ((currentTimestamp - sensorsTimestamp) >= sensorsInterval) {
-            sensorsHealthy = sensorChecks(100L) && state.isHomeSet()
+            sensorsHealthy = sensorChecks() && state.isHomeSet()
             sensorsTimestamp = currentTimestamp
         }
 
@@ -135,35 +134,21 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return AsyncUtils.waitTimeout(timeout, 1000L, parameters::isLoaded)
     }
 
-    private suspend fun sensorChecks(timeout: Long = 10000L): Boolean {
-        val perSensorTime = (timeout / 3f).roundToLong()
-
-        if (!AsyncUtils.waitTimeout(100L, timeout, telemetry::isReadingSensors)) {
+    private fun sensorChecks(): Boolean {
+        if (!telemetry.isReadingSensors()) {
             logger.e { "No sensor readings!" }
             return false
         }
 
         // https://developer.dji.com/api-reference/android-api/Components/Compass/DJICompass.html
-        val compassOk = AsyncUtils.waitTimeout(
-            100L,
-            perSensorTime,
-            telemetry::isCompassOk
-        )
+        val compassOk = telemetry.isCompassOk()
         if (!compassOk) logger.e { "Compass error!" }
 
         // https://developer.dji.com/api-reference/android-api/Components/IMUState/DJIIMUState.html
-        val accOk = AsyncUtils.waitTimeout(
-            100L,
-            perSensorTime,
-            telemetry::isAccelerometerOk
-        )
+        val accOk = telemetry.isAccelerometerOk()
         if (!accOk) logger.e { "Accelerometer error!" }
 
-        val gyroOk = AsyncUtils.waitTimeout(
-            100L,
-            perSensorTime,
-            telemetry::isGyroscopeOk
-        )
+        val gyroOk = telemetry.isGyroscopeOk()
         if (!gyroOk) logger.e { "Gyroscope error!" }
 
         return compassOk && accOk && gyroOk
@@ -212,7 +197,8 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         if (!startTelemetry(timeout)) return "No telemetry"
         logger.d { "\tTelemetry: OK" }
 
-        sensorsHealthy = sensorChecks(timeout)
+        sensorsHealthy =
+            AsyncUtils.waitTimeout(500L, timeout) { sensorChecks() } && state.isHomeSet()
         logger.d { "\tSensors healthy?: $sensorsHealthy" }
 
         logger.d { "Aircraft boot: OK" }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
@@ -186,6 +186,24 @@ object PowerOffTransition : StateTransition {
     )
 }
 
+data class FlightModeTransition(private val flightMode: ArduCopterFlightMode) : StateTransition {
+    private fun flyingMode(from: AircraftState): UnitResult = when {
+        !from.isFlying() -> CommandResult.error("Not flying")
+        else -> CommandResult.ok
+    }
+
+    // TODO: update AircraftState with an attribute for mission state an allow
+    //        ArduCopterFlightMode.AUTO -> from.isFlying() && from.isMissionRunning()
+    override fun canTransition(from: AircraftState): UnitResult = when (flightMode) {
+        ArduCopterFlightMode.LAND, ArduCopterFlightMode.RTL -> flyingMode(from)
+        else -> CommandResult.ok
+    }
+
+    override fun reduce(from: AircraftState): AircraftState = from.copy(
+        flightMode = this.flightMode
+    )
+}
+
 /**
  * Single source of truth for MAVLink + landed state transitions.
  * FSM / Reducer pattern.
@@ -198,14 +216,14 @@ class AircraftStateMachine {
 
     fun dispatch(event: StateTransition): AircraftState {
         state = event.reduce(state)
-        return state
+        return syncArmState()
     }
 
     fun forceSet(target: AircraftState) {
         state = target
     }
 
-    fun hasStateChanged(target: AircraftState): Boolean = state.mavlink != target.mavlink ||
+    fun hasStateChanged(target: AircraftState) = state.mavlink != target.mavlink ||
         state.landed != target.landed
 
     fun updateHomePosition(homeCoordinates: Coordinates3D): AircraftState {
@@ -214,27 +232,20 @@ class AircraftStateMachine {
     }
 
     fun syncArmState(): AircraftState {
-        var modeFlag = state.flightMode.baseMode
-        if (state.isArmed()) {
-            modeFlag = modeFlag or MAV_MODE_FLAG.MAV_MODE_FLAG_SAFETY_ARMED
+        val modeFlag = if (state.isArmed()) {
+            state.flightMode.baseMode or MAV_MODE_FLAG.MAV_MODE_FLAG_SAFETY_ARMED
+        } else {
+            state.flightMode.baseMode
         }
         state = state.copy(modeFlag = modeFlag)
         return state
     }
 
-    fun updateFlightMode(mode: ArduCopterFlightMode): AircraftState {
-        state = state.copy(flightMode = mode)
-        return syncArmState()
-    }
+    fun updateFlightMode(mode: ArduCopterFlightMode): AircraftState =
+        dispatch(FlightModeTransition(mode))
 
-    fun isModeAllowed(mode: ArduCopterFlightMode): Boolean = when (mode) {
-        ArduCopterFlightMode.GUIDED -> state.isFlying() || state.isStandBy()
-
-        //        ArduCopterFlightMode.AUTO -> state.isFlying() && mission.isMissionRunning
-        ArduCopterFlightMode.LAND, ArduCopterFlightMode.RTL -> state.isFlying()
-
-        else -> true
-    }
+    fun isModeAllowed(mode: ArduCopterFlightMode): UnitResult =
+        canDispatch(FlightModeTransition(mode))
 }
 
 /**

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -178,7 +178,7 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
             )
 
             FCManager.registerIMUStateCallback { imuState ->
-                logger.i { "setIMUStateCallback: ${imuState.index}" }
+                // logger.i { "setIMUStateCallback: ${imuState.index}" }
                 // The callback is executed one time per sensor, with -1 indicating the list's end
                 if (imuState.index == -1) {
                     // Publish a copy after receiving the entire list

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -65,7 +65,9 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
         logger.e { "Unable to set runSimulation=$enable, Simulation not available." }
     } else {
         if (mustRunSimulation && !enable) {
-            logger.w { "Deactivating the simulation requires to reboot the Aircraft for real aircraft connection" }
+            logger.w {
+                "Deactivating the simulation requires to reboot the Aircraft for real aircraft connection"
+            }
         }
 
         mustRunSimulation = enable

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -59,10 +59,15 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
 
     @Synchronized
     fun enableSimulation(enable: Boolean) = if (isActive()) {
+        // TODO: move to CommandResult
         logger.e { "Unable to set runSimulation=$enable, Telemetry active." }
     } else if (!isSimulationAvailable) {
         logger.e { "Unable to set runSimulation=$enable, Simulation not available." }
     } else {
+        if (mustRunSimulation && !enable) {
+            logger.w { "Deactivate simulation to reboot the Aircraft for real aircraft connection" }
+        }
+
         mustRunSimulation = enable
         logger.i { "Enable Simulation $mustRunSimulation" }
     }
@@ -100,6 +105,8 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
             registerSimState(register)
         } else {
             registerRealState(register)
+            // Sensor listeners only for real aircraft
+            registerIMUListener(register)
         }
     }
 
@@ -124,8 +131,11 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
                 attempts++
                 delay(500L)
             }
-            if (attempts < 3) logger.i { "Simulation running." }
-            else logger.e { "Unable to start simulation, 3 failed attempts. Stoping" }
+            if (attempts < 3) {
+                logger.i { "Simulation running." }
+            } else {
+                logger.e { "Unable to start simulation, 3 failed attempts. Stoping" }
+            }
         } else {
             val stopError = SimManager.stop()
             if (stopError == null) {
@@ -167,8 +177,6 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
                 MutableList(nSensors) { SensorState.BOOT }
             )
 
-            updateIMUState(state)
-
             FCManager.registerIMUStateCallback { imuState ->
                 logger.i { "setIMUStateCallback: ${imuState.index}" }
                 // The callback is executed one time per sensor, with -1 indicating the list's end
@@ -181,7 +189,6 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
                 state.gyroscope[imuState.index] = FCManager.sensorState(imuState.gyroscopeState)
                 state.accelerometer[imuState.index] =
                     FCManager.sensorState(imuState.accelerometerState)
-
             }
         } else {
             logger.d { "Stop listening IMU(s)" }
@@ -190,17 +197,21 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
         }
     }
 
-    @Synchronized
-    fun isReadingSensors() = lastIMUState.gyroscope.isNotEmpty() || mustRunSimulation
+    private fun noIMU() = FCManager.getIMUCount() == 0
 
     @Synchronized
-    fun isCompassOk() = FCManager.compassOk() || mustRunSimulation
+    fun isReadingSensors() = noIMU() || lastIMUState.gyroscope.isNotEmpty() || mustRunSimulation
 
     @Synchronized
-    fun isAccelerometerOk() =lastIMUState.accelerometer.all { it == SensorState.OK } || mustRunSimulation
+    fun isCompassOk() = noIMU() || FCManager.compassOk() || mustRunSimulation
 
     @Synchronized
-    fun isGyroscopeOk() = lastIMUState.gyroscope.all { it == SensorState.OK } || mustRunSimulation
+    fun isAccelerometerOk() = noIMU() || mustRunSimulation ||
+        lastIMUState.accelerometer.all { it == SensorState.OK }
+
+    @Synchronized
+    fun isGyroscopeOk() = noIMU() || mustRunSimulation ||
+        lastIMUState.gyroscope.all { it == SensorState.OK }
 
     fun startBroadcast() {
         if (isReadingData()) {
@@ -252,24 +263,21 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
                 }
             }
             .launchIn(scope)
-        // Sensor listeners at register since appears that cannot be removed and set again
-        registerIMUListener(true)
     }
 
     override fun unload() {
         launchTelemetry(false)
-        registerIMUListener(false)
     }
 
-    fun isReadingData(): Boolean = // RC should always exists
-        RCManager.isUpdated() &&
-            // If simulation activated, must wait for its startup
-            if (mustRunSimulation) {
-                isSimulationActive
-            } // Assumes that if not sim, Aircraft is present
-            else {
-                AircraftManager.isUpdated()
-            }
+    private fun hasAircraftData(): Boolean = // If simulation activated, must wait for its startup
+        if (mustRunSimulation) {
+            isSimulationActive
+        } // Assumes that if not sim, Aircraft is present
+        else {
+            AircraftManager.isUpdated()
+        }
+
+    fun isReadingData(): Boolean = RCManager.isUpdated() && hasAircraftData() && isReadingSensors()
 
     suspend fun waitDataReading(timeout: Long = 5000L): Boolean {
         // First check wait for listeners transfer data

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -2,6 +2,7 @@ package org.WenuLink.adapters.aircraft
 
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,7 +36,7 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
     private val _isListeningAircraft = MutableStateFlow(false)
     val isListeningAircraft: StateFlow<Boolean> = _isListeningAircraft.asStateFlow()
     private var lastTelemetryData: TelemetryData? = null
-    private var lastIMUState: IMUState? = null
+    private var lastIMUState: IMUState = IMUState()
     val isSimulationAvailable: Boolean
         get() = SimManager.isAvailable()
     val isSimulationActive: Boolean
@@ -100,8 +101,6 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
         } else {
             registerRealState(register)
         }
-        // Sensor listeners
-        registerSensorState(register)
     }
 
     fun listenRemoteController(listen: Boolean) = if (listen) {
@@ -116,59 +115,92 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
         AircraftManager.stopListeners()
     }
 
-    fun listenSimulation(listen: Boolean) {
+    suspend fun listenSimulation(listen: Boolean) {
+        var attempts = 0
         if (listen) {
-            SimManager.run { error ->
-                if (error == null) {
-                    logger.i { "Simulation running." }
-                } else {
-                    logger.e { "Unable to start simulation: $error" }
-                }
+            while (attempts < 3) {
+                val runError = SimManager.run() ?: break
+                logger.w { "Error in run simulation: $runError. Trying again" }
+                attempts++
+                delay(500L)
             }
+            if (attempts < 3) logger.i { "Simulation running." }
+            else logger.e { "Unable to start simulation, 3 failed attempts. Stoping" }
         } else {
-            SimManager.stop { error ->
-                if (error == null) {
-                    logger.i { "Simulation stopped." }
-                } else {
-                    logger.e { "Unable to stop simulation: $error" }
-                }
+            val stopError = SimManager.stop()
+            if (stopError == null) {
+                logger.i { "Simulation stopped." }
+            } else {
+                logger.e { "Unable to stop simulation: $stopError" }
             }
         }
     }
 
-    fun listenVehicleState(listen: Boolean) = if (mustRunSimulation) {
+    suspend fun listenVehicleState(listen: Boolean) = if (mustRunSimulation) {
         listenSimulation(listen)
     } else {
         listenAircraft(listen)
     }
 
-    fun registerSensorState(listen: Boolean) {
-        FCManager.unregisterIMUState() // always clear first
+    @Synchronized
+    fun updateIMUState(imuState: IMUState) {
+        lastIMUState = lastIMUState.copy(
+            gyroscope = imuState.gyroscope,
+            accelerometer = imuState.accelerometer
+        )
+    }
+
+    fun registerIMUListener(listen: Boolean) {
+        // These sensors are only reported with real Aircraft
         if (listen) {
-            FCManager.registerIMUState { imuState ->
-                updateIMUState(imuState)
+            val nSensors = FCManager.getIMUCount()
+
+            if (nSensors <= 0) {
+                logger.i { "No IMU sensor found!" }
+                return
+            }
+
+            logger.d { "Listening $nSensors IMU(s)" }
+
+            val state = IMUState(
+                MutableList(nSensors) { SensorState.BOOT },
+                MutableList(nSensors) { SensorState.BOOT }
+            )
+
+            updateIMUState(state)
+
+            FCManager.registerIMUStateCallback { imuState ->
+                logger.i { "setIMUStateCallback: ${imuState.index}" }
+                // The callback is executed one time per sensor, with -1 indicating the list's end
+                if (imuState.index == -1) {
+                    // Publish a copy after receiving the entire list
+                    updateIMUState(state)
+                    return@registerIMUStateCallback
+                }
+                // assumes same number gyros and accel
+                state.gyroscope[imuState.index] = FCManager.sensorState(imuState.gyroscopeState)
+                state.accelerometer[imuState.index] =
+                    FCManager.sensorState(imuState.accelerometerState)
+
             }
         } else {
-            updateIMUState(null)
+            logger.d { "Stop listening IMU(s)" }
+            FCManager.unregisterIMUStateCallback()
+            updateIMUState(IMUState())
         }
     }
 
     @Synchronized
-    fun isReadingSensors() = lastIMUState != null
+    fun isReadingSensors() = lastIMUState.gyroscope.isNotEmpty() || mustRunSimulation
 
     @Synchronized
-    fun updateIMUState(imuState: IMUState?) {
-        lastIMUState = imuState
-    }
+    fun isCompassOk() = FCManager.compassOk() || mustRunSimulation
 
     @Synchronized
-    fun isCompassOk() = FCManager.compassOk()
+    fun isAccelerometerOk() =lastIMUState.accelerometer.all { it == SensorState.OK } || mustRunSimulation
 
     @Synchronized
-    fun isAccelerometerOk() = lastIMUState?.accelerometer?.all { it == SensorState.OK } == true
-
-    @Synchronized
-    fun isGyroscopeOk() = lastIMUState?.gyroscope?.all { it == SensorState.OK } == true
+    fun isGyroscopeOk() = lastIMUState.gyroscope.all { it == SensorState.OK } || mustRunSimulation
 
     fun startBroadcast() {
         if (isReadingData()) {
@@ -220,10 +252,13 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
                 }
             }
             .launchIn(scope)
+        // Sensor listeners at register since appears that cannot be removed and set again
+        registerIMUListener(true)
     }
 
     override fun unload() {
-        stopBroadcast()
+        launchTelemetry(false)
+        registerIMUListener(false)
     }
 
     fun isReadingData(): Boolean = // RC should always exists

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -65,7 +65,7 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
         logger.e { "Unable to set runSimulation=$enable, Simulation not available." }
     } else {
         if (mustRunSimulation && !enable) {
-            logger.w { "Deactivate simulation to reboot the Aircraft for real aircraft connection" }
+            logger.w { "Deactivating the simulation requires to reboot the Aircraft for real aircraft connection" }
         }
 
         mustRunSimulation = enable

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
@@ -51,7 +51,9 @@ class CameraHandler : CommandHandler<CameraHandler>() {
         availableCameras.clear()
         photoSeqIndex = 0
         lastSeenCaptureCount = 0
+        _captureCount.value = 0
         wasStoringPhoto = false
+        wasInitialized = false
         super.unload()
     }
 
@@ -65,7 +67,6 @@ class CameraHandler : CommandHandler<CameraHandler>() {
     suspend fun initCameras(): Boolean {
         if (!CameraManager.isConnected()) return false
 
-        logger.d { "initCamera" }
         CameraManager.retrieveMetadata()
 
         // for now assumes a single camera, however this class should manage multi camera if must
@@ -84,7 +85,6 @@ class CameraHandler : CommandHandler<CameraHandler>() {
                     CAMERA_CAP_FLAGS.CAMERA_CAP_FLAGS_HAS_MODES.toLong()
             )
         )
-        logger.d { "availableCameras(${availableCameras.size})" }
         setMode(CAMERA_MODE.CAMERA_MODE_IMAGE, 0)
 
         logger.d { "Managing ${availableCameras.size} detected camera(s)" }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -96,7 +96,6 @@ class MissionHandler : CommandHandler<MissionHandler>() {
     @Synchronized
     fun syncState() {
         state = state.fromMissionManager()
-        logger.d { "updateMissionState: $state" }
     }
 
     @Synchronized

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
@@ -88,7 +88,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
         if (msg.msgid != msg_command_long.MAVLINK_MSG_ID_COMMAND_LONG) return
 
         val commandMsg = msg as msg_command_long
-        logger.d { "\t- COMMAND_LONG ID: ${commandMsg.command} - ${commandMsg.name()}" }
+        logger.d { "\t- COMMAND_LONG ID: ${commandMsg.command}" }
 
         if (!isTargetSystem(commandMsg.target_system.toInt())) return
 
@@ -110,7 +110,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
         if (msg.msgid != msg_command_int.MAVLINK_MSG_ID_COMMAND_INT) return
 
         val commandMsg = msg as msg_command_int
-        logger.d { "\t- COMMAND_INT ID: ${commandMsg.command} - ${commandMsg.name()}" }
+        logger.d { "\t- COMMAND_INT ID: ${commandMsg.command}" }
 
         if (!isTargetSystem(commandMsg.target_system.toInt())) return
 

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
@@ -88,7 +88,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
         if (msg.msgid != msg_command_long.MAVLINK_MSG_ID_COMMAND_LONG) return
 
         val commandMsg = msg as msg_command_long
-        logger.d { "\t- COMMAND_LONG ID: ${commandMsg.command}" }
+        logger.d { "\t- COMMAND_LONG ID: ${commandMsg.command} - ${commandMsg.name()}" }
 
         if (!isTargetSystem(commandMsg.target_system.toInt())) return
 
@@ -110,7 +110,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
         if (msg.msgid != msg_command_int.MAVLINK_MSG_ID_COMMAND_INT) return
 
         val commandMsg = msg as msg_command_int
-        logger.d { "\t- COMMAND_INT ID: ${commandMsg.command}" }
+        logger.d { "\t- COMMAND_INT ID: ${commandMsg.command} - ${commandMsg.name()}" }
 
         if (!isTargetSystem(commandMsg.target_system.toInt())) return
 
@@ -166,6 +166,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
 
     fun notifySystemReady() {
         telemetryController.startBroadcast()
+        logger.i { "Service is up an ready" }
     }
 
     fun isStationConnected(): Boolean = connectionController.isGCSPresent

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
@@ -167,7 +167,7 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
 
     fun notifySystemReady() {
         telemetryController.startBroadcast()
-        logger.i { "Service is up an ready" }
+        logger.i { "Service is up and ready" }
     }
 
     fun isStationConnected(): Boolean = connectionController.isGCSPresent

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -86,7 +86,9 @@ class MAVLinkService(handler: WenuLinkHandler) {
         createClient()
         if (!clientCanStart()) {
             onResult(
-                CommandResult.error("MAVLinkClient not ready, possibly disabled or already running.")
+                CommandResult.error(
+                    "MAVLinkClient not ready, possibly disabled or already running."
+                )
             )
             return
         }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -44,6 +44,7 @@ class CameraController(
 ) : IController {
     private val logger by taggedLogger(CameraController::class.java.simpleName)
 
+    // TODO: Unhandled COMMAND_LONG ID: 2504 MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION
     override fun processCommandLong(commandLongMsg: msg_command_long): Boolean {
         when (commandLongMsg.command) {
             MAV_CMD.MAV_CMD_REQUEST_CAMERA_INFORMATION -> handleCameraInformation(commandLongMsg)
@@ -57,6 +58,7 @@ class CameraController(
         return true
     }
 
+    // TODO: Unhandled REQUEST_LONG ID: 269 VIDEO_STREAM_INFORMATION
     override fun processRequestLong(commandLongMsg: msg_command_long): Boolean {
         val requestID = commandLongMsg.param1.toInt()
         when (requestID) {

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
@@ -152,6 +152,7 @@ class TelemetryController(
             }
 
             // create the message from controllers definitions
+            logger.i { "Creating MessageID: ${rate.messageID}" }
             val message = controllers.asSequence()
                 .mapNotNull { it.createMessage(rate.messageID) }
                 .firstOrNull()

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
@@ -212,7 +212,6 @@ class TelemetryController(
 
     @Synchronized
     fun processMessageInterval(commandMsg: msg_command_long) {
-        logger.d { "processMessageInterval" }
         val mavlinkMsgID = commandMsg.param1.toInt()
         val interval = commandMsg.param2.toLong() // already in micro seconds
         setMessageRate(mavlinkMsgID, interval)

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/TelemetryController.kt
@@ -150,9 +150,12 @@ class TelemetryController(
                 // skip if deactivated
                 continue
             }
+            if ((currentMicroTime - rate.lastUpdateStamp) <= rate.microSecondsInterval) {
+                // skip if not time-ready
+                continue
+            }
 
             // create the message from controllers definitions
-            logger.i { "Creating MessageID: ${rate.messageID}" }
             val message = controllers.asSequence()
                 .mapNotNull { it.createMessage(rate.messageID) }
                 .firstOrNull()
@@ -164,11 +167,9 @@ class TelemetryController(
                 continue
             }
 
-            // if a message is created, check if must sent and update
-            if ((currentMicroTime - rate.lastUpdateStamp) >= rate.microSecondsInterval) {
-                rate.lastUpdateStamp = currentMicroTime
-                client.sendMessage(message)
-            }
+            // send message and update timestamp
+            client.sendMessage(message)
+            rate.lastUpdateStamp = currentMicroTime
         }
     }
 

--- a/app/src/main/java/org/WenuLink/sdk/APIManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/APIManager.kt
@@ -3,6 +3,7 @@ package org.WenuLink.sdk
 import android.content.Context
 import dji.common.error.DJIError
 import dji.common.error.DJISDKError
+import dji.common.product.Model
 import dji.common.realname.AircraftBindingState
 import dji.common.realname.AircraftBindingState.AircraftBindingStateListener
 import dji.common.realname.AppActivationState
@@ -18,6 +19,7 @@ import dji.sdk.remotecontroller.RemoteController
 import dji.sdk.sdkmanager.DJISDKInitEvent
 import dji.sdk.sdkmanager.DJISDKManager
 import io.getstream.log.taggedLogger
+import org.WenuLink.adapters.AsyncUtils
 
 object APIManager {
     private val logger by taggedLogger(APIManager::class.java.simpleName)
@@ -41,6 +43,9 @@ object APIManager {
             DJISDKManager.getInstance().registerApp(context, sdkManagerCallback)
         }
     }
+
+    fun areComponentsPresent() =
+        AircraftManager.isConnected() && FCManager.isConnected() && CameraManager.isConnected()
 
     private fun setActivationCallback(callback: (Boolean, String?) -> Unit) {
         activationStateListener =
@@ -83,6 +88,23 @@ object APIManager {
         sdkManagerCallback = null
     }
 
+    private fun updateAircraftInstance(instance: BaseProduct?): Boolean {
+        logger.i { "Product present: $instance" }
+
+        return instance
+            ?.takeIf { it is Aircraft && it.model != Model.UNKNOWN_AIRCRAFT }
+            ?.also { aircraft ->
+                logger.i { "Model: ${aircraft.model}" }
+            }
+            ?.model
+            ?.let {
+                AircraftManager.init(instance as Aircraft)
+                logger.i { "Aircraft: $instance" }
+                true
+            }
+            ?: false
+    }
+
     fun registerCallbacks(
         registrationCallback: (String?) -> Unit,
         productConnectedCallback: (Boolean) -> Unit,
@@ -113,15 +135,13 @@ object APIManager {
             }
 
             override fun onProductConnect(product: BaseProduct?) {
-                product.let {
-                    if (it is Aircraft) AircraftManager.init(it)
-                }
-                productConnectedCallback(true)
+                loggerC.i { "onProductConnect()" }
+                productConnectedCallback(updateAircraftInstance(product))
             }
 
-            override fun onProductChanged(p0: BaseProduct?) {
+            override fun onProductChanged(product: BaseProduct?) {
                 loggerC.i { "onProductChanged()" }
-                productConnectedCallback(true)
+                productConnectedCallback(updateAircraftInstance(product))
             }
 
             override fun onComponentChange(

--- a/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/AircraftManager.kt
@@ -25,14 +25,17 @@ object AircraftManager {
         aircraftInstance = aircraft
         batteryInstance = aircraft.battery
         CameraManager.updateStreamID(getModel())
-        logger.i { "Aircraft connected: ${getModelName()}" }
+        logger.i { "Aircraft present: ${getModelName()}" }
     }
+
+    @Synchronized
+    fun isConnected(): Boolean = aircraftInstance != null
 
     @Synchronized
     fun initAirLink(airLink: AirLink) {
         this.airLinkInstance = airLink
         useAirLink = true
-        logger.i { "AirLink connected" }
+        logger.i { "AirLink present" }
     }
 
     @Synchronized

--- a/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
@@ -61,40 +61,6 @@ object CameraManager {
         logger.i { toString() }
     }
 
-    fun createCompletionCallback(
-        onResult: (String, Boolean) -> Unit
-    ): CommonCallbacks.CompletionCallbackWith<String> =
-        object : CommonCallbacks.CompletionCallbackWith<String> {
-            override fun onSuccess(value: String) = onResult(value, true)
-
-            override fun onFailure(p0: DJIError?) =
-                onResult(p0?.description ?: "Unknown error", false)
-        }
-
-    suspend fun retrieveFirmwareVersion(): String? = suspendCancellableCoroutine { cont ->
-        if (fwVersion != null) {
-            cont.resume(fwVersion)
-            return@suspendCancellableCoroutine
-        }
-        mInstance?.getFirmwareVersion(
-            createCompletionCallback { firmwareVersion, _ ->
-                cont.resume(firmwareVersion)
-            }
-        ) ?: cont.resume(null)
-    }
-
-    suspend fun retrieveSerialNumber(): String? = suspendCancellableCoroutine { cont ->
-        if (serialNumber != null) {
-            cont.resume(serialNumber)
-            return@suspendCancellableCoroutine
-        }
-        mInstance?.getSerialNumber(
-            createCompletionCallback { serialNumber, _ ->
-                cont.resume(serialNumber)
-            }
-        ) ?: cont.resume(null)
-    }
-
     suspend fun retrieveCameraMode(): SettingsDefinitions.CameraMode? =
         suspendCancellableCoroutine { cont ->
             mInstance?.getMode(
@@ -125,12 +91,9 @@ object CameraManager {
             ) ?: cont.resume(null)
         }
 
-    suspend fun retrieveMetadata() {
-        if (mInstance == null) return
-
-        fwVersion = retrieveFirmwareVersion()
-        serialNumber = retrieveSerialNumber()
-
+    suspend fun retrieveMetadata() = mInstance?.let { camInstance ->
+        fwVersion = SDKUtils.retrieveFirmwareVersion(camInstance)
+        serialNumber = SDKUtils.retrieveSerialNumber(camInstance)
         retrieveCameraMode()?.let { this.cameraMode = it }
         retrieveCaptureMode()?.let { this.captureMode = it }
     }

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -8,7 +8,6 @@ import dji.common.model.LocationCoordinate2D
 import dji.sdk.flightcontroller.FlightController
 import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.aircraft.Coordinates3D
-import org.WenuLink.adapters.aircraft.IMUState as AppIMUState
 import org.WenuLink.adapters.aircraft.SensorState as AppSensorState
 import org.WenuLink.adapters.aircraft.TelemetryData
 
@@ -35,15 +34,14 @@ object FCManager {
     @Synchronized
     fun isConnected(): Boolean = mInstance != null
 
-    override fun toString(): String {
-        return if (isConnected() && serialNumber != null && fwVersion != null) {
+    override fun toString(): String =
+        if (isConnected() && serialNumber != null && fwVersion != null) {
             "FlightController SN: $serialNumber - FW: $fwVersion"
         } else if (isConnected()) {
             "Reading FlightController"
         } else {
             "No FlightController"
         }
-    }
 
     fun state2Telemetry(state: FlightControllerState): TelemetryData = TelemetryData(
         roll = state.attitude.roll,
@@ -152,16 +150,16 @@ object FCManager {
 
     fun unregisterIMUStateCallback() = mInstance?.setIMUStateCallback(null)
 
-    fun compassOk(): Boolean {
-        val nSensors = mInstance?.compassCount ?: 0
+    fun getCompassCount(): Int = mInstance?.compassCount ?: 0
 
-        if (nSensors <= 0) {
+    fun compassOk(): Boolean {
+        if (getCompassCount() <= 0) {
             logger.i { "No Compass sensor found!" }
             return false
         }
 
-        val compass = mInstance?.compass
-        return compass?.hasError() != true &&
-            compass?.calibrationState == CompassCalibrationState.NOT_CALIBRATING
+        return mInstance?.compass?.let {
+            !it.hasError() && it.calibrationState == CompassCalibrationState.NOT_CALIBRATING
+        } ?: false
     }
 }

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -1,11 +1,10 @@
 package org.WenuLink.sdk
 
-import dji.common.error.DJIError
 import dji.common.flightcontroller.CompassCalibrationState
 import dji.common.flightcontroller.FlightControllerState
+import dji.common.flightcontroller.imu.IMUState
 import dji.common.flightcontroller.imu.SensorState
 import dji.common.model.LocationCoordinate2D
-import dji.common.util.CommonCallbacks
 import dji.sdk.flightcontroller.FlightController
 import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.aircraft.Coordinates3D
@@ -16,64 +15,30 @@ import org.WenuLink.adapters.aircraft.TelemetryData
 object FCManager {
     private val logger by taggedLogger(FCManager::class.java.simpleName)
 
-    var fcInstance: FlightController? = null
+    var mInstance: FlightController? = null
         private set
     private var serialNumber: String? = null
     private var fwVersion: String? = null
 
     @Synchronized
-    fun updateSerialNumber(sn: String) {
-        serialNumber = sn
-    }
-
-    @Synchronized
-    fun updateFirmwareVersion(firmware: String) {
-        fwVersion = firmware
-    }
-
-    @Synchronized
     fun init(flightController: FlightController) {
-        fcInstance = flightController
-
-        flightController.getSerialNumber(
-            object : CommonCallbacks.CompletionCallbackWith<String> {
-                override fun onSuccess(sn: String) {
-                    updateSerialNumber(sn)
-                    logger.i { "${this@FCManager}: $sn" }
-                }
-
-                override fun onFailure(error: DJIError) {
-                    logger.e { "No Serial Number obtained: $error" }
-                }
-            }
-        )
-
-        flightController.getFirmwareVersion(
-            object : CommonCallbacks.CompletionCallbackWith<String> {
-                override fun onSuccess(firmware: String) {
-                    updateFirmwareVersion(firmware)
-                    logger.i { this@FCManager.toString() }
-                }
-
-                override fun onFailure(error: DJIError) {
-                    logger.e { "No Firmware version obtained: $error" }
-                }
-            }
-        )
-
-        logger.i { "FlightController init" }
-
         SimManager.init(flightController)
+        mInstance = flightController
+        logger.i { "FlightController init" }
+    }
+
+    suspend fun retrieveMetadata() = mInstance?.let { fcInstance ->
+        fwVersion = SDKUtils.retrieveFirmwareVersion(fcInstance)
+        serialNumber = SDKUtils.retrieveSerialNumber(fcInstance)
     }
 
     @Synchronized
-    fun isConnected(): Boolean = fcInstance != null
+    fun isConnected(): Boolean = mInstance != null
 
     override fun toString(): String {
-        val isConnected = isConnected()
-        return if (isConnected && serialNumber != null && fwVersion != null) {
+        return if (isConnected() && serialNumber != null && fwVersion != null) {
             "FlightController SN: $serialNumber - FW: $fwVersion"
-        } else if (isConnected) {
+        } else if (isConnected()) {
             "Reading FlightController"
         } else {
             "No FlightController"
@@ -102,12 +67,12 @@ object FCManager {
     )
 
     fun registerStateCallback(stateCallback: (FlightControllerState) -> Unit) =
-        fcInstance?.setStateCallback(stateCallback)
+        mInstance?.setStateCallback(stateCallback)
 
-    fun unregisterStateCallback() = fcInstance?.setStateCallback(null)
+    fun unregisterStateCallback() = mInstance?.setStateCallback(null)
 
     fun getHomePosition(): Coordinates3D? {
-        val flightState = fcInstance!!.state
+        val flightState = mInstance!!.state
         if (!flightState.isHomeLocationSet) return null
 
         val homeLocation = flightState.homeLocation
@@ -124,40 +89,40 @@ object FCManager {
         onResult: (String?) -> Unit
     ) {
         if (latitude != null && longitude != null) {
-            fcInstance?.setHomeLocation(
+            mInstance?.setHomeLocation(
                 LocationCoordinate2D(latitude, longitude),
                 SDKUtils.createCompletionCallback(onResult)
             )
         } else {
-            fcInstance?.setHomeLocationUsingAircraftCurrentLocation(
+            mInstance?.setHomeLocationUsingAircraftCurrentLocation(
                 SDKUtils.createCompletionCallback(onResult)
             )
         }
     }
 
-    fun isFlying(): Boolean = fcInstance?.state?.isFlying == true
+    fun isFlying(): Boolean = mInstance?.state?.isFlying == true
 
-    fun needLandingConfirmation(): Boolean = fcInstance?.state?.isLandingConfirmationNeeded == true
+    fun needLandingConfirmation(): Boolean = mInstance?.state?.isLandingConfirmationNeeded == true
 
-    fun getAltitude(): Float = fcInstance?.state?.aircraftLocation?.altitude ?: Float.MAX_VALUE
+    fun getAltitude(): Float = mInstance?.state?.aircraftLocation?.altitude ?: Float.MAX_VALUE
 
-    fun startTakeoff() = fcInstance?.startTakeoff { }
+    fun startTakeoff() = mInstance?.startTakeoff { }
 
     fun confirmLanding(onResult: (String?) -> Unit) =
         // for somehow these kind of actions does not return anything, possibly is a thread issue.
-        fcInstance?.confirmLanding { SDKUtils.createCompletionCallback(onResult) }
+        mInstance?.confirmLanding { SDKUtils.createCompletionCallback(onResult) }
 
-    fun areMotorsArmed(): Boolean = fcInstance?.state?.areMotorsOn() == true
+    fun areMotorsArmed(): Boolean = mInstance?.state?.areMotorsOn() == true
 
     fun armMotors() {
         logger.d { "Arming motors" }
-        fcInstance?.turnOnMotors { } // ignored callback, async wait for state change
+        mInstance?.turnOnMotors { } // ignored callback, async wait for state change
     }
 
     fun disarmMotors() {
         logger.d { "Disarming motors" }
         // apparently ignores the callback and must wait for change to happen
-        fcInstance?.turnOffMotors { }
+        mInstance?.turnOffMotors { }
     }
 
     fun sensorState(sensorState: SensorState?): AppSensorState = when (sensorState) {
@@ -180,54 +145,22 @@ object FCManager {
         null -> AppSensorState.BOOT
     }
 
-    fun registerIMUState(onSensor: (AppIMUState) -> Unit) {
-        val nSensors = fcInstance?.imuCount ?: 0
-        logger.d { "Listening sensor: $nSensors IMU(s)" }
+    fun getIMUCount(): Int = mInstance?.imuCount ?: 0
 
-        if (nSensors <= 0) {
-            logger.i { "No IMU sensor found!" }
-            return
-        }
+    fun registerIMUStateCallback(stateCallback: (IMUState) -> Unit) =
+        mInstance?.setIMUStateCallback(stateCallback)
 
-        val state = AppIMUState(
-            MutableList(nSensors) { AppSensorState.BOOT },
-            MutableList(nSensors) { AppSensorState.BOOT }
-        )
-
-        fcInstance?.setIMUStateCallback { p0 ->
-            // The callback is executed one time per sensor, with -1 indicating the list's end
-            if (p0.index == -1) {
-                // Publish a copy after receiving the entire list
-                onSensor(
-                    AppIMUState().copy(
-                        gyroscope = state.gyroscope,
-                        accelerometer = state.accelerometer
-                    )
-                )
-                return@setIMUStateCallback
-            }
-
-            // assumes same number gyros and accel
-            state.gyroscope[p0.index] = sensorState(p0.gyroscopeState)
-            state.accelerometer[p0.index] = sensorState(p0.accelerometerState)
-        }
-    }
-
-    fun unregisterIMUState() {
-        logger.d { "Stop listening sensor: ${fcInstance?.imuCount} IMU(s)" }
-        fcInstance?.setIMUStateCallback(null)
-    }
+    fun unregisterIMUStateCallback() = mInstance?.setIMUStateCallback(null)
 
     fun compassOk(): Boolean {
-        val nSensors = fcInstance?.compassCount ?: 0
-        logger.d { "Reading sensor: $nSensors compasses" }
+        val nSensors = mInstance?.compassCount ?: 0
 
         if (nSensors <= 0) {
             logger.i { "No Compass sensor found!" }
             return false
         }
 
-        val compass = fcInstance?.compass
+        val compass = mInstance?.compass
         return compass?.hasError() != true &&
             compass?.calibrationState == CompassCalibrationState.NOT_CALIBRATING
     }

--- a/app/src/main/java/org/WenuLink/sdk/RCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/RCManager.kt
@@ -14,7 +14,7 @@ object RCManager {
     @Synchronized
     fun init(remoteController: RemoteController) {
         rcInstance = remoteController
-        logger.i { "Remote Controller connected" }
+        logger.i { "Remote Controller present" }
     }
 
     @Synchronized

--- a/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
@@ -6,7 +6,10 @@ package org.WenuLink.sdk
 import dji.common.error.DJIError
 import dji.common.flightcontroller.GPSSignalLevel
 import dji.common.util.CommonCallbacks
+import dji.sdk.base.BaseComponent
 import io.getstream.log.taggedLogger
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 object SDKUtils {
     private val logger by taggedLogger(SDKUtils::class.java.simpleName)
@@ -22,5 +25,33 @@ object SDKUtils {
                 logger.e { "CompletionCallback onFailure $error" }
             }
             onResult(error?.description)
+        }
+
+    fun createCompletionCallback(
+        onResult: (String, Boolean) -> Unit
+    ): CommonCallbacks.CompletionCallbackWith<String> =
+        object : CommonCallbacks.CompletionCallbackWith<String> {
+            override fun onSuccess(value: String) = onResult(value, true)
+
+            override fun onFailure(p0: DJIError?) =
+                onResult(p0?.description ?: "Unknown error", false)
+        }
+
+    suspend fun retrieveFirmwareVersion(componentInstance: BaseComponent): String? =
+        suspendCancellableCoroutine { cont ->
+            componentInstance.getFirmwareVersion(
+                createCompletionCallback { firmwareVersion, _ ->
+                    cont.resume(firmwareVersion)
+                }
+            )
+        }
+
+    suspend fun retrieveSerialNumber(componentInstance: BaseComponent): String? =
+        suspendCancellableCoroutine { cont ->
+            componentInstance.getSerialNumber(
+                createCompletionCallback { serialNumber, _ ->
+                    cont.resume(serialNumber)
+                }
+            )
         }
 }

--- a/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
@@ -8,8 +8,8 @@ import dji.common.flightcontroller.GPSSignalLevel
 import dji.common.util.CommonCallbacks
 import dji.sdk.base.BaseComponent
 import io.getstream.log.taggedLogger
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 object SDKUtils {
     private val logger by taggedLogger(SDKUtils::class.java.simpleName)

--- a/app/src/main/java/org/WenuLink/sdk/SimManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SimManager.kt
@@ -7,7 +7,9 @@ import dji.common.model.LocationCoordinate2D
 import dji.sdk.flightcontroller.FlightController
 import dji.sdk.flightcontroller.Simulator
 import io.getstream.log.taggedLogger
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.aircraft.TelemetryData
+import kotlin.coroutines.resume
 
 object SimManager {
     private val logger by taggedLogger(SimManager::class.java.simpleName)
@@ -84,17 +86,16 @@ object SimManager {
         )
     }
 
-    fun run(
+    suspend fun run(
         lat: Double = -8.066478642777481,
         long: Double = -34.98744367551871,
         alt: Float = 24f,
         updateFrequency: Int = 10,
-        satelliteCount: Int = 8,
-        onResult: (String?) -> Unit
-    ) {
+        satelliteCount: Int = 8
+    ) = suspendCancellableCoroutine { cont ->
         if (isActive()) {
-            onResult(null)
-            return
+            cont.resume(null)
+            return@suspendCancellableCoroutine
         }
         logger.d { "Simulation start." }
         this.satelliteCount = satelliteCount
@@ -107,16 +108,16 @@ object SimManager {
                 updateFrequency,
                 satelliteCount
             ),
-            SDKUtils.createCompletionCallback(onResult)
+            SDKUtils.createCompletionCallback(cont::resume)
         )
     }
 
-    fun stop(onResult: (String?) -> Unit) {
+    suspend fun stop() = suspendCancellableCoroutine { cont ->
         if (!isActive()) {
-            onResult(null)
-            return
+            cont.resume(null)
+            return@suspendCancellableCoroutine
         }
         logger.d { "Simulation stop." }
-        simInstance?.stop(SDKUtils.createCompletionCallback(onResult))
+        simInstance?.stop(SDKUtils.createCompletionCallback(cont::resume))
     }
 }

--- a/app/src/main/java/org/WenuLink/sdk/SimManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SimManager.kt
@@ -7,9 +7,9 @@ import dji.common.model.LocationCoordinate2D
 import dji.sdk.flightcontroller.FlightController
 import dji.sdk.flightcontroller.Simulator
 import io.getstream.log.taggedLogger
+import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.WenuLink.adapters.aircraft.TelemetryData
-import kotlin.coroutines.resume
 
 object SimManager {
     private val logger by taggedLogger(SimManager::class.java.simpleName)

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -15,20 +15,18 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
 
     private var thisApp = (getApplication() as WenuLinkApp)
 
+    // Basic status reporting
     val isPermissionsGranted: StateFlow<Boolean> = thisApp.isPermissionsGranted.asStateFlow()
+    val workflowStatus: StateFlow<String> = thisApp.workflowStatus.asStateFlow()
+    val sdkStatus: StateFlow<String> = thisApp.sdkStatus.asStateFlow()
+    // SDK related reporting
     val isRegistered: StateFlow<Boolean> = thisApp.isRegistered.asStateFlow()
-    val isAircraftPresent: StateFlow<Boolean> = thisApp.isAircraftPresent.asStateFlow()
-
 //    val bindingString: StateFlow<String> = thisApp.bindingString.asStateFlow()
 //    val activationString: StateFlow<String> = thisApp.activationString.asStateFlow()
-    val sdkStatus: StateFlow<String> = thisApp.sdkStatus.asStateFlow()
-    val workflowStatus: StateFlow<String> = thisApp.workflowStatus.asStateFlow()
+    val isAircraftPresent: StateFlow<Boolean> = thisApp.isAircraftPresent.asStateFlow()
     val isSimReady: StateFlow<Boolean> = thisApp.isSimulationReady.asStateFlow()
     val isAircraftBoot: StateFlow<Boolean> = thisApp.isAircraftBoot.asStateFlow()
-
-    // To expose the StateFlow for Telemetry
-    val telemetryStateFlow: StateFlow<Boolean>
-        get() = thisApp.wenuLinkHandler?.telemetryStateFlow ?: MutableStateFlow(false)
+    val isServiceUp: StateFlow<Boolean> = thisApp.isServiceUp.asStateFlow()
 
     // To expose the StateFlow for MAVLink
     val isMAVLinkRunning: StateFlow<Boolean>
@@ -70,17 +68,22 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    fun runService(run: Boolean, simEnabled: Boolean = false) {
+    fun runService(run: Boolean) = viewModelScope.launch {
         logger.d { "runService($run)" }
-        viewModelScope.launch {
-            if (simEnabled) thisApp.wenuLinkHandler?.enableSimulation(true)
-            if (run) {
-                // Launch and wait for state update
-                thisApp.launchWenulinkService()
-            } else {
-                // Stop services and wait for shutdown
-                thisApp.stopWenulinkService()
-            }
+        if (run) {
+            // Launch and wait for state update
+            thisApp.launchWenulinkService()
+        } else {
+            // Stop services and wait for shutdown
+            thisApp.stopWenulinkService()
+        }
+    }
+
+    fun loadAircraft(load: Boolean, simEnabled: Boolean = false) = viewModelScope.launch {
+        if (load) {
+            thisApp.connectAircraft(simEnabled)
+        } else {
+            thisApp.disconnectAircraft()
         }
     }
 }

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -19,10 +19,9 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
     val isPermissionsGranted: StateFlow<Boolean> = thisApp.isPermissionsGranted.asStateFlow()
     val workflowStatus: StateFlow<String> = thisApp.workflowStatus.asStateFlow()
     val sdkStatus: StateFlow<String> = thisApp.sdkStatus.asStateFlow()
+
     // SDK related reporting
     val isRegistered: StateFlow<Boolean> = thisApp.isRegistered.asStateFlow()
-//    val bindingString: StateFlow<String> = thisApp.bindingString.asStateFlow()
-//    val activationString: StateFlow<String> = thisApp.activationString.asStateFlow()
     val isAircraftPresent: StateFlow<Boolean> = thisApp.isAircraftPresent.asStateFlow()
     val isSimReady: StateFlow<Boolean> = thisApp.isSimulationReady.asStateFlow()
     val isAircraftBoot: StateFlow<Boolean> = thisApp.isAircraftBoot.asStateFlow()

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -84,7 +84,11 @@ class WebRTCService {
 
     // getting front camera
     private val videoCapturer: VideoCapturer by lazy { CameraCapturer() }
-    lateinit var mediaOptions: CameraCapturer.MediaMetadata
+    private val mediaOptions: CameraCapturer.MediaMetadata by lazy {
+        CameraCapturer.MediaMetadata.fromCameraManager() ?: error(
+            "CameraManager not ready, cannot start WebRTC"
+        )
+    }
     private var offer: String? = null
 
     fun updateServerAddress(serverAddress: String) {
@@ -109,11 +113,6 @@ class WebRTCService {
     fun startClient(serviceScope: CoroutineScope, context: Context) {
         if (!isEnabled) {
             logger.i { "Unable to start client, WebRTC not enabled." }
-            return
-        }
-
-        mediaOptions = CameraCapturer.MediaMetadata.fromCameraManager() ?: run {
-            logger.e { "CameraManager not ready, cannot start WebRTC" }
             return
         }
 


### PR DESCRIPTION
Closes #46

The following changes move the `AircraftHandler` init/shutdown (I/S) sequence from `WenuLinkService` to `WenuLinkApp`, making now the application layer responsible of the start and finish contract with the SDK. In such way, a proper initialization is first made before consume the API features for different components, for example #47 appears to also be solved here. Nevertheless, I did not ran such test. This PR was only focused to the `AircraftHandler` I/S sequence. Another PR will be opened for other issues.

Addressed changes were mostly required to fit the I/S of the command pattern into a suitable way. Additionally, the `monitorJob` was also updated to ensure loops of desired `ms` and to perform non-suspendable sensor checks seems as an async method, is not required anymore.

One change that can be addressed in a near future is the moment where enforce or continuously ask for home position, maybe on the `TakeOffCommand` is a good place instead of iteratively check if was set.