### PR TITLE
CI GitHub Action - ktlintCheck

### DIFF
--- a/.github/workflows/ktlint.yaml
+++ b/.github/workflows/ktlint.yaml
@@ -1,0 +1,29 @@
+name: ktlint
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  ktlint:
+    name: Check code style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant Gradle wrapper execute permission
+        run: chmod +x ./gradlew
+
+      - name: Run ktlintCheck
+        run: ./gradlew ktlintCheck


### PR DESCRIPTION
Add `.github/workflows/ktlint.yaml` defining a GitHub Action to run `gradlew ktlintCheck` on every pr targeting either `main` or `develop`, blocking the pr if not successful.

Closes #60 