### PR TITLE
refactor: make WebRTCService.stop awaitable, mirror MAVLinkService shape

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -143,7 +143,6 @@ class WenuLinkService : Service() {
         }
 
         webRTC.startClient(serviceScope, applicationContext)
-        webRTC.runProcess(true) // autostart
         logger.i { "WebRTC service started" }
     }
 
@@ -157,12 +156,10 @@ class WenuLinkService : Service() {
         if (!isWebRTCReady()) return null
 
         return serviceScope.launch {
-            webRTC.runProcess(false)
+            webRTC.stopService()
             logger.i { "WebRTC service stop." }
         }
     }
-
-    fun isWebRTCUp() = isWebRTCReady() && webRTC.isServiceUp
 
     fun isMAVLinkReady() = ::mavlink.isInitialized
 

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -140,7 +140,7 @@ class MAVLinkService(handler: WenuLinkHandler) {
         }
     }
 
-    suspend fun stopClient() {
+    private suspend fun stopClient() {
         if (isServiceStop()) return // nothing to stop
 
         messagesScope?.launch {

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -58,7 +58,7 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
             if (run) {
                 thisApp.wenuLinkService?.startWebRTCService()
             } else {
-                thisApp.wenuLinkService?.stopWebRTCService()
+                thisApp.wenuLinkService?.stopWebRTCService()?.join()
             }
         }
     }

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -5,6 +5,7 @@ import io.getstream.log.taggedLogger
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -56,17 +57,11 @@ class WebRTCService {
 
     // Signaling configuration
     private lateinit var signalingServer: ServiceAddress
-    var isServiceUp = false
-        private set
     var isStreaming = false
         private set
 
     private val _isRunning = MutableStateFlow(false)
     val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
-
-    fun runProcess(isRunning: Boolean) {
-        _isRunning.value = isRunning
-    }
 
     // used to send local video track to the fragment
     private val _localVideoTrackFlow = MutableSharedFlow<VideoTrack>()
@@ -128,17 +123,11 @@ class WebRTCService {
             peerConnectionFactory.eglBaseContext
         )
 
-        isRunning.distinctUntilChangedBy { it }
-            .onEach {
-                if (it) run(context) else disconnect()
-                logger.d { "isRunning: $it" }
-            }
-            .launchIn(this.serviceScope)
+        run(context)
+        _isRunning.value = true
     }
 
-    fun run(context: Context) {
-        if (isServiceUp) return
-
+    private fun run(context: Context) {
         runningJob = serviceScope.launch {
             webRTCClient.signalingCommandFlow.collect { (command, value) ->
                 handleSignalingCommand(command, value, context)
@@ -203,11 +192,9 @@ class WebRTCService {
         }
     }
 
-    fun disconnect() {
-        if (!isServiceUp) return
-
+    private suspend fun stopClient() {
         try {
-            runningJob?.cancel()
+            runningJob?.cancelAndJoin()
             runningJob = null
             // dispose video tracks
             localVideoTrackFlow.replayCache.forEach { it.dispose() }
@@ -231,8 +218,13 @@ class WebRTCService {
             webRTCClient.dispose()
         } finally {
             isStreaming = false
-            isServiceUp = false
         }
+    }
+
+    suspend fun stopService() {
+        logger.d { "Request to stop WebRTXService." }
+        stopClient()
+        _isRunning.value = false
     }
 
     private suspend fun sendAnswer() {

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -11,9 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.distinctUntilChangedBy
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.WenuLink.adapters.ServiceAddress
 import org.WenuLink.adapters.camera.CameraCapturer
@@ -45,15 +42,16 @@ class WebRTCService {
 
     // logger an coroutine scope
     private val logger by taggedLogger(WebRTCService::class.java.simpleName)
-    private lateinit var serviceScope: CoroutineScope // (SupervisorJob() + Dispatchers.Main)
+    private var serviceScope: CoroutineScope? = null // (SupervisorJob() + Dispatchers.Main)
     private var runningJob: Job? = null
 
     // element required for WebRTC logics
-    private lateinit var videoSource: VideoSource
-    private lateinit var localVideoTrack: VideoTrack
-    private lateinit var webRTCClient: WebRTCClient
-    private lateinit var peerConnectionFactory: StreamPeerConnectionFactory
-    private lateinit var surfaceTextureHelper: SurfaceTextureHelper
+    private var videoSource: VideoSource? = null
+    private var localVideoTrack: VideoTrack? = null
+    private var webRTCClient: WebRTCClient? = null
+    private var peerConnection: StreamPeerConnection? = null
+    private var peerConnectionFactory: StreamPeerConnectionFactory? = null
+    private var surfaceTextureHelper: SurfaceTextureHelper? = null
 
     // Signaling configuration
     private lateinit var signalingServer: ServiceAddress
@@ -86,21 +84,17 @@ class WebRTCService {
     }
     private var offer: String? = null
 
+    private fun makePeerConnection() = peerConnectionFactory!!.makePeerConnection(
+        coroutineScope = serviceScope!!,
+        configuration = peerConnectionFactory!!.rtcConfig,
+        type = StreamPeerType.PUBLISHER,
+        mediaConstraints = mediaConstraints,
+        onIceCandidateRequest = { iceCandidate, _ -> webRTCClient!!.sendCandidate(iceCandidate) }
+    )
+
     fun updateServerAddress(serverAddress: String) {
         val (ip, port) = serverAddress.split(":")
         signalingServer = ServiceAddress(ip, port.toInt(), "WS")
-    }
-
-    private val peerConnection: StreamPeerConnection by lazy {
-        peerConnectionFactory.makePeerConnection(
-            coroutineScope = serviceScope,
-            configuration = peerConnectionFactory.rtcConfig,
-            type = StreamPeerType.PUBLISHER,
-            mediaConstraints = mediaConstraints,
-            onIceCandidateRequest = { iceCandidate, _ ->
-                webRTCClient.sendCandidate(iceCandidate)
-            }
-        )
     }
 
     fun canStartClient() = CameraCapturer.hasCameraPresent() && isEnabled
@@ -111,25 +105,32 @@ class WebRTCService {
             return
         }
 
+        if (!::signalingServer.isInitialized) {
+            logger.e { "Signaling address not configured" }
+            return
+        }
+
+        if (webRTCClient != null) return
+
         this.serviceScope = serviceScope
 
         logger.i { "Connecting WebRTC client to $signalingServer" }
-        if (::webRTCClient.isInitialized) return
 
         webRTCClient = WebRTCClient(signalingServer.toString())
         peerConnectionFactory = StreamPeerConnectionFactory(context)
         surfaceTextureHelper = SurfaceTextureHelper.create(
             "SurfaceTextureHelperThread",
-            peerConnectionFactory.eglBaseContext
+            peerConnectionFactory!!.eglBaseContext
         )
+        peerConnection = makePeerConnection()
 
         run(context)
         _isRunning.value = true
     }
 
     private fun run(context: Context) {
-        runningJob = serviceScope.launch {
-            webRTCClient.signalingCommandFlow.collect { (command, value) ->
+        runningJob = serviceScope!!.launch {
+            webRTCClient!!.signalingCommandFlow.collect { (command, value) ->
                 handleSignalingCommand(command, value, context)
             }
         }
@@ -151,9 +152,9 @@ class WebRTCService {
 
     fun createVideoTrack(context: Context) {
         logger.d { "mediaOptions: $mediaOptions" }
-        videoSource = peerConnectionFactory.makeVideoSource(videoCapturer.isScreencast)
+        videoSource = peerConnectionFactory!!.makeVideoSource(videoCapturer.isScreencast)
             .apply {
-                videoCapturer.initialize(surfaceTextureHelper, context, this.capturerObserver)
+                videoCapturer.initialize(surfaceTextureHelper!!, context, this.capturerObserver)
                 videoCapturer.startCapture(
                     mediaOptions.videoResolutionWidth,
                     mediaOptions.videoResolutionHeight,
@@ -162,17 +163,17 @@ class WebRTCService {
                 isStreaming = true
             }
 
-        localVideoTrack = peerConnectionFactory.makeVideoTrack(
-            source = videoSource,
+        localVideoTrack = peerConnectionFactory!!.makeVideoTrack(
+            source = videoSource!!,
             trackId = "Video${UUID.randomUUID()}"
         )
     }
 
     fun onAnswerReady() {
-        peerConnection.connection.addTrack(localVideoTrack, listOf(mediaOptions.mediaStreamId))
-        serviceScope.launch {
+        peerConnection!!.connection.addTrack(localVideoTrack, listOf(mediaOptions.mediaStreamId))
+        serviceScope!!.launch {
             // sending local video track to show local video from start
-            _localVideoTrackFlow.emit(localVideoTrack)
+            _localVideoTrackFlow.emit(localVideoTrack!!)
 
             if (offer != null) sendAnswer()
         }
@@ -193,12 +194,23 @@ class WebRTCService {
     }
 
     private suspend fun stopClient() {
+        val job = runningJob
+        val helper = surfaceTextureHelper
+        val track = localVideoTrack
+        val pc = peerConnection
+        val client = webRTCClient
+
+        runningJob = null
+        surfaceTextureHelper = null
+        localVideoTrack = null
+        peerConnection = null
+        webRTCClient = null
+
         try {
-            runningJob?.cancelAndJoin()
-            runningJob = null
+            job?.cancelAndJoin()
             // dispose video tracks
             localVideoTrackFlow.replayCache.forEach { it.dispose() }
-            if (::localVideoTrack.isInitialized) localVideoTrack.dispose()
+            track?.dispose()
 
             // stop capturer
             try {
@@ -209,13 +221,11 @@ class WebRTCService {
             videoCapturer.dispose()
 
             // release surfaceTextureHelper
-            if (::surfaceTextureHelper.isInitialized) surfaceTextureHelper.dispose()
-
+            helper?.dispose()
             // close peer connection
-            peerConnection.connection.close()
-
+            pc?.connection?.close()
             // stop signaling client
-            webRTCClient.dispose()
+            client?.dispose()
         } finally {
             isStreaming = false
         }
@@ -228,13 +238,13 @@ class WebRTCService {
     }
 
     private suspend fun sendAnswer() {
-        peerConnection.setRemoteDescription(
+        peerConnection!!.setRemoteDescription(
             SessionDescription(SessionDescription.Type.OFFER, offer)
         )
-        val answer = peerConnection.createAnswer().getOrThrow()
-        val result = peerConnection.setLocalDescription(answer)
+        val answer = peerConnection!!.createAnswer().getOrThrow()
+        val result = peerConnection!!.setLocalDescription(answer)
         result.onSuccess {
-            webRTCClient.sendAnswer(answer.description)
+            webRTCClient!!.sendAnswer(answer.description)
         }
         logger.d { "[SDP] send answer: ${answer.stringify()}" }
     }
@@ -242,27 +252,27 @@ class WebRTCService {
     private fun handleOffer(sdp: String, context: Context) {
         logger.d { "[SDP] handle offer: $sdp" }
         createVideoTrack(context)
-        offer = webRTCClient.valueFromKey(sdp, "sdp")!!
+        offer = webRTCClient!!.valueFromKey(sdp, "sdp")!!
         onAnswerReady()
     }
 
     private suspend fun handleAnswer(sdp: String) {
         logger.d { "[SDP] handle answer: $sdp" }
-        peerConnection.setRemoteDescription(
+        peerConnection!!.setRemoteDescription(
             SessionDescription(
                 SessionDescription.Type.ANSWER,
-                webRTCClient.valueFromKey(sdp, "sdp")!!
+                webRTCClient!!.valueFromKey(sdp, "sdp")!!
             )
         )
     }
 
     private suspend fun handleIce(iceMessage: String) {
         logger.d { "[ICE] handle candidate: $iceMessage" }
-        peerConnection.addIceCandidate(
+        peerConnection!!.addIceCandidate(
             IceCandidate(
-                webRTCClient.valueFromKey(iceMessage, "id")!!,
-                webRTCClient.valueFromKey(iceMessage, "label")!!.toInt(),
-                webRTCClient.valueFromKey(iceMessage, "candidate")!!
+                webRTCClient!!.valueFromKey(iceMessage, "id")!!,
+                webRTCClient!!.valueFromKey(iceMessage, "label")!!.toInt(),
+                webRTCClient!!.valueFromKey(iceMessage, "candidate")!!
             )
         )
     }


### PR DESCRIPTION
`WebRTCService` teardown was driven by a collector on the `isRunning` flow:

`runProcess(false)` flipped a flag, and a launchIn-bound collector in `startClient` picked it up and called `disconnect()` asynchronously. Callers had no way to await completion, `stopWebRTCService().join()` only waited for the flag flip, not for the actual cleanup.

Replace the flow-driven indirection with a direct suspending API that mirrors `MAVLinkService.stopService()`:
- Rename `disconnect()` to `stopClient()`, make it suspend, and use `cancelAndJoin()` on `runningJob` so teardown actually completes before the function returns.
- Add `suspend fun stopService()` as the public entry point; flip `_isRunning` to false after teardown (matches `MAVLinkService` ordering, so observers see "stopped" only once teardown actually happened).
- Remove the `isRunning` collector from `startClient()`; start path now calls `run()` directly and flips `_isRunning = true` itself.
- Delete `runProcess(Boolean)`
- Update `WenuLinkService.stopWebRTCService()` and `ServicesViewModel .runWebRTC()` to match the MAVLink call shape, with `.join()` at the VM layer.

`isRunning` remains exposed as `StateFlow<Boolean>` for UI observers; only its role as a teardown trigger is removed.

---

Closes #85 