### PR TITLE
Fix YUV color-format routing and MediaFormat lookups

### DIFF
--- a/app/src/main/java/org/WenuLink/webrtc/utils/VideoCapturerUtils.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/utils/VideoCapturerUtils.kt
@@ -9,32 +9,33 @@ import org.webrtc.JavaI420Buffer
 import org.webrtc.NV12Buffer
 import org.webrtc.VideoFrame
 
+private fun MediaFormat.getIntegerOrDefault(key: String, default: Int): Int =
+    if (containsKey(key)) getInteger(key) else default
+
 fun getBufferNV12(
     mediaFormat: MediaFormat,
     videoBuffer: ByteBuffer,
     width: Int,
     height: Int
-): NV12Buffer {
-    // NV12 Buffer
-    return NV12Buffer(
+): NV12Buffer = // NV12 Buffer
+    NV12Buffer(
         width,
         height,
-        mediaFormat.getInteger(MediaFormat.KEY_STRIDE),
-        mediaFormat.getInteger(MediaFormat.KEY_SLICE_HEIGHT),
+        mediaFormat.getIntegerOrDefault(MediaFormat.KEY_STRIDE, width),
+        mediaFormat.getIntegerOrDefault(MediaFormat.KEY_SLICE_HEIGHT, height),
         videoBuffer,
         null
     )
-}
 
 fun getBufferI420(
     mediaFormat: MediaFormat,
     videoBuffer: ByteBuffer,
     width: Int,
     height: Int
-): JavaI420Buffer? {
+): JavaI420Buffer {
     // I420 Buffer
-    val yStride = mediaFormat.getInteger(MediaFormat.KEY_STRIDE)
-    val sliceHeight = mediaFormat.getInteger(MediaFormat.KEY_SLICE_HEIGHT)
+    val yStride = mediaFormat.getIntegerOrDefault(MediaFormat.KEY_STRIDE, width)
+    val sliceHeight = mediaFormat.getIntegerOrDefault(MediaFormat.KEY_SLICE_HEIGHT, height)
 
     // Y plane size in memory
     val yPlaneSize = yStride * sliceHeight
@@ -67,6 +68,15 @@ fun getBufferI420(
     )
 }
 
+/**
+ * Converts a YUV [ByteBuffer] received from [DJICodecManager.YuvDataCallback] into a WebRTC
+ * [VideoFrame]. The specific YUV420 color-format constants (Planar / SemiPlanar and their Packed
+ * variants) are deprecated in favour of [MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible],
+ * but real-world codecs, including the one inside DJICodecManager, still report them, so we must
+ * keep the branches. Suppressing the warning at function scope rather than per-case to keep the
+ * `when`-expression readable.
+ */
+@Suppress("DEPRECATION")
 fun videoBuffer2VideoFrame(
     mediaFormat: MediaFormat,
     videoBuffer: ByteBuffer,
@@ -77,13 +87,13 @@ fun videoBuffer2VideoFrame(
     // Check the color format. Could create more cases if needed
     val colorFormat = mediaFormat.getInteger(MediaFormat.KEY_COLOR_FORMAT)
     val procBuffer = when (colorFormat) {
-        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible
+        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible,
+        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420SemiPlanar,
+        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420PackedSemiPlanar
         -> getBufferNV12(mediaFormat, videoBuffer, width, height)
 
         MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar,
-        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420SemiPlanar,
-        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420PackedPlanar,
-        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420PackedSemiPlanar
+        MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420PackedPlanar
         -> getBufferI420(mediaFormat, videoBuffer, width, height)
 
         else -> return null


### PR DESCRIPTION
Semi-planar formats were incorrectly routed through the I420 path.
These formats use interleaved chroma (typically NV12/NV21 layouts), while I420 expects separate U and V planes. As a result, the U plane was read correctly but the V plane was corrupted.

Route `COLOR_FormatYUV420SemiPlanar` and `COLOR_FormatYUV420PackedSemiPlanar` to the NV12 path, and keep planar formats on the I420 path.

Additional improvements:
- Use safe fallbacks for `KEY_STRIDE` and `KEY_SLICE_HEIGHT` (defaulting to width/height), since `MediaFormat.getInteger()` throws if keys are absent and they are not guaranteed to be present.
- Suppress deprecation warnings at function scope