### PR TITLE
Add release signing config and CI workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write  # required by softprops/action-gh-release to publish a release
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/keystore"
+          echo "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/keystore/release.keystore"
+
+      - name: Write local.properties
+        env:
+          KEYSTORE_PATH: ${{ runner.temp }}/keystore/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          DJI_API_KEY: ${{ secrets.DJI_API_KEY }}
+        run: |
+          cat > local.properties <<EOF
+          release.keystore.path=$KEYSTORE_PATH
+          release.keystore.password=$KEYSTORE_PASSWORD
+          release.key.alias=$KEY_ALIAS
+          release.key.password=$KEY_PASSWORD
+          dji.api.key=$DJI_API_KEY
+          EOF
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      - name: Rename APK to include version
+        id: rename
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          SRC="app/build/outputs/apk/release/app-release.apk"
+          DEST="app/build/outputs/apk/release/WenuLink-${VERSION}.apk"
+          mv "$SRC" "$DEST"
+          echo "apk_path=$DEST" >> "$GITHUB_OUTPUT"
+
+      - name: Verify APK signature
+        run: |
+          BUILD_TOOLS_DIR=$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -n 1)
+          "$BUILD_TOOLS_DIR/apksigner" verify --verbose "${{ steps.rename.outputs.apk_path }}"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          name: ${{ github.ref_name }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
+          files: ${{ steps.rename.outputs.apk_path }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,18 @@ android {
         )
     }
 
+    signingConfigs {
+        create("release") {
+            val keystorePath = localProps.getProperty("release.keystore.path")
+            if (!keystorePath.isNullOrBlank()) {
+                storeFile = file(keystorePath)
+                storePassword = localProps.getProperty("release.keystore.password")
+                keyAlias = localProps.getProperty("release.key.alias")
+                keyPassword = localProps.getProperty("release.key.password")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -89,6 +101,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+
+            val releaseSigning = signingConfigs.getByName("release")
+            if (releaseSigning.storeFile != null) {
+                signingConfig = releaseSigning
+            }
         }
     }
 


### PR DESCRIPTION
Adds the infrastructure needed to produce signed release APKs via CI. Required before cutting `v0.1.0-alpha`.

Related to #65.

### Changes

- `app/build.gradle.kts`: adds a `signingConfigs.release` block that reads from `local.properties`. The release `buildType` applies the config only when a keystore path is configured, so debug and contributor builds without release secrets are unaffected.
- `.github/workflows/release.yml`: new workflow triggered on `v*` tag pushes. Decodes the release keystore from secrets, writes a `local.properties`, builds with `./gradlew assembleRelease`, verifies the APK signature with `apksigner`, and publishes a GitHub Release with the signed APK attached. Tags containing a dash are auto-flagged as pre-releases.

### Required GitHub Actions secrets

The workflow will not succeed until these secrets are populated at the org or repo level:

- `RELEASE_KEYSTORE_BASE64`
- `RELEASE_KEYSTORE_PASSWORD`
- `RELEASE_KEY_ALIAS`
- `RELEASE_KEY_PASSWORD`
- `DJI_API_KEY`

