### PR TITLE
refactor: return UnitResult from dispatchControlAuthority

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -58,7 +58,8 @@ data class RequestLand(val withLandingConfirmation: Boolean = true, val timeout:
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         super.execute(ctx)
 
-        ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
+        val authorityResult = ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
+        if (authorityResult.hasError) return authorityResult
 
         val landingResult = ctx.dispatchAndAwait(WenuLinkCommand.Mission(LandAction(true)))
         if (landingResult.hasError) return landingResult
@@ -79,7 +80,8 @@ data class RequestTakeoff(val altitude: Float = 2f, val timeout: Long = 15_000L)
 
         super.execute(ctx)
 
-        ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
+        val authorityResult = ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
+        if (authorityResult.hasError) return authorityResult
 
         val takeoffResult = ctx.dispatchAndAwait(WenuLinkCommand.Aircraft(TakeoffCommand(timeout)))
         if (takeoffResult.hasError) return takeoffResult
@@ -112,7 +114,8 @@ data class RequestStartMission(
 
         super.execute(ctx)
 
-        ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
+        val authorityResult = ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
+        if (authorityResult.hasError) return authorityResult
 
         ctx.mission.setStartSequence(startSequence)
 
@@ -125,7 +128,8 @@ open class RequestMissionAction(private val action: MissionActionCommand) :
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         super.execute(ctx)
 
-        ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
+        val authorityResult = ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
+        if (authorityResult.hasError) return authorityResult
 
         return ctx.dispatchAndAwait(WenuLinkCommand.Mission(action))
     }

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -28,6 +28,7 @@ import org.WenuLink.adapters.mission.ResumeActionCommand
 import org.WenuLink.adapters.mission.ResumeWaypointMission
 import org.WenuLink.adapters.mission.StopWaypointMission
 import org.WenuLink.commands.CommandHandler
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.UnitResult
 
 class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
@@ -174,6 +175,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     suspend fun loadComponents(scope: CoroutineScope): UnitResult {
         // prevent cancel command when manualControl() after boot
         dispatchControlAuthority(ControlAuthorityType.REMOTE_CONTROLLER)
+
         val bootResult = dispatchAndAwait(WenuLinkCommand.Aircraft(BootCommand(30_000L)))
         if (bootResult.isOk) {
             manualControl()
@@ -185,6 +187,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
             AsyncUtils.waitTimeout(100L, 5000L) { camera.wasInitialized }
             startMonitorJob(scope)
         }
+
         return bootResult
     }
 
@@ -194,9 +197,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         camera.unload()
         onImageCaptured = null
         stopMonitor()
-        val shutdownError =
-            dispatchAndAwait(WenuLinkCommand.Aircraft(ShutdownCommand(strictTransition)))
-        return shutdownError
+        return dispatchAndAwait(WenuLinkCommand.Aircraft(ShutdownCommand(strictTransition)))
     }
 
     fun setAuthority(authority: ControlAuthorityType): ControlAuthority {
@@ -204,13 +205,20 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
         return controlAuthority
     }
 
-    fun dispatchControlAuthority(authority: ControlAuthorityType) {
+    fun dispatchControlAuthority(authority: ControlAuthorityType): UnitResult {
         // Decide policy: reject or stop mission
-        if (!controlAuthority.isNewAuthority(authority) || controlAuthority.isRemote()) return
+        if (!controlAuthority.isNewAuthority(authority)) return CommandResult.ok
+
+        if (controlAuthority.isRemote()) {
+            logger.d { "Skip authority switch: remote active" }
+            return CommandResult.error("Remote pilot has authority")
+        }
+
         // Always stop everything
         stopAllCommands()
         logger.d { "Control transition: ${controlAuthority.authorityType}->$authority" }
         setAuthority(authority)
+        return CommandResult.ok
     }
 
     fun manualControl() {


### PR DESCRIPTION
Align `dispatchControlAuthority` with the rest of the handler layer by returning `UnitResult` instead of `Unit`, and make the `RequestCommand` call sites observe the outcome.

This is based on the changes from #62 and should be merged after it