### PR TITLE
Fix missing CommandResult checks

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
@@ -21,8 +21,6 @@ data class BootCommand(val timeout: Long = 5000L) : AircraftCommand {
         // TODO: check if compatible with CancellableCoroutine
         ctx.dispatchTransition(BootTransition)
         return ctx.boot(timeout)
-            ?.let { CommandResult.error(it) }
-            ?: CommandResult.ok
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -173,14 +173,14 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return telemetry.waitDataRemoving(delay)
     }
 
-    suspend fun boot(timeout: Long = 5000L): String? {
+    suspend fun boot(timeout: Long = 5000L): UnitResult {
         sensorsHealthy = false
         logger.d { "Aircraft booting..." }
 
-        if (!loadParameters(timeout)) return "No parameters"
+        if (!loadParameters(timeout)) return CommandResult.error("No parameters")
         logger.d { "\tParameters: OK" }
 
-        if (!startTelemetry(timeout)) return "No telemetry"
+        if (!startTelemetry(timeout)) return CommandResult.error("No telemetry")
         logger.d { "\tTelemetry: OK" }
 
         sensorsHealthy =
@@ -189,7 +189,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
 
         logger.d { "Aircraft boot: OK" }
         isPowerOff = false
-        return null
+        return CommandResult.ok
     }
 
     override fun registerScope(scope: CoroutineScope) {

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -304,9 +304,9 @@ class CameraController(
 
         handler.dispatchCommand(
             WenuLinkCommand.Camera(StopRecordCommand(cameraInfo.id))
-        ) { error ->
-            if (error != null) {
-                logger.w { "Error in requestStopRecording: $error" }
+        ) { result ->
+            if (result.hasError) {
+                logger.w { "Error in requestStopRecording: ${result.errorReason}" }
                 return@dispatchCommand
             }
             // deactivating messages

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -136,8 +136,8 @@ class CommandController(override var client: MAVLinkClient, override val handler
         logger.d { "Requesting to ${if (action) "arm" else "disarm"} motors" }
 
         val command = if (action) ArmCommand() else DisarmCommand()
-        handler.dispatchCommand(WenuLinkCommand.Aircraft(command)) { error ->
-            logger.d { "processTakeoff: $error" }
+        handler.dispatchCommand(WenuLinkCommand.Aircraft(command)) { result ->
+            logger.d { "processTakeoff: $result" }
         }
 
         sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
@@ -145,8 +145,8 @@ class CommandController(override var client: MAVLinkClient, override val handler
 
     fun processTakeoff(commandMsg: msg_command_long) {
         logger.d { "processTakeoff: $commandMsg" }
-        handler.dispatchCommand(WenuLinkCommand.Request(RequestTakeoff())) { error ->
-            logger.d { "processTakeoff: $error" }
+        handler.dispatchCommand(WenuLinkCommand.Request(RequestTakeoff())) { result ->
+            logger.d { "processTakeoff: $result" }
         }
         sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
     }
@@ -175,8 +175,8 @@ class CommandController(override var client: MAVLinkClient, override val handler
             WenuLinkCommand.Request(
                 RequestMissionAction(DelayAction.fromCommandLong(commandMsg))
             )
-        ) { error ->
-            logger.d { "processDelay: $error" }
+        ) { result ->
+            logger.d { "processDelay: $result" }
         }
         sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
     }
@@ -187,8 +187,8 @@ class CommandController(override var client: MAVLinkClient, override val handler
             WenuLinkCommand.Request(
                 RequestMissionAction(RotateAction.fromCommandLong(commandMsg))
             )
-        ) { error ->
-            logger.d { "processYaw: $error" }
+        ) { result ->
+            logger.d { "processYaw: $result" }
         }
         sendCommandAck(commandMsg.command, MAV_RESULT.MAV_RESULT_ACCEPTED)
     }

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -46,8 +46,8 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
         // mavlink.initClient("192.168.1.220", 14550)
         viewModelScope.launch {
             if (run) {
-                thisApp.wenuLinkService?.startMAVLinkService { error ->
-                    logger.d { "startMAVLinkService error: $error" }
+                thisApp.wenuLinkService?.startMAVLinkService { result ->
+                    if (result.hasError) logger.d { "startMAVLinkService error: $result" }
                 }
             } else {
                 thisApp.wenuLinkService?.stopMAVLinkService()?.join()


### PR DESCRIPTION
Found three cases where the lambda didn't match the new `CommandResult` type. All other cases of `error == null` or `error != null` are on the manager classes or DJI classes and reflect the `String?` type the DJI SDK uses for errors.

If we want to define a result type for the manager classes it should not also be `CommandResult` since the name would be inappropriate.

Let me know if I missed anything.

Closes #57 