### PR TITLE
Refactor: Simplify mavlink message creation

### DIFF
--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -19,7 +19,6 @@ import org.WenuLink.adapters.OrientationUtils
 import org.WenuLink.adapters.WenuLinkCommand
 import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.adapters.aircraft.TelemetryMapper
-import org.WenuLink.adapters.camera.CameraCaptureStatus
 import org.WenuLink.adapters.camera.CameraMetadata
 import org.WenuLink.adapters.camera.ImageMetadata
 import org.WenuLink.adapters.camera.SetModeCommand
@@ -367,34 +366,30 @@ class CameraController(
             storage_usage = STORAGE_USAGE_FLAG.STORAGE_USAGE_FLAG_PHOTO.toShort()
         }
 
-    fun msgCaptureStatus(cameraInfo: CameraMetadata): msg_camera_capture_status {
+    fun msgCaptureStatus(cameraInfo: CameraMetadata): msg_camera_capture_status =
         // TODO: add proper updates
-        var imageStatus = CameraCaptureStatus.IDLE
-        var imageInterval = 0f
-        var videoStatus = CameraCaptureStatus.IDLE
-        var videoTime = 0L
-        if (cameraInfo.state.mavlinkMode == CAMERA_MODE.CAMERA_MODE_IMAGE) {
-            imageStatus = cameraInfo.state.captureStatus
-            imageInterval = cameraInfo.state.captureTime.toFloat()
-        } else if (cameraInfo.state.mavlinkMode == CAMERA_MODE.CAMERA_MODE_VIDEO) {
-            videoStatus = cameraInfo.state.captureStatus
-            videoTime = cameraInfo.state.captureTime
-        }
-        return msg_camera_capture_status().apply {
-            image_status = imageStatus.value.toShort()
-            video_status = videoStatus.value.toShort()
-            image_interval = imageInterval
-            recording_time_ms = videoTime
+        msg_camera_capture_status().apply {
+            when (cameraInfo.state.mavlinkMode) {
+                CAMERA_MODE.CAMERA_MODE_IMAGE -> {
+                    image_status = cameraInfo.state.captureStatus.value.toShort()
+                    image_interval = cameraInfo.state.captureTime.toFloat()
+                }
+
+                CAMERA_MODE.CAMERA_MODE_VIDEO -> {
+                    video_status = cameraInfo.state.captureStatus.value.toShort()
+                    recording_time_ms = cameraInfo.state.captureTime
+                }
+            }
+
             // TODO: read true value
             available_capacity = 4000f
             image_count = 0
             camera_device_id = cameraInfo.id.toShort()
         }
-    }
 
-    fun msgImageCaptured(imageInfo: ImageMetadata): msg_camera_image_captured {
-        val mavData = TelemetryMapper.toMavlink(imageInfo.telemetry)
-        return msg_camera_image_captured().apply {
+    fun msgImageCaptured(imageInfo: ImageMetadata): msg_camera_image_captured =
+        msg_camera_image_captured().apply {
+            val mavData = TelemetryMapper.toMavlink(imageInfo.telemetry)
             camera_id = imageInfo.cameraID.toShort()
             lat = mavData.latitude
             lon = mavData.longitude
@@ -409,5 +404,4 @@ class CameraController(
             capture_result = (if (imageInfo.captureOk) 1 else 0).toByte()
             file_url = "".toByteArray()
         }
-    }
 }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -351,24 +351,23 @@ class CameraController(
         camera_device_id = cameraInfo.id.toShort()
     }
 
-    fun msgStorageInformation(): msg_storage_information =
+    fun msgStorageInformation(): msg_storage_information = msg_storage_information().apply {
         // TODO: get from https://developer.dji.com/api-reference/android-api/Components/Camera/DJICamera_DJICameraSDCardState.html
-        msg_storage_information().apply {
-            storage_id = 1
-            storage_count = 1
-            status = STORAGE_STATUS.STORAGE_STATUS_READY.toShort()
-            total_capacity = 4096f // MB
-            used_capacity = 0f // MB
-            read_speed = 0f // MB/s
-            write_speed = 0f // MB/s
-            type = STORAGE_TYPE.STORAGE_TYPE_MICROSD.toShort()
-            name = "FakeSDCard".toByteArray()
-            storage_usage = STORAGE_USAGE_FLAG.STORAGE_USAGE_FLAG_PHOTO.toShort()
-        }
+        storage_id = 1
+        storage_count = 1
+        status = STORAGE_STATUS.STORAGE_STATUS_READY.toShort()
+        total_capacity = 4096f // MB
+        used_capacity = 0f // MB
+        read_speed = 0f // MB/s
+        write_speed = 0f // MB/s
+        type = STORAGE_TYPE.STORAGE_TYPE_MICROSD.toShort()
+        name = "FakeSDCard".toByteArray()
+        storage_usage = STORAGE_USAGE_FLAG.STORAGE_USAGE_FLAG_PHOTO.toShort()
+    }
 
     fun msgCaptureStatus(cameraInfo: CameraMetadata): msg_camera_capture_status =
-        // TODO: add proper updates
         msg_camera_capture_status().apply {
+            // TODO: add proper updates
             when (cameraInfo.state.mavlinkMode) {
                 CAMERA_MODE.CAMERA_MODE_IMAGE -> {
                     image_status = cameraInfo.state.captureStatus.value.toShort()

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ParameterController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ParameterController.kt
@@ -48,11 +48,10 @@ class ParameterController(
         logger.d { "Parameters list requested: $wasRequested" }
     }
 
-    private fun msgParam(spec: ParameterSpec, value: ParamValue): msg_param_value {
-        val pValue = spec.toMavlink(value)
-        return msg_param_value().apply {
+    private fun msgParam(spec: ParameterSpec, value: ParamValue): msg_param_value =
+        msg_param_value().apply {
             param_Id = spec.name
-            param_value = pValue.toFloat()
+            param_value = spec.toMavlink(value).toFloat()
             param_type = spec.type.toShort()
             param_count = handler.aircraft.parameters.size()
             param_index = if (spec.index == -1) {
@@ -61,7 +60,6 @@ class ParameterController(
                 spec.index
             }
         }
-    }
 
     fun sendParameter(spec: ParameterSpec, value: ParamValue) {
         val msg = msgParam(spec, value)


### PR DESCRIPTION
Simplify mavlink message creation already started by #59 

In `CameraController.msgCaptureStatus` the default value for possibly non-initialized variables like `imageStatus` and `videoStatus` is 0, which coincides wth `CameraCaptureStatus.IDLE`