### PR TITLE
Fix mission upload ACK protocol for non-waypoint items

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
@@ -20,14 +20,13 @@ class MissionAssembler {
         nWaypoints = 0
     }
 
-    fun addTakeoff(coordinates: Coordinates3D) {
+    fun addTakeoff(coordinates: Coordinates3D): Boolean =
         nodes.add(MissionNode.Takeoff(coordinates))
-    }
 
-    fun addWaypoint(coordinates: Coordinates3D) {
-        nodes.add(MissionNode.Waypoint(coordinates))
-        nWaypoints += 1
-    }
+    fun addWaypoint(coordinates: Coordinates3D): Boolean =
+        nodes.add(MissionNode.Waypoint(coordinates)).also {
+            nWaypoints += 1
+        }
 
     fun addActionToLast(missionAction: MissionActionCommand) {
         (nodes.lastOrNull() as? MissionNode.Waypoint)

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -165,13 +165,13 @@ class MissionHandler : CommandHandler<MissionHandler>() {
 
     fun addWaypointNode(itemMsg: msg_mission_item_int): Boolean {
         logger.d { "Append mission item." }
-
         when (itemMsg.command) {
             MAV_CMD.MAV_CMD_NAV_TAKEOFF -> assembleTakeoffNode(itemMsg)
 
             MAV_CMD.MAV_CMD_NAV_WAYPOINT -> assembleWaypointNode(itemMsg)
 
-            MAV_CMD.MAV_CMD_NAV_DELAY -> state.assembler.addActionToLast(
+            MAV_CMD.MAV_CMD_NAV_DELAY,
+            MAV_CMD.MAV_CMD_CONDITION_DELAY -> state.assembler.addActionToLast(
                 DelayAction.fromParameters(NavDelayMessage(itemMsg))
             )
 
@@ -197,7 +197,6 @@ class MissionHandler : CommandHandler<MissionHandler>() {
 
             else -> return false
         }
-
         return true
     }
 
@@ -259,9 +258,7 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         logger.d { "Scheduling $action" }
         MissionActionManager.clearScheduleAndListeners()
         return MissionActionManager.schedule(action)
-            ?.let {
-                CommandResult.error("Error in $action: ${it.description}")
-            }
+            ?.let { CommandResult.error("Error in $action: ${it.description}") }
             ?: CommandResult.ok
     }
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -221,7 +221,12 @@ class NavigationController(
         }
 
         // Store item and request next or upload the mission
-        handler.mission.addWaypointNode(itemMsg)
+        val accepted = handler.mission.addWaypointNode(itemMsg)
+        if (!accepted) {
+            logger.w { "Unsupported mission command: ${itemMsg.command}" }
+            sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED)
+            return
+        }
         ackReceivedItem(nextExpectedSeq)
         nextExpectedSeq += 1
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -41,7 +41,7 @@ import org.WenuLink.mavlink.messages.NavTakeoffMissionItem
 import org.WenuLink.mavlink.messages.NavWaypointMissionItem
 
 /**
- * MAVLinkController class to deal with the handler.mission service and related MAVLink messages.
+ * MAVLinkController class to deal with the mission service and related MAVLink messages.
  *
  * https://mavlink.io/en/services/handler.mission.html
  *
@@ -58,6 +58,7 @@ class NavigationController(
     private var maxRetryTimes = 5
     private var currentRetryTimes = 0
     private var numberOfExpectedItems = -1
+    private var nextExpectedSeq = 0
     var wasRequested = false
         private set
 
@@ -179,14 +180,16 @@ class NavigationController(
 
         if (!handler.mission.state.canCreateMission()) return
 
-        // TODO: Stop handler.mission execution first if needed
+        // TODO: Stop mission execution first if needed
         numberOfExpectedItems = missionMsg.count
+        currentRetryTimes = 0
+        nextExpectedSeq = 0
 
-        // Only creates a new handler.mission if has elements on it
+        // Only creates a new mission if has elements on it
         if (numberOfExpectedItems > 0) {
             // ask for the first item an iterate over count
-            logger.d { "Creating new handler.mission with ${missionMsg.count} items" }
-            // Request first handler.mission item...
+            logger.d { "Creating new mission with ${missionMsg.count} items" }
+            // Request first mission item...
             requestMissionItem(0)
             // TODO: timeout waiting start?
         }
@@ -203,28 +206,30 @@ class NavigationController(
         logger.d { "processMissionItem" }
         val itemMsg = msg as msg_mission_item_int
         logger.d { "\t$itemMsg" }
+
         // Validate sequence
-        val expectedSeq = handler.mission.state.totalNodes()
-        if (itemMsg.seq != expectedSeq) {
-            logger.e { "Received item #${itemMsg.seq} instead #$expectedSeq, re-requesting..." }
+        if (itemMsg.seq != nextExpectedSeq) {
+            logger.e { "Received item #${itemMsg.seq} instead #$nextExpectedSeq, re-requesting..." }
             if (currentRetryTimes < maxRetryTimes) {
-                requestMissionItem(expectedSeq)
+                requestMissionItem(nextExpectedSeq)
                 currentRetryTimes += 1
             } else {
                 logger.w { "Max re-requesting attempts reached" }
+                sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_INVALID_SEQUENCE)
             }
-
             return
         }
-        // Store item and request next or upload the handler.mission
+
+        // Store item and request next or upload the mission
         handler.mission.addWaypointNode(itemMsg)
-        ackReceivedItem(expectedSeq)
+        ackReceivedItem(nextExpectedSeq)
+        nextExpectedSeq += 1
 
         if (itemMsg.seq < numberOfExpectedItems - 1) {
-            // request next handler.mission item
-            requestMissionItem(expectedSeq + 1)
+            // request next mission item
+            requestMissionItem(nextExpectedSeq)
         } else {
-            // reached the end of the handler.mission items
+            // reached the end of the mission items
             handler.mission.uploadWaypoints { result ->
                 if (result.hasError) {
                     sendStatusText(
@@ -258,7 +263,7 @@ class NavigationController(
     )
 
     fun missionStart(commandLongMsg: msg_command_long) {
-        // TODO: Process init seq to custom first handler.mission element
+        // TODO: Process init seq to custom first mission element
         val params = MissionStartCommandLong(commandLongMsg)
 
         client.sendMessage(
@@ -313,7 +318,7 @@ class NavigationController(
 //        val reset = msg.param2 == 1f
 //        val requestedSeq = msg.param1.toInt()
 //
-//        // TODO; stop first if must, update currentItemSequence, and current handler.mission in aircraft(?)
+//        // TODO; stop first if must, update currentItemSequence, and current mission in aircraft(?)
 //
 //        currentItemSequence = if (requestedSeq == -1 || reset) 0 else requestedSeq
 //        startMission { error ->


### PR DESCRIPTION
- adds a separate sequence counter to `NavigationController`
- adds Message ACKs to all failure branches in `processMissionItem`
- adds check if `addWaypointNode` was successfull
- adds `MAV_CMD_CONDITION_DELAY`
