### PR TITLE
GPS fix type mapping and Message Construction

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkUtils.kt
@@ -59,16 +59,14 @@ object MessageUtils {
         messageID: Int,
         result: Int = MAV_RESULT.MAV_RESULT_UNSUPPORTED,
         progress: Int = -1
-    ): MAVLinkMessage {
-        val msg = msg_command_ack()
-        msg.command = messageID
+    ): MAVLinkMessage = msg_command_ack().apply {
+        command = messageID
         if (progress > -1) {
-            msg.result = MAV_RESULT.MAV_RESULT_IN_PROGRESS.toShort()
-            msg.progress = progress.toShort()
+            this.result = MAV_RESULT.MAV_RESULT_IN_PROGRESS.toShort()
+            this.progress = progress.toShort()
         } else {
-            msg.result = result.toShort()
+            this.result = result.toShort()
         }
-        return msg
     }
 
     fun msgRequestAck(

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -1,5 +1,7 @@
 package org.WenuLink.adapters.aircraft
 
+import com.MAVLink.enums.GPS_FIX_TYPE
+import dji.common.flightcontroller.GPSSignalLevel
 import dji.common.remotecontroller.HardwareState.FlightModeSwitch
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
@@ -28,10 +30,9 @@ data class TelemetryData(
     val isFlying: Boolean,
     val motorsOn: Boolean,
     val satelliteCount: Int,
-    // DJI reports signal quality on a scale of 1-11
-    // Mavlink has separate codes for fix type.
-    val gpsLevel: List<Boolean>,
-    val gpsFixType: Int = 0
+    // DJI reports signal quality on a scale of 0-10 and None
+    // Mavlink has fix types from 0-8.
+    val gpsFixType: Int
 )
 
 data class MAVLinkTelemetryData(
@@ -186,6 +187,29 @@ object BatteryMapper {
             voltagesBattery = source.voltage ?: UNKNOWN_INT,
             currentBatteryRaw = source.current?.toShort() ?: UNKNOWN_INT.toShort()
         )
+    }
+}
+
+object GPSMapper {
+
+    /** DJI reports signal quality as level 0-11 and None; mapped to Mavlink 0-8 fix types. */
+    fun toMavlinkFixType(level: GPSSignalLevel): Int = when (level) {
+        GPSSignalLevel.LEVEL_0,
+        GPSSignalLevel.LEVEL_1 -> GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX
+
+        GPSSignalLevel.LEVEL_2 -> GPS_FIX_TYPE.GPS_FIX_TYPE_2D_FIX
+
+        GPSSignalLevel.LEVEL_3,
+        GPSSignalLevel.LEVEL_4,
+        GPSSignalLevel.LEVEL_5 -> GPS_FIX_TYPE.GPS_FIX_TYPE_3D_FIX
+
+        GPSSignalLevel.LEVEL_6, // TODO: Pick a fix type for 6 and above
+        GPSSignalLevel.LEVEL_7,
+        GPSSignalLevel.LEVEL_8,
+        GPSSignalLevel.LEVEL_9,
+        GPSSignalLevel.LEVEL_10 -> GPS_FIX_TYPE.GPS_FIX_TYPE_DGPS
+
+        GPSSignalLevel.NONE -> GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX
     }
 }
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -91,11 +91,12 @@ class CameraController(
         sendRequestAck(MAV_RESULT.MAV_RESULT_ACCEPTED)
         handler.availableCameras.forEach {
             // Append boot time before send
-            val msg = msgCameraInformation(it).apply {
-                time_boot_ms = handler.systemBootTime
-            }
-            logger.d { "CameraReport: $msg" }
-            client.sendMessage(msg)
+            client.sendMessage(
+                msgCameraInformation(it).apply {
+                    logger.d { "CameraReport: $this" }
+                    time_boot_ms = handler.systemBootTime
+                }
+            )
         }
     }
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -31,6 +31,16 @@ class CommandController(override var client: MAVLinkClient, override val handler
     IController {
     private val logger by taggedLogger(CommandController::class.java.simpleName)
 
+    private val autopilotCapabilities = listOf(
+        MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_MISSION_INT,
+        MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_COMMAND_INT,
+        MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET,
+        MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED,
+        MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT,
+        MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION,
+        MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_MAVLINK2
+    ).fold(0L) { acc, value -> acc or value.toLong() }
+
     override fun processMessage(msg: MAVLinkMessage): Boolean {
         when (msg.msgid) {
             msg_autopilot_version.MAVLINK_MSG_ID_AUTOPILOT_VERSION -> sendAutopilotAck()
@@ -78,29 +88,20 @@ class CommandController(override var client: MAVLinkClient, override val handler
         MAV_RESULT.MAV_RESULT_ACCEPTED
     )
 
-    fun sendAutopilotVersion() {
-        val msg = msg_autopilot_version()
-        msg.capabilities = listOf(
-            MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_MISSION_INT,
-            MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_COMMAND_INT,
-            MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET,
-            MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED,
-            MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT,
-            MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION,
-            MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_MAVLINK2
-        ).fold(0L) { acc, value -> acc or value.toLong() }
-
-        msg.flight_sw_version = MessageUtils.packVersion(
-            4,
-            18,
-            23,
-            FIRMWARE_VERSION_TYPE.FIRMWARE_VERSION_TYPE_DEV
-        ) // Match SDK version
-        // TODO: Identify SDK and Aircraft too
-        msg.os_sw_version = 0 // Possibly Android version
-        msg.middleware_sw_version = 0 // Possibly WenuLink version
-        client.sendMessage(msg)
-    }
+    fun sendAutopilotVersion() = client.sendMessage(
+        msg_autopilot_version().apply {
+            capabilities = autopilotCapabilities
+            flight_sw_version = MessageUtils.packVersion(
+                4,
+                18,
+                23,
+                FIRMWARE_VERSION_TYPE.FIRMWARE_VERSION_TYPE_DEV
+            ) // Match SDK version
+            // TODO: Identify SDK and Aircraft too
+            os_sw_version = 0 // Possibly Android version
+            middleware_sw_version = 0 // Possibly WenuLink version
+        }
+    )
 
     fun setMode(commandMsg: msg_command_long) {
         val requestedMode = commandMsg.param2.toLong()

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
@@ -118,10 +118,8 @@ class ConnectionController(
         gcsLastTimestamp = System.currentTimeMillis()
     }
 
-    fun msgTimeSync(): MAVLinkMessage {
-        val msg = msg_timesync()
-        msg.tc1 = MessageUtils.getMicroTime()
-        return msg
+    fun msgTimeSync(): MAVLinkMessage = msg_timesync().apply {
+        tc1 = MessageUtils.getMicroTime()
     }
 
     fun processTimeSync(msg: MAVLinkMessage) {
@@ -132,145 +130,128 @@ class ConnectionController(
         client.sendMessage(outMsg)
     }
 
-    fun msgSystemTime(): MAVLinkMessage {
+    fun msgSystemTime(): MAVLinkMessage = msg_system_time().apply {
         val currentStamp = System.currentTimeMillis()
-        val msg = msg_system_time()
-        msg.time_unix_usec = currentStamp * 1000
-        msg.time_boot_ms = currentStamp - handler.startTimestamp
-        return msg
+        time_unix_usec = currentStamp * 1000
+        time_boot_ms = currentStamp - handler.startTimestamp
     }
 
     fun processSystemTime(msg: MAVLinkMessage) = client.sendMessage(msgSystemTime())
 
-    fun msgHeartbeat(): MAVLinkMessage {
-        val heartbeat = msg_heartbeat()
-        heartbeat.type = MAV_TYPE.MAV_TYPE_QUADROTOR.toShort()
-        heartbeat.autopilot = MAV_AUTOPILOT.MAV_AUTOPILOT_ARDUPILOTMEGA.toShort()
-        heartbeat.system_status = handler.aircraftState.mavlink.toShort()
-        heartbeat.mavlink_version = 3
+    fun msgHeartbeat(): MAVLinkMessage = msg_heartbeat().apply {
+        type = MAV_TYPE.MAV_TYPE_QUADROTOR.toShort()
+        autopilot = MAV_AUTOPILOT.MAV_AUTOPILOT_ARDUPILOTMEGA.toShort()
+        system_status = handler.aircraftState.mavlink.toShort()
+        mavlink_version = 3
         // mode definition
         // For base mode logic, see Copter::sendHeartBeat() in ArduCopter/GCS_Mavlink.cpp
-        heartbeat.base_mode = handler.aircraftState.modeFlag.toShort()
-        heartbeat.custom_mode = handler.aircraftState.flightMode.mode
-        return heartbeat
+        base_mode = handler.aircraftState.modeFlag.toShort()
+        custom_mode = handler.aircraftState.flightMode.mode
     }
 
-    fun msgSysStatus(): MAVLinkMessage {
+    fun msgSysStatus(): MAVLinkMessage = msg_sys_status().apply {
         val battery = BatteryMapper.toMavlink(handler.aircraft.telemetry.getAircraftBattery())
-        val msg = msg_sys_status()
 
 //        if (!aircraft.preArmCheckOk) sensorsHealth = sensorsHealth and
 //                MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_PREARM_CHECK.inv()
 
-        msg.onboard_control_sensors_present = sensorsPresent.toLong()
-        msg.onboard_control_sensors_enabled = sensorsEnabled.toLong()
-        msg.onboard_control_sensors_health = sensorsHealth.toLong()
+        onboard_control_sensors_present = sensorsPresent.toLong()
+        onboard_control_sensors_enabled = sensorsEnabled.toLong()
+        onboard_control_sensors_health = sensorsHealth.toLong()
 
-        msg.battery_remaining = battery.batteryRemaining
-        msg.voltage_battery = battery.voltagesBattery
-        msg.current_battery = battery.currentBatteryRaw
+        battery_remaining = battery.batteryRemaining
+        voltage_battery = battery.voltagesBattery
+        current_battery = battery.currentBatteryRaw
 //        client.sendMessage(msg)
-        return msg
     }
 
-    fun msgAttitude(): MAVLinkMessage? {
+    fun msgAttitude(): MAVLinkMessage? = msg_attitude().apply {
         val telemetryData = handler.aircraft.telemetry.getData() ?: return null
-
-        val msg = msg_attitude()
         // TODO: this next line causes an exception
         // msg.time_boot_ms = getTimestampMilliseconds();
-        msg.roll = (telemetryData.roll * Math.PI / 180).toFloat()
-        msg.pitch = (telemetryData.pitch * Math.PI / 180).toFloat()
-        msg.yaw = (telemetryData.yaw * Math.PI / 180).toFloat()
-        // TODO msg.rollspeed = 0;
-        // TODO msg.pitchspeed = 0;
-        // TODO msg.yawspeed = 0;
+        roll = (telemetryData.roll * Math.PI / 180).toFloat()
+        pitch = (telemetryData.pitch * Math.PI / 180).toFloat()
+        yaw = (telemetryData.yaw * Math.PI / 180).toFloat()
+        // TODO rollspeed = 0;
+        // TODO pitchspeed = 0;
+        // TODO yawspeed = 0;
 //        client.sendMessage(msg)
-        return msg
     }
 
-    fun msgAltitude(): MAVLinkMessage? {
+    fun msgAltitude(): MAVLinkMessage? = msg_altitude().apply {
         val data = handler.aircraft.telemetry.getData() ?: return null
-        val msg = msg_altitude()
-        msg.altitude_relative = data.altitude
+
+        altitude_relative = data.altitude
 //        client.sendMessage(msg)
-        return msg
     }
 
-    fun msgVibration(): MAVLinkMessage {
-//        client.sendMessage(msg_vibration())
-        return msg_vibration()
-    }
+    fun msgVibration(): MAVLinkMessage = // client.sendMessage(msg_vibration())
+        msg_vibration()
 
-    fun msgHUD(): MAVLinkMessage? {
+    fun msgHUD(): MAVLinkMessage? = msg_vfr_hud().apply {
         val telemetryData = handler.aircraft.telemetry.getData() ?: return null
         val rcData = handler.aircraft.telemetry.getRCData()?.toMAVLink() ?: return null
-        val msg = msg_vfr_hud()
+
         // Mavlink: Current airspeed in m/s
         // DJI: unclear whether getState() returns airspeed or groundspeed
-        msg.airspeed = sqrt(
+        airspeed = sqrt(
             telemetryData.velocityX * telemetryData.velocityX +
                 telemetryData.velocityY * telemetryData.velocityY
         )
         // Mavlink: Current ground speed in m/s. For now, just echoing airspeed.
-        msg.groundspeed = msg.airspeed
+        groundspeed = airspeed
         // yaw angle
         var heading = telemetryData.yaw
         if (heading < 0) heading += 360
-        msg.heading = heading.toInt().toShort()
+        this.heading = heading.toInt().toShort()
         // vertical info
-        msg.throttle = rcData.throttleSetting
-        msg.alt = -telemetryData.altitude
+        throttle = rcData.throttleSetting
+        alt = -telemetryData.altitude
         // Mavlink: Current climb rate in meters/second
         // DJI: m/s, positive values down
-        msg.climb = -telemetryData.velocityZ
-        return msg
+        climb = -telemetryData.velocityZ
     }
 
-    fun msgRadioStatus(): MAVLinkMessage {
+    fun msgRadioStatus(): MAVLinkMessage = msg_radio_status().apply {
         val airlinkSignal = handler.aircraft.telemetry.getAirlinkSignal()
-        val msg = msg_radio_status()
         // DJI represent the signal quality in percent with range [0, 100], where 100 is the best
         // quality. MAVLink uses [0, 254] as uint8_t
 
         // AirLink's DownLinkSignalQuality
-        msg.rssi = airlinkSignal.downlink?.let { ((it / 100f) * 255f).roundToInt().toShort() }
+        rssi = airlinkSignal.downlink
+            ?.let { ((it / 100f) * 255f).roundToInt().toShort() }
             ?: Short.MAX_VALUE
+
         // AirLink's UpLinkSignalQuality
-        msg.remrssi = airlinkSignal.uplink?.let { ((it / 100f) * 255f).roundToInt().toShort() }
+        remrssi = airlinkSignal.uplink
+            ?.let { ((it / 100f) * 255f).roundToInt().toShort() }
             ?: Short.MAX_VALUE
-        return msg
     }
 
     fun msgPowerStatus(): MAVLinkMessage = msg_power_status()
 
-    fun msgBatteryStatus(): MAVLinkMessage {
+    fun msgBatteryStatus(): MAVLinkMessage = msg_battery_status().apply {
         val battery = BatteryMapper.toMavlink(handler.aircraft.telemetry.getAircraftBattery())
-        val msg = msg_battery_status()
-        msg.current_consumed = battery.currentConsumed
-        msg.temperature = battery.temperature
-        msg.voltages = battery.voltages.toIntArray()
-        msg.battery_remaining = battery.batteryRemaining
-        msg.current_battery = battery.currentBattery
+
+        current_consumed = battery.currentConsumed
+        temperature = battery.temperature
+        voltages = battery.voltages.toIntArray()
+        battery_remaining = battery.batteryRemaining
+        current_battery = battery.currentBattery
 //        client.sendMessage(msg)
-        return msg
     }
 
-    fun msgExtendedSys(): MAVLinkMessage {
-        val msg = msg_extended_sys_state()
-        msg.landed_state = handler.aircraftState.landed.toShort()
-        msg.vtol_state = MAV_VTOL_STATE.MAV_VTOL_STATE_MC.toShort()
-        return msg
+    fun msgExtendedSys(): MAVLinkMessage = msg_extended_sys_state().apply {
+        landed_state = handler.aircraftState.landed.toShort()
+        vtol_state = MAV_VTOL_STATE.MAV_VTOL_STATE_MC.toShort()
     }
 
-    fun msgMagCal(): MAVLinkMessage {
-        val msg = msg_mag_cal_report()
-        msg.compass_id = 1
-        msg.cal_mask = 1
-        msg.cal_status = MAG_CAL_STATUS.MAG_CAL_SUCCESS.toShort()
-        msg.old_orientation = MAV_SENSOR_ORIENTATION.MAV_SENSOR_ROTATION_NONE.toShort()
-        msg.new_orientation = MAV_SENSOR_ORIENTATION.MAV_SENSOR_ROTATION_NONE.toShort()
-        msg.autosaved = 1
-        return msg
+    fun msgMagCal(): MAVLinkMessage = msg_mag_cal_report().apply {
+        compass_id = 1
+        cal_mask = 1
+        cal_status = MAG_CAL_STATUS.MAG_CAL_SUCCESS.toShort()
+        old_orientation = MAV_SENSOR_ORIENTATION.MAV_SENSOR_ROTATION_NONE.toShort()
+        new_orientation = MAV_SENSOR_ORIENTATION.MAV_SENSOR_ROTATION_NONE.toShort()
+        autosaved = 1
     }
 }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
@@ -185,8 +185,8 @@ class ConnectionController(
 //        client.sendMessage(msg)
     }
 
-    fun msgVibration(): MAVLinkMessage = // client.sendMessage(msg_vibration())
-        msg_vibration()
+    // client.sendMessage(msg_vibration())
+    fun msgVibration(): MAVLinkMessage = msg_vibration()
 
     fun msgHUD(): MAVLinkMessage? = msg_vfr_hud().apply {
         val telemetryData = handler.aircraft.telemetry.getData() ?: return null

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -357,20 +357,11 @@ class NavigationController(
             return@apply
         }
 
-        val gpsLevel = telemetryData.gpsLevel.indexOfFirst { it }
-
         time_usec = MessageUtils.getMicroTime()
         lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
         lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
         satellites_visible = telemetryData.satelliteCount.toShort()
-
-        // DJI reports signal quality as a level 0-11; mapped to Mavlink  fix types below.
-        fix_type = when (gpsLevel) {
-            0, 1 -> GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX.toShort()
-            2 -> GPS_FIX_TYPE.GPS_FIX_TYPE_2D_FIX.toShort()
-            3, 4, 5 -> GPS_FIX_TYPE.GPS_FIX_TYPE_3D_FIX.toShort()
-            else -> GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX.toShort()
-        }
+        fix_type = telemetryData.gpsFixType.toShort()
     }
 
     fun msgLocalPositionNed(): MAVLinkMessage? = msg_local_position_ned().apply {

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -353,7 +353,7 @@ class NavigationController(
         val telemetryData = handler.aircraft.telemetry.getData() ?: return null
 
         if (handler.aircraft.telemetry.isSimulationActive) {
-            fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_NO_GPS.toShort()
+            fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_2D_FIX.toShort()
             return@apply
         }
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -134,12 +134,12 @@ class NavigationController(
         )
     }
 
-    fun sendAckAnswer(type: Int) {
-        val msg = msg_mission_ack()
-        msg.type = type.toShort()
-        msg.opaque_id = handler.mission.state.id.toLong()
-        client.sendMessage(msg)
-    }
+    fun sendAckAnswer(type: Int) = client.sendMessage(
+        msg_mission_ack().apply {
+            this.type = type.toShort()
+            opaque_id = handler.mission.state.id.toLong()
+        }
+    )
 
     fun processAck(msg: MAVLinkMessage) {
         val ackMsg = msg as msg_mission_ack
@@ -147,14 +147,14 @@ class NavigationController(
         logger.d { "ACK type: ${ackMsg.type} missionType ${ackMsg.mission_type}" }
     }
 
-    fun sendMissionCount() {
-        val msg = msg_mission_count()
-        msg.mission_type = MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION.toShort()
-        msg.count = handler.mission.state.totalNodes()
-        msg.opaque_id = handler.mission.state.id.toLong()
-        logger.d { "sendMissionCount: ${msg.count}" }
-        client.sendMessage(msg)
-    }
+    fun sendMissionCount() = client.sendMessage(
+        msg_mission_count().apply {
+            logger.d { "sendMissionCount: $count" }
+            mission_type = MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION.toShort()
+            count = handler.mission.state.totalNodes()
+            opaque_id = handler.mission.state.id.toLong()
+        }
+    )
 
     fun sendMissionItem(msg: MAVLinkMessage) {
         val itemMsg = msg as msg_mission_request_int
@@ -171,13 +171,13 @@ class NavigationController(
         sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED)
     }
 
-    fun requestMissionItem(seq: Int) {
-        logger.d { "requestMissionItem #$seq" }
-        val msg = msg_mission_request_int()
-        msg.seq = seq
-        msg.mission_type = MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION.toShort()
-        client.sendMessage(msg)
-    }
+    fun requestMissionItem(seq: Int) = client.sendMessage(
+        msg_mission_request_int().apply {
+            logger.d { "requestMissionItem #$seq" }
+            this.seq = seq
+            mission_type = MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION.toShort()
+        }
+    )
 
     fun createNewMission(msg: MAVLinkMessage) {
         logger.d { "createNewMission" }
@@ -198,12 +198,12 @@ class NavigationController(
         }
     }
 
-    fun ackReceivedItem(sequence: Int) {
-        logger.d { "ackReceivedItem #$sequence" }
-        val msg = msg_mission_item_reached()
-        msg.seq = sequence
-        client.sendMessage(msg)
-    }
+    fun ackReceivedItem(sequence: Int) = client.sendMessage(
+        msg_mission_item_reached().apply {
+            logger.d { "ackReceivedItem #$sequence" }
+            seq = sequence
+        }
+    )
 
     fun processMissionItem(msg: MAVLinkMessage) {
         logger.d { "processMissionItem" }
@@ -243,20 +243,20 @@ class NavigationController(
         }
     }
 
-    fun sendMissionCurrent(sequence: Int) {
-        logger.d { "sendCurrentMission" }
-        val msg = msgMissionCurrent()
-        msg.seq = sequence
-        client.sendMessage(msg)
-    }
+    fun sendMissionCurrent(sequence: Int) = client.sendMessage(
+        msgMissionCurrent().apply {
+            logger.d { "sendCurrentMission" }
+            seq = sequence
+        }
+    )
 
-    fun sendStatusText(error: String, severity: Int) {
-        logger.d { "sendStatusText" }
-        val msg = msg_statustext()
-        msg.text = error.toByteArray()
-        msg.severity = severity.toShort()
-        client.sendMessage(msg)
-    }
+    fun sendStatusText(error: String, severity: Int) = client.sendMessage(
+        msg_statustext().apply {
+            logger.d { "sendStatusText" }
+            text = error.toByteArray()
+            this.severity = severity.toShort()
+        }
+    )
 
     fun missionStart(commandLongMsg: msg_command_long) {
         // TODO: Process init seq to custom first handler.mission element
@@ -268,6 +268,7 @@ class NavigationController(
                 )
             )
         )
+
         client.sendMessage(
             MessageUtils.msgCommandAck(
                 MAV_CMD.MAV_CMD_MISSION_START,
@@ -311,96 +312,85 @@ class NavigationController(
 //        }
 //    }
 
-    fun msgMissionCurrent(): msg_mission_current {
-        val msg = msg_mission_current()
-        msg.seq = handler.mission.state.currentSequence ?: 0
-        msg.mission_id = handler.mission.state.id.toLong()
-        msg.mission_state = handler.mission.state.mavlink.toShort()
-        return msg
+    fun msgMissionCurrent(): msg_mission_current = msg_mission_current().apply {
+        seq = handler.mission.state.currentSequence ?: 0
+        mission_id = handler.mission.state.id.toLong()
+        mission_state = handler.mission.state.mavlink.toShort()
     }
 
     // TODO: start, pause, and resume procedures
 
-    fun msgHomePosition(): MAVLinkMessage? {
+    fun msgHomePosition(): MAVLinkMessage? = msg_home_position().apply {
         val coordinates = handler.aircraft.state.homeCoordinates ?: return null
-        val msg = msg_home_position()
-        msg.latitude = MessageUtils.coordinateDJI2MAVLink(coordinates.lat)
-        msg.longitude = MessageUtils.coordinateDJI2MAVLink(coordinates.long)
-        msg.altitude = MessageUtils.altitudeDJI2MAVLink(coordinates.alt)
-        return msg
+
+        latitude = MessageUtils.coordinateDJI2MAVLink(coordinates.lat)
+        longitude = MessageUtils.coordinateDJI2MAVLink(coordinates.long)
+        altitude = MessageUtils.altitudeDJI2MAVLink(coordinates.alt)
     }
 
-    fun msgGlobalPositionInt(): MAVLinkMessage? {
+    fun msgGlobalPositionInt(): MAVLinkMessage? = msg_global_position_int().apply {
         val telemetryData = handler.aircraft.telemetry.getData() ?: return null
-        val msg = msg_global_position_int()
-        msg.lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
-        msg.lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
-        msg.alt = MessageUtils.altitudeDJI2MAVLink(telemetryData.altitude)
-        // NOTE: Commented out this field, because msg.relative_alt seems to be intended for altitude above the current terrain,
-        // but DJI reports altitude above home point.
+
+        lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
+        lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
+        alt = MessageUtils.altitudeDJI2MAVLink(telemetryData.altitude)
+        // NOTE: Commented out this field, because relative_alt seems to be intended for
+        // altitude above the current terrain, but DJI reports altitude above home point.
         // Mavlink: Millimeters above ground (unspecified: presumably above home point?)
-        // DJI: relative altitude of the aircraft relative to take off location, measured by barometer, in meters.
-        msg.relative_alt = MessageUtils.altitudeDJI2MAVLink(telemetryData.relativeAltitude)
-        msg.vx = (telemetryData.velocityX * 100).roundToInt().toShort()
-        msg.vy = (telemetryData.velocityY * 100).roundToInt().toShort()
-        msg.vz = (telemetryData.velocityZ * 100).roundToInt().toShort()
+        // DJI: relative altitude of the aircraft relative to take off location, measured by
+        // barometer, in meters.
+        relative_alt = MessageUtils.altitudeDJI2MAVLink(telemetryData.relativeAltitude)
+        vx = (telemetryData.velocityX * 100).roundToInt().toShort()
+        vy = (telemetryData.velocityY * 100).roundToInt().toShort()
+        vz = (telemetryData.velocityZ * 100).roundToInt().toShort()
         var yaw = telemetryData.yaw
         if (yaw < 0) yaw += 360
-        msg.hdg = (yaw * 100).roundToInt()
+        hdg = (yaw * 100).roundToInt()
 //        client.sendMessage(msg)
-        return msg
     }
 
-    fun msgRawGPSInt(): MAVLinkMessage? {
+    fun msgRawGPSInt(): MAVLinkMessage? = msg_gps_raw_int().apply {
         val telemetryData = handler.aircraft.telemetry.getData() ?: return null
 
-        val msg = msg_gps_raw_int()
         if (handler.aircraft.telemetry.isSimulationActive) {
-            msg.fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_NO_GPS.toShort()
-            return msg
+            fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_NO_GPS.toShort()
+            return@apply
         }
-        msg.time_usec = MessageUtils.getMicroTime()
-        msg.lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
-        msg.lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
-        msg.satellites_visible = telemetryData.satelliteCount.toShort()
-        // DJI reports signal quality on a scale of 1-11
-        // Mavlink has separate codes for fix type.
-        if (telemetryData.gpsLevel[0] || telemetryData.gpsLevel[1]) {
-            msg.fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX.toShort()
-        } else if (telemetryData.gpsLevel[2]) {
-            msg.fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_2D_FIX.toShort()
-        } else if (
-            telemetryData.gpsLevel[3] ||
-            telemetryData.gpsLevel[4] ||
-            telemetryData.gpsLevel[5]
-        ) {
-            msg.fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_3D_FIX.toShort()
-        } else {
-            msg.fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX.toShort()
+
+        val gpsLevel = telemetryData.gpsLevel.indexOfFirst { it }
+
+        time_usec = MessageUtils.getMicroTime()
+        lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
+        lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
+        satellites_visible = telemetryData.satelliteCount.toShort()
+
+        // DJI reports signal quality as a level 0-11; mapped to Mavlink  fix types below.
+        fix_type = when (gpsLevel) {
+            0, 1 -> GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX.toShort()
+            2 -> GPS_FIX_TYPE.GPS_FIX_TYPE_2D_FIX.toShort()
+            3, 4, 5 -> GPS_FIX_TYPE.GPS_FIX_TYPE_3D_FIX.toShort()
+            else -> GPS_FIX_TYPE.GPS_FIX_TYPE_NO_FIX.toShort()
         }
-        return msg
     }
 
-    fun msgLocalPositionNed(): MAVLinkMessage? {
+    fun msgLocalPositionNed(): MAVLinkMessage? = msg_local_position_ned().apply {
         val telemetryData = handler.aircraft.telemetry.getData() ?: return null
-        val msg = msg_local_position_ned()
-        msg.time_boot_ms = handler.systemBootTime
-        msg.x = telemetryData.positionX
-        msg.y = telemetryData.positionY
-        msg.z = telemetryData.positionZ
-        msg.vx = telemetryData.velocityX
-        msg.vy = telemetryData.velocityY
-        msg.vz = telemetryData.velocityZ
-        return msg
+
+        time_boot_ms = handler.systemBootTime
+        x = telemetryData.positionX
+        y = telemetryData.positionY
+        z = telemetryData.positionZ
+        vx = telemetryData.velocityX
+        vy = telemetryData.velocityY
+        vz = telemetryData.velocityZ
     }
 
-    fun msgGpsGlobalOrigin(): MAVLinkMessage? {
+    fun msgGpsGlobalOrigin(): MAVLinkMessage? = msg_gps_global_origin().apply {
         val homeLoc = handler.aircraft.state.homeCoordinates ?: return null
-        val msg = msg_gps_global_origin()
-        msg.latitude = MessageUtils.coordinateDJI2MAVLink(homeLoc.lat)
-        msg.longitude = MessageUtils.coordinateDJI2MAVLink(homeLoc.long)
-        msg.altitude = MessageUtils.altitudeDJI2MAVLink(homeLoc.alt)
-        msg.time_usec = MessageUtils.getMicroTime()
-        return msg
+
+        latitude = MessageUtils.coordinateDJI2MAVLink(homeLoc.lat)
+        longitude = MessageUtils.coordinateDJI2MAVLink(homeLoc.long)
+        altitude = MessageUtils.altitudeDJI2MAVLink(homeLoc.alt)
+        time_usec = MessageUtils.getMicroTime()
     }
 }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -149,10 +149,10 @@ class NavigationController(
 
     fun sendMissionCount() = client.sendMessage(
         msg_mission_count().apply {
-            logger.d { "sendMissionCount: $count" }
             mission_type = MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION.toShort()
             count = handler.mission.state.totalNodes()
             opaque_id = handler.mission.state.id.toLong()
+            logger.d { "sendMissionCount: $count" }
         }
     )
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ParameterController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ParameterController.kt
@@ -6,7 +6,6 @@ import com.MAVLink.common.msg_param_request_read
 import com.MAVLink.common.msg_param_set
 import com.MAVLink.common.msg_param_value
 import io.getstream.log.taggedLogger
-import kotlin.math.round
 import kotlin.math.roundToInt
 import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.mavlink.MAVLinkClient

--- a/app/src/main/java/org/WenuLink/sdk/APIManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/APIManager.kt
@@ -19,7 +19,6 @@ import dji.sdk.remotecontroller.RemoteController
 import dji.sdk.sdkmanager.DJISDKInitEvent
 import dji.sdk.sdkmanager.DJISDKManager
 import io.getstream.log.taggedLogger
-import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.UnitResult
 

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -8,6 +8,7 @@ import dji.common.model.LocationCoordinate2D
 import dji.sdk.flightcontroller.FlightController
 import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.aircraft.Coordinates3D
+import org.WenuLink.adapters.aircraft.GPSMapper
 import org.WenuLink.adapters.aircraft.SensorState as AppSensorState
 import org.WenuLink.adapters.aircraft.TelemetryData
 
@@ -61,7 +62,7 @@ object FCManager {
         isFlying = state.isFlying,
         motorsOn = state.areMotorsOn(),
         satelliteCount = state.satelliteCount,
-        gpsLevel = SDKUtils.gpsSignalLevelFlags(state.gpsSignalLevel)
+        gpsFixType = GPSMapper.toMavlinkFixType(state.gpsSignalLevel)
     )
 
     fun registerStateCallback(stateCallback: (FlightControllerState) -> Unit) =

--- a/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
@@ -4,7 +4,6 @@
 package org.WenuLink.sdk
 
 import dji.common.error.DJIError
-import dji.common.flightcontroller.GPSSignalLevel
 import dji.common.util.CommonCallbacks
 import dji.sdk.base.BaseComponent
 import io.getstream.log.taggedLogger

--- a/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SDKUtils.kt
@@ -14,9 +14,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 object SDKUtils {
     private val logger by taggedLogger(SDKUtils::class.java.simpleName)
 
-    fun gpsSignalLevelFlags(inputLevel: GPSSignalLevel): List<Boolean> =
-        GPSSignalLevel.entries.map { it == inputLevel }
-
     fun createCompletionCallback(
         onResult: (String?) -> Unit
     ): CommonCallbacks.CompletionCallback<DJIError> =

--- a/app/src/main/java/org/WenuLink/sdk/SimManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/SimManager.kt
@@ -9,6 +9,7 @@ import dji.sdk.flightcontroller.Simulator
 import io.getstream.log.taggedLogger
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
+import org.WenuLink.adapters.aircraft.GPSMapper
 import org.WenuLink.adapters.aircraft.TelemetryData
 
 object SimManager {
@@ -64,7 +65,7 @@ object SimManager {
             isFlying = state.isFlying,
             motorsOn = state.areMotorsOn(),
             satelliteCount = satelliteCount,
-            gpsLevel = SDKUtils.gpsSignalLevelFlags(GPSSignalLevel.LEVEL_7)
+            gpsFixType = GPSMapper.toMavlinkFixType(GPSSignalLevel.LEVEL_7)
         )
         // complete data from previous one
         if (previousData == null) return data


### PR DESCRIPTION
## Refactor message construction and fix GPS fix type mapping

The `TelemetryData` class held a `gpsLevel: List<Boolean>` field, a one-hot encoding of DJI's `GPSSignalLevel` enum, alongside a `gpsFixType: Int` field that was always defaulted to `0` and never populated. `msgRawGPSInt` then had to extract that value to recover the original level, and its mapping was incomplete: `DJI's GPSSignalLevel` has 12 values (LEVEL_0–LEVEL_10 + NONE) but only levels 0–5 were handled, leaving the rest incorrectly falling through to `GPS_FIX_TYPE_NO_FIX`.

This PR fixes the root cause by doing the DJI -> MAVLink mapping at the SDK boundary, where the DJI type is already available, and storing only the resolved MAVLink fix type in `TelemetryData`:

- Add `GPSMapper.toMavlinkFixType(GPSSignalLevel)` in the adapter layer (alongside `BatteryMapper`), with a complete mapping covering all 12 DJI levels.
- Replace `gpsLevel: List<Boolean>` with `gpsFixType: Int` (non-defaulting) in `TelemetryData`, removing the dead default-zero field.
- Update `FCManager` and `SimManager` to call `GPSMapper` at construction time; delete `SDKUtils.gpsSignalLevelFlags`.
- `msgRawGPSInt` now simply reads `telemetryData.gpsFixType.toShort()`.

The remaining changes apply the same `.apply {}`/expression-body pattern to all other message-construction functions across `ConnectionController`, `NavigationController`, `CommandController`, `CameraController`, and `MessageUtils`, eliminating the intermediate` val msg =` /` return msg` boilerplate throughout.
