### PR TITLE
Fix RequestReposition

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -125,7 +125,7 @@ open class RequestMissionAction(private val action: MissionActionCommand) :
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
         super.execute(ctx)
 
-        ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
+        ctx.dispatchControlAuthority(ControlAuthorityType.TIMELINE_COMMAND)
 
         return ctx.dispatchAndAwait(WenuLinkCommand.Mission(action))
     }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -169,7 +169,7 @@ interface MissionActionCommand : MissionCommand {
         else -> CommandResult.ok
     }
 
-    override suspend fun onStop(ctx: MissionHandler) = ctx.onActionError("Stop invoked")
+    override suspend fun onStop(ctx: MissionHandler) = ctx.stopAction("Stop invoked")
 }
 
 data class DelayAction(val timeMillis: Long) : MissionActionCommand {
@@ -202,7 +202,7 @@ data class DelayAction(val timeMillis: Long) : MissionActionCommand {
 open class ActionCommand(val action: MissionAction) : MissionActionCommand {
     override suspend fun execute(ctx: MissionHandler): UnitResult {
         // schedule and register termination
-        val scheduleResult = ctx.scheduleUrgentAction(action)
+        val scheduleResult = ctx.scheduleImmediateAction(action)
         if (scheduleResult.hasError) return scheduleResult
 
         return suspendCancellableCoroutine { cont ->
@@ -215,7 +215,7 @@ open class ActionCommand(val action: MissionAction) : MissionActionCommand {
             }
 
             cont.invokeOnCancellation {
-                ctx.onActionError("Cancellation invoked")
+                ctx.stopAction("Cancellation invoked")
             }
         }
     }
@@ -226,7 +226,7 @@ data class RepositionAction(private val target: Coordinates3D, private val speed
         GoToAction(
             LocationCoordinate2D(target.lat, target.long),
             target.alt
-        ).apply { flightSpeed = speed.coerceIn(2f, 15f) } // value should be in the range [2, 15]
+        ).apply { flightSpeed = speed } // value should be in the range [2, 15]
     ) {
     companion object {
         fun fromParameters(params: DoRepositionCommandInt): RepositionAction {

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -1,6 +1,5 @@
 package org.WenuLink.adapters.mission
 
-import com.MAVLink.common.msg_command_int
 import dji.common.gimbal.Attitude
 import dji.common.model.LocationCoordinate2D
 import dji.sdk.mission.timeline.actions.AircraftYawAction
@@ -170,7 +169,7 @@ interface MissionActionCommand : MissionCommand {
         else -> CommandResult.ok
     }
 
-    override suspend fun onStop(ctx: MissionHandler) = MissionActionManager.stop()
+    override suspend fun onStop(ctx: MissionHandler) = ctx.onActionError("Stop invoked")
 }
 
 data class DelayAction(val timeMillis: Long) : MissionActionCommand {
@@ -202,34 +201,21 @@ data class DelayAction(val timeMillis: Long) : MissionActionCommand {
 
 open class ActionCommand(val action: MissionAction) : MissionActionCommand {
     override suspend fun execute(ctx: MissionHandler): UnitResult {
-        MissionActionManager.clear()
-
-        val error = MissionActionManager.schedule(action)
-
-        if (error != null) {
-            return CommandResult.error("Error in $action: ${error.description}")
-        }
+        // schedule and register termination
+        val scheduleResult = ctx.scheduleUrgentAction(action)
+        if (scheduleResult.hasError) return scheduleResult
 
         return suspendCancellableCoroutine { cont ->
-            val actionKey = MissionActionManager.onFinish(action::class) {
-                if (cont.isActive) {
-                    cont.resume(CommandResult.ok)
-                }
+            ctx.onActionFinish(action) {
+                cont.resume(CommandResult.ok)
             }
 
-            MissionActionManager.startListener {
-                if (cont.isActive) {
-                    // onError
-                    cont.resume(CommandResult.error("Action failed: $it"))
-                }
+            ctx.performAction { error ->
+                cont.resume(CommandResult.error(error))
             }
-
-            MissionActionManager.start()
 
             cont.invokeOnCancellation {
-                // Add SDK cancel if available
-                MissionActionManager.removeCallback(actionKey)
-                MissionActionManager.stop()
+                ctx.onActionError("Cancellation invoked")
             }
         }
     }
@@ -240,15 +226,12 @@ data class RepositionAction(private val target: Coordinates3D, private val speed
         GoToAction(
             LocationCoordinate2D(target.lat, target.long),
             target.alt
-        ).apply { flightSpeed = speed }
+        ).apply { flightSpeed = speed.coerceIn(2f, 15f) } // value should be in the range [2, 15]
     ) {
     companion object {
-        fun fromCommandInt(commandIntMsg: msg_command_int): RepositionAction {
-            val params = DoRepositionCommandInt(commandIntMsg)
-            return RepositionAction(
-                Coordinates3D(params.latitude, params.longitude, params.altitude),
-                if (params.speed == -1f) 1f else params.speed
-            )
+        fun fromParameters(params: DoRepositionCommandInt): RepositionAction {
+            val coordinates = Coordinates3D(params.latitude, params.longitude, params.altitude)
+            return RepositionAction(coordinates, params.speed)
         }
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -226,38 +226,35 @@ class MissionHandler : CommandHandler<MissionHandler>() {
      * MissionActionManager methods
      */
 
-    fun onActionError(description: String) {
-        logger.e { "Timeline error: $description" }
-        lastActionKey?.let { MissionActionManager.removeCallback(it) }
-        MissionActionManager.stop()
-    }
+    fun teardownActions() = lastActionKey?.let { MissionActionManager.removeCallback(it) }
 
-    fun scheduleUrgentAction(action: MissionAction): UnitResult {
-        logger.d { "Scheduling $action with urgency" }
+    fun scheduleImmediateAction(action: MissionAction): UnitResult {
+        logger.d { "Scheduling $action" }
         MissionActionManager.clearScheduleAndListeners()
-        val error = MissionActionManager.schedule(action)
-
-        if (error != null) {
-            return CommandResult.error("Error in $action: ${error.description}")
-        }
-
-        return CommandResult.ok
+        return MissionActionManager.schedule(action)
+            ?.let {
+                CommandResult.error("Error in $action: ${it.description}")
+            }
+            ?: CommandResult.ok
     }
 
-    fun onActionFinish(action: MissionAction, onFinish: (UnitResult) -> Unit) {
+    fun onActionFinish(action: MissionAction, onFinish: () -> Unit) {
         lastActionKey = MissionActionManager.onFinish(action::class) {
-            onFinish(CommandResult.ok)
-            lastActionKey?.let { MissionActionManager.removeCallback(it) } // reset at the end
+            onFinish()
+            stopAction("Action finished")
         }
     }
 
     fun performAction(onError: (String) -> Unit) {
+        logger.i { "Timeline start" }
         // start listeners and action
-        MissionActionManager.startListener {
-            onActionError(it)
-            onError(it)
-        }
-
+        MissionActionManager.startListener(onError)
         MissionActionManager.start()
+    }
+
+    fun stopAction(description: String) {
+        logger.i { "Timeline stop: $description" }
+        if (MissionActionManager.isRunning) MissionActionManager.stop()
+        teardownActions()
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -3,11 +3,13 @@ package org.WenuLink.adapters.mission
 import com.MAVLink.common.msg_mission_item_int
 import com.MAVLink.enums.MAV_CMD
 import com.MAVLink.enums.MISSION_STATE
+import dji.sdk.mission.timeline.actions.MissionAction
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.WenuLink.adapters.aircraft.Coordinates3D
 import org.WenuLink.commands.CommandHandler
+import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.UnitResult
 import org.WenuLink.mavlink.messages.ConditionYawMessage
 import org.WenuLink.mavlink.messages.ImageStartCaptureMissionItem
@@ -82,6 +84,7 @@ class MissionHandler : CommandHandler<MissionHandler>() {
     }
 
     private val logger by taggedLogger(MissionHandler::class.java.simpleName)
+    private var lastActionKey: MissionActionManager.ActionCallbackKey? = null
     var flightSpeed = 5f
         private set
     var state = MissionState()
@@ -137,7 +140,7 @@ class MissionHandler : CommandHandler<MissionHandler>() {
 
     fun clear() {
         state = state.reset()
-        MissionActionManager.clear()
+        MissionActionManager.clearScheduleAndListeners()
     }
 
     fun addWaypointNode(itemMsg: msg_mission_item_int): Boolean {
@@ -218,4 +221,43 @@ class MissionHandler : CommandHandler<MissionHandler>() {
 
     fun uploadWaypoints(onResult: (UnitResult) -> Unit) =
         dispatchCommand(UploadMissionCommand(state.assembler, flightSpeed), onResult)
+
+    /**
+     * MissionActionManager methods
+     */
+
+    fun onActionError(description: String) {
+        logger.e { "Timeline error: $description" }
+        lastActionKey?.let { MissionActionManager.removeCallback(it) }
+        MissionActionManager.stop()
+    }
+
+    fun scheduleUrgentAction(action: MissionAction): UnitResult {
+        logger.d { "Scheduling $action with urgency" }
+        MissionActionManager.clearScheduleAndListeners()
+        val error = MissionActionManager.schedule(action)
+
+        if (error != null) {
+            return CommandResult.error("Error in $action: ${error.description}")
+        }
+
+        return CommandResult.ok
+    }
+
+    fun onActionFinish(action: MissionAction, onFinish: (UnitResult) -> Unit) {
+        lastActionKey = MissionActionManager.onFinish(action::class) {
+            onFinish(CommandResult.ok)
+            lastActionKey?.let { MissionActionManager.removeCallback(it) } // reset at the end
+        }
+    }
+
+    fun performAction(onError: (String) -> Unit) {
+        // start listeners and action
+        MissionActionManager.startListener {
+            onActionError(it)
+            onError(it)
+        }
+
+        MissionActionManager.start()
+    }
 }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CommandController.kt
@@ -155,9 +155,7 @@ class CommandController(override var client: MAVLinkClient, override val handler
         logger.d { "processTakeoff: $commandMsg" }
         val params = NavTakeoffCommandLong(commandMsg)
         handler.dispatchCommand(
-            WenuLinkCommand.Request(
-                RequestTakeoff(params.altitude)
-            )
+            WenuLinkCommand.Request(RequestTakeoff(params.altitude))
         ) { result ->
             if (result.hasError) logger.e { "Takeoff error: ${result.errorReason}" }
         }
@@ -200,9 +198,7 @@ class CommandController(override var client: MAVLinkClient, override val handler
         logger.d { "processYaw: $commandMsg" }
         handler.dispatchCommand(
             WenuLinkCommand.Request(
-                RequestMissionAction(
-                    RotateAction.fromParameters(ConditionYawMessage(commandMsg))
-                )
+                RequestMissionAction(RotateAction.fromParameters(ConditionYawMessage(commandMsg)))
             )
         ) { result ->
             logger.d { "processYaw: $result" }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -24,6 +24,7 @@ import com.MAVLink.enums.MAV_MISSION_TYPE
 import com.MAVLink.enums.MAV_RESULT
 import com.MAVLink.enums.MAV_SEVERITY
 import io.getstream.log.taggedLogger
+import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 import org.WenuLink.adapters.RequestMissionAction
 import org.WenuLink.adapters.RequestStartMission
@@ -273,10 +274,21 @@ class NavigationController(
 
     fun processDoReposition(commandIntMsg: msg_command_int) {
         val params = DoRepositionCommandInt(commandIntMsg)
+        // mission flight speed is [-15, 15], so take its absolute
+        val flightSpeed = if (params.speed == -1f) {
+            logger.d { "Using default's mission flight speed: ${handler.mission.flightSpeed} m/s" }
+            handler.mission.flightSpeed.absoluteValue
+        } else {
+            params.speed
+        }
+        // TODO: move this kind of conversion to something centralized, not sure if
+        //  DoRepositionCommandInt should have it, since also happens with MissionHandler.flightSpeed
+        //  demanding and easy to find of SDK constraints regard to commands and actions.
+        // Ensure values [2, 15]
+        val range = 2f..15f
+        if (flightSpeed !in range) logger.w { "Clipped speed $flightSpeed to [$range]" }
         val repositionAction = RepositionAction.fromParameters(
-            params.copy(
-                speed = if (params.speed == -1f) handler.mission.flightSpeed else params.speed
-            )
+            params.copy(speed = flightSpeed.coerceIn(range))
         )
 
         client.sendMessage(

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -32,6 +32,7 @@ import org.WenuLink.adapters.WenuLinkHandler
 import org.WenuLink.adapters.mission.MissionNode
 import org.WenuLink.adapters.mission.RepositionAction
 import org.WenuLink.mavlink.MAVLinkClient
+import org.WenuLink.mavlink.messages.DoRepositionCommandInt
 import org.WenuLink.mavlink.messages.MessageUtils
 import org.WenuLink.mavlink.messages.MissionStartCommandLong
 import org.WenuLink.mavlink.messages.NavLandMissionItem
@@ -271,9 +272,10 @@ class NavigationController(
     }
 
     fun processDoReposition(commandIntMsg: msg_command_int) {
-        handler.dispatchCommand(
-            WenuLinkCommand.Request(
-                RequestMissionAction(RepositionAction.fromCommandInt(commandIntMsg))
+        val params = DoRepositionCommandInt(commandIntMsg)
+        val repositionAction = RepositionAction.fromParameters(
+            params.copy(
+                speed = if (params.speed == -1f) handler.mission.flightSpeed else params.speed
             )
         )
 
@@ -282,6 +284,10 @@ class NavigationController(
                 MAV_CMD.MAV_CMD_DO_REPOSITION,
                 MAV_RESULT.MAV_RESULT_ACCEPTED
             )
+        )
+
+        handler.dispatchCommand(
+            WenuLinkCommand.Request(RequestMissionAction(repositionAction))
         )
     }
 

--- a/app/src/main/java/org/WenuLink/sdk/MissionActionManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/MissionActionManager.kt
@@ -28,7 +28,7 @@ object MissionActionManager {
     val isRunning get() = missionControl.isTimelineRunning
 
     // ---- Lifecycle ----
-    fun clear() {
+    fun clearScheduleAndListeners() {
         missionControl.unscheduleEverything()
         stopListener()
     }


### PR DESCRIPTION
Fixes #72 by correcting default flight speed and other mission related reorganization.

The `RepositionAction` was only working for takeoff but no on request of DO_REPOSITION, with a main bug related to the default flight speed = 1, below the minimum required by the SDK (2m/s). Since the logger function is not reachable by any command, auxiliary methods were created on MissionHandler making it easier to follow.

Fixes MAV_CMD_DO_REPOSITION parameters processing as required by SDK.

In this changes I aimed to keep all manager classes accessible by handlers but no by commands, but then I saw that this is not consistent, in certain cases, commands are still calling SDK manager related methods. Probably we should also define a way an keep it alongside the development.
Specifically here, `MissionHandler` now import the SDK's `MissionAction` class violating the restriction of calling SDK dependencies only inside Manager classes, requiring a major refactor to avoid such situation.