### PR TITLE
Concurrency bug in `ParameterRegistry.filterAvailable`

### DIFF
--- a/app/src/main/java/org/WenuLink/parameters/ParameterBase.kt
+++ b/app/src/main/java/org/WenuLink/parameters/ParameterBase.kt
@@ -1,6 +1,12 @@
 package org.WenuLink.parameters
 
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
 
 enum class SemanticType {
     BOOL,
@@ -76,30 +82,24 @@ class ParameterRegistry(private val providers: List<ParameterProvider>) {
     private lateinit var byIndex: Map<Int, WenuLinkParameter>
     private lateinit var byName: Map<String, WenuLinkParameter>
 
-    suspend fun filterAvailable(parameters: List<ParameterSpec>): List<WenuLinkParameter> {
-        val availableParams = mutableListOf<WenuLinkParameter>()
-        var index = 0
-        var counter = 0
-        parameters.forEach { spec ->
-            spec.read { value ->
-                if (value != null) {
-                    spec.index = index
-                    index += 1
-                    availableParams += WenuLinkParameter(
-                        spec,
-                        value
-                    )
+    suspend fun filterAvailable(parameters: List<ParameterSpec>): List<WenuLinkParameter> =
+        coroutineScope {
+            parameters
+                .map { spec ->
+                    async {
+                        val value = suspendCoroutine { cont ->
+                            spec.read { cont.resume(it) }
+                        }
+                        value?.let { spec to it }
+                    }
                 }
-                counter += 1
-            }
+                .awaitAll()
+                .filterNotNull()
+                .mapIndexed { i, (spec, value) ->
+                    spec.index = i
+                    WenuLinkParameter(spec, value)
+                }
         }
-
-        while (counter < parameters.size) {
-            delay(500)
-        }
-
-        return availableParams
-    }
 
     fun isLoaded() = ::params.isInitialized && ::byName.isInitialized
 


### PR DESCRIPTION
`ParameterRegistry.load()` intermittently crashes with an NPE during `BootCommand` execution. The failure is timing-dependent and not always reproducible on the same hardware.

#### Stack trace

```
java.lang.NullPointerException: Attempt to invoke virtual method
  'org.WenuLink.parameters.ParameterSpec org.WenuLink.parameters.WenuLinkParameter.getSpec()'
  on a null object reference
    at org.WenuLink.parameters.ParameterRegistry.load(ParameterBase.kt:111)
    at org.WenuLink.parameters.ParameterRegistry$load$1.invokeSuspend(Unknown Source:14)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(...)
    at kotlinx.coroutines.android.HandlerContext$scheduleResumeAfterDelay$$inlined$Runnable$1.run(...)
```

Logcat context just before the crash:

```
AircraftHandler  Executing: BootCommand
AircraftHandler  Aircraft booting...
AircraftHandler  Loading parameters
AircraftHandler  Command failed: BootCommand
WenuLinkApp      Workflow: Boot error: ...getSpec() on a null object reference
AndroidRuntime   FATAL EXCEPTION: main
```

#### Root cause

`filterAvailable` mutates `availableParams`, `index`, and `counter` from DJI SDK callbacks that fire on background worker threads, with no synchronization:

```kotlin
parameters.forEach { spec ->
    spec.read { value ->        // DJI callback, background thread
        if (value != null) {
            spec.index = index
            index += 1
            availableParams += WenuLinkParameter(spec, value)
        }
        counter += 1
    }
}
```

Concurrent `+=` on a plain `ArrayList` can leave null elements in the backing array (one thread bumps `size`, another thread's element write hasn't been published yet). `load()` then iterates `params` via `associateBy { it.spec.index }` and dereferences a null slot, producing the NPE on `getSpec()`.

#### Solution

Replace the fire-and-poll design with structured concurrency: wrap each callback-based read in `suspendCoroutine`, run them under `coroutineScope { ... async { ... } }.awaitAll()`, and assign `spec.index` deterministically after all reads return. This removes the shared mutable state entirely