### PR TITLE
feature: Update and cleanup Dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ ktlint {
 
 android {
     namespace = "org.WenuLink"
-    compileSdk = 35
+    compileSdk = 36
     useLibrary("org.apache.http.legacy")
 
     defaultConfig {
@@ -109,27 +109,31 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    implementation(libs.androidx.runtime.livedata)
-    implementation(libs.androidx.foundation)
 
+    implementation(platform(libs.androidx.compose.bom))
+
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui)
+
+    // --- Testing ---
     testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
-    // DJI
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.junit)
+
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+
+    // --- AndroidX ---
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.multidex)
+
+    // --- DJI ---
     implementation(libs.dji.sdk) {
         // Uncomment the "library-anti-distortion" if your app does not need Anti Distortion for Mavic 2 Pro and Mavic 2 Zoom.
         // Uncomment the "fly-safe-database" if you need database for release, or we will download it when DJISDKManager.getInstance().registerApp
@@ -140,12 +144,15 @@ dependencies {
     }
     compileOnly(libs.dji.sdk.provided)
     // implementation("com.dji:dji-uxsdk:4.18")
-    // WebRTC and WebSocket
-    implementation(libs.stream.webrtc.android)
+
+    // --- Networking ---
     implementation(libs.okhttp)
-    // Log
     implementation(libs.stream.log)
-    // UI Rework
+    implementation(libs.stream.webrtc.android)
+
+    // ---UI Navigation ---
     implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.material.icons.extended)
+
+    // --- Icons ---
+    implementation(libs.androidx.compose.material.icons.extended)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,49 +1,54 @@
 [versions]
-agp = "8.12.0"
+activityCompose = "1.13.0"
+agp = "8.13.2"
+composeBom = "2026.03.01"
 constraintlayout = "2.2.1"
+coreKtx = "1.18.0"
 djiSdk = "4.18"
-kotlin = "2.2.0"
-ktlintPlugin = "14.1.0"
-ktlintEngine = "1.8.0"
-coreKtx = "1.16.0"
+espressoCore = "3.7.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.9.0"
-activityCompose = "1.10.1"
-composeBom = "2024.09.00"
+junitVersion = "1.3.0"
+kotlin = "2.3.20"
+ktlintEngine = "1.8.0"
+ktlintPlugin = "14.2.0"
+lifecycleRuntimeKtx = "2.10.0"
 multidex = "2.0.1"
-okhttp = "5.1.0"
-runtimeLivedata = "1.8.3"
-foundation = "1.9.0"
-streamLog = "1.3.4"
-streamWebrtcAndroid = "1.3.9"
 navigationCompose = "2.9.7"
-materialIconsExtended = "1.7.8"
+okhttp = "5.3.2"
+streamLog = "1.3.4"
+streamWebrtcAndroid = "1.3.10"
 
 [libraries]
+# --- AndroidX core ---
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
-androidx-ui = { group = "androidx.compose.ui", name = "ui" }
-androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
-androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+
+# --- Compose BOM ---
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+
+# --- Compose (Managed by BOM) ---
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+
+# --- Testing ---
+androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
+junit = { module = "junit:junit", version.ref = "junit" }
+
+# --- DJI ---
 dji-sdk = { module = "com.dji:dji-sdk", version.ref = "djiSdk" }
 dji-sdk-provided = { module = "com.dji:dji-sdk-provided", version.ref = "djiSdk" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+# --- Other Third-party
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 stream-log = { module = "io.getstream:stream-log", version.ref = "streamLog" }
 stream-webrtc-android = { module = "io.getstream:stream-webrtc-android", version.ref = "streamWebrtcAndroid" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Update versions in `libs.versions.toml`
- Reduce number of explicit versions by utilizing `androidx.compose.bom`
- Remove unused and redundant dependencies
- Sort libraries and versions
- Update to `gradle-8.14.4`
- Update `compileSdk` to 36