### PR TITLE
Fix: NaN crash in outgoing telemetry messages

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -33,8 +33,12 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     val telemetry = TelemetryHandler.getInstance()
     val currentTelemetry: TelemetryData? get() = telemetry.getData()
     val currentCoordinates: Coordinates3D?
-        get() = telemetry.getData()?.let {
-            Coordinates3D(it.latitude, it.longitude, it.relativeAltitude)
+        get() {
+            val data = telemetry.getData() ?: return null
+            val lat = data.latitude ?: return null
+            val lon = data.longitude ?: return null
+            val rel = data.relativeAltitude ?: return null
+            return Coordinates3D(lat, lon, rel)
         }
     var isPowerOff = true
     val parameters by lazy {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryData.kt
@@ -15,8 +15,8 @@ data class TelemetryData(
     val roll: Double,
     val pitch: Double,
     val yaw: Double,
-    val latitude: Double,
-    val longitude: Double,
+    val latitude: Double?,
+    val longitude: Double?,
     val positionX: Float,
     val positionY: Float,
     val positionZ: Float,
@@ -24,9 +24,13 @@ data class TelemetryData(
     val velocityY: Float,
     val velocityZ: Float,
     val flightTime: Int,
-    val takeOffAltitude: Float,
-    val relativeAltitude: Float,
-    val altitude: Float = takeOffAltitude + relativeAltitude,
+    val takeOffAltitude: Float?,
+    val relativeAltitude: Float?,
+    val altitude: Float? = if (takeOffAltitude != null && relativeAltitude != null) {
+        takeOffAltitude + relativeAltitude
+    } else {
+        null
+    },
     val isFlying: Boolean,
     val motorsOn: Boolean,
     val satelliteCount: Int,
@@ -58,10 +62,18 @@ object TelemetryMapper {
         roll = source.roll.toFloat(),
         pitch = source.pitch.toFloat(),
         yaw = source.yaw.toFloat(),
-        latitude = MessageUtils.coordinateDJI2MAVLink(source.latitude),
-        longitude = MessageUtils.coordinateDJI2MAVLink(source.longitude),
-        relativeAltitude = MessageUtils.altitudeDJI2MAVLink(source.relativeAltitude),
-        takeOffAltitude = MessageUtils.altitudeDJI2MAVLink(source.takeOffAltitude),
+        latitude = source.latitude
+            ?.let { MessageUtils.coordinateDJI2MAVLink(it) }
+            ?: Int.MAX_VALUE,
+        longitude = source.longitude
+            ?.let { MessageUtils.coordinateDJI2MAVLink(it) }
+            ?: Int.MAX_VALUE,
+        relativeAltitude = source.relativeAltitude
+            ?.let { MessageUtils.altitudeDJI2MAVLink(it) }
+            ?: Int.MAX_VALUE,
+        takeOffAltitude = source.takeOffAltitude
+            ?.let { MessageUtils.altitudeDJI2MAVLink(it) }
+            ?: Int.MAX_VALUE,
         velocityX = (source.velocityX * 100).roundToInt().toShort(),
         velocityY = (source.velocityY * 100).roundToInt().toShort(),
         velocityZ = (source.velocityZ * 100).roundToInt().toShort(),

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -183,7 +183,7 @@ class CameraController(
 
         // register callback for the duration of this capture session
         handler.onImageCaptured = fun(cameraId, seqIndex) {
-            val telemetry = handler.aircraft.telemetry.getData() ?: return
+            val telemetry = handler.aircraft.currentTelemetry ?: return
             client.sendMessage(msgImageCaptured(ImageMetadata(seqIndex, true, cameraId, telemetry)))
         }
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
@@ -167,7 +167,7 @@ class ConnectionController(
     }
 
     fun msgAttitude(): MAVLinkMessage? = msg_attitude().apply {
-        val telemetryData = handler.aircraft.telemetry.getData() ?: return null
+        val telemetryData = handler.aircraft.currentTelemetry ?: return null
         // TODO: this next line causes an exception
         // msg.time_boot_ms = getTimestampMilliseconds();
         roll = (telemetryData.roll * Math.PI / 180).toFloat()
@@ -180,9 +180,10 @@ class ConnectionController(
     }
 
     fun msgAltitude(): MAVLinkMessage? = msg_altitude().apply {
-        val data = handler.aircraft.telemetry.getData() ?: return null
+        val data = handler.aircraft.currentTelemetry ?: return null
+        val alt = data.altitude ?: return null
 
-        altitude_relative = data.altitude
+        altitude_relative = alt
 //        client.sendMessage(msg)
     }
 
@@ -190,7 +191,8 @@ class ConnectionController(
     fun msgVibration(): MAVLinkMessage = msg_vibration()
 
     fun msgHUD(): MAVLinkMessage? = msg_vfr_hud().apply {
-        val telemetryData = handler.aircraft.telemetry.getData() ?: return null
+        val telemetryData = handler.aircraft.currentTelemetry ?: return null
+        val altitude = telemetryData.altitude ?: return null
         val rcData = handler.aircraft.telemetry.getRCData()?.toMAVLink() ?: return null
 
         // Mavlink: Current airspeed in m/s
@@ -207,7 +209,7 @@ class ConnectionController(
         this.heading = heading.toInt().toShort()
         // vertical info
         throttle = rcData.throttleSetting
-        alt = -telemetryData.altitude
+        alt = -altitude
         // Mavlink: Current climb rate in meters/second
         // DJI: m/s, positive values down
         climb = -telemetryData.velocityZ

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -348,25 +348,32 @@ class NavigationController(
     // TODO: start, pause, and resume procedures
 
     fun msgHomePosition(): MAVLinkMessage? = msg_home_position().apply {
-        val coordinates = handler.aircraft.state.homeCoordinates ?: return null
+        val telemetryData = handler.aircraft.currentTelemetry ?: return null
+        val latVal = telemetryData.latitude ?: return null
+        val lonVal = telemetryData.longitude ?: return null
+        val altVal = telemetryData.altitude ?: return null
 
-        latitude = MessageUtils.coordinateDJI2MAVLink(coordinates.lat)
-        longitude = MessageUtils.coordinateDJI2MAVLink(coordinates.long)
-        altitude = MessageUtils.altitudeDJI2MAVLink(coordinates.alt)
+        latitude = MessageUtils.coordinateDJI2MAVLink(latVal)
+        longitude = MessageUtils.coordinateDJI2MAVLink(lonVal)
+        altitude = MessageUtils.altitudeDJI2MAVLink(altVal)
     }
 
     fun msgGlobalPositionInt(): MAVLinkMessage? = msg_global_position_int().apply {
-        val telemetryData = handler.aircraft.telemetry.getData() ?: return null
+        val telemetryData = handler.aircraft.currentTelemetry ?: return null
+        val latVal = telemetryData.latitude ?: return null
+        val lonVal = telemetryData.longitude ?: return null
+        val altVal = telemetryData.altitude ?: return null
+        val relAltVal = telemetryData.relativeAltitude ?: return null
 
-        lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
-        lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
-        alt = MessageUtils.altitudeDJI2MAVLink(telemetryData.altitude)
+        lat = MessageUtils.coordinateDJI2MAVLink(latVal)
+        lon = MessageUtils.coordinateDJI2MAVLink(lonVal)
+        alt = MessageUtils.altitudeDJI2MAVLink(altVal)
         // NOTE: Commented out this field, because relative_alt seems to be intended for
         // altitude above the current terrain, but DJI reports altitude above home point.
         // Mavlink: Millimeters above ground (unspecified: presumably above home point?)
         // DJI: relative altitude of the aircraft relative to take off location, measured by
         // barometer, in meters.
-        relative_alt = MessageUtils.altitudeDJI2MAVLink(telemetryData.relativeAltitude)
+        relative_alt = MessageUtils.altitudeDJI2MAVLink(relAltVal)
         vx = (telemetryData.velocityX * 100).roundToInt().toShort()
         vy = (telemetryData.velocityY * 100).roundToInt().toShort()
         vz = (telemetryData.velocityZ * 100).roundToInt().toShort()
@@ -377,22 +384,24 @@ class NavigationController(
     }
 
     fun msgRawGPSInt(): MAVLinkMessage? = msg_gps_raw_int().apply {
-        val telemetryData = handler.aircraft.telemetry.getData() ?: return null
-
         if (handler.aircraft.telemetry.isSimulationActive) {
             fix_type = GPS_FIX_TYPE.GPS_FIX_TYPE_2D_FIX.toShort()
             return@apply
         }
 
+        val telemetryData = handler.aircraft.currentTelemetry ?: return null
+        val latVal = telemetryData.latitude ?: return null
+        val lonVal = telemetryData.longitude ?: return null
+
         time_usec = MessageUtils.getMicroTime()
-        lat = MessageUtils.coordinateDJI2MAVLink(telemetryData.latitude)
-        lon = MessageUtils.coordinateDJI2MAVLink(telemetryData.longitude)
+        lat = MessageUtils.coordinateDJI2MAVLink(latVal)
+        lon = MessageUtils.coordinateDJI2MAVLink(lonVal)
         satellites_visible = telemetryData.satelliteCount.toShort()
         fix_type = telemetryData.gpsFixType.toShort()
     }
 
     fun msgLocalPositionNed(): MAVLinkMessage? = msg_local_position_ned().apply {
-        val telemetryData = handler.aircraft.telemetry.getData() ?: return null
+        val telemetryData = handler.aircraft.currentTelemetry ?: return null
 
         time_boot_ms = handler.systemBootTime
         x = telemetryData.positionX

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -12,6 +12,11 @@ import org.WenuLink.adapters.aircraft.GPSMapper
 import org.WenuLink.adapters.aircraft.SensorState as AppSensorState
 import org.WenuLink.adapters.aircraft.TelemetryData
 
+private fun Double.finiteOrNull(): Double? = takeIf { isFinite() }
+private fun Float.finiteOrNull(): Float? = takeIf { isFinite() }
+private fun Double.finiteOr(default: Double): Double = if (isFinite()) this else default
+private fun Float.finiteOr(default: Float): Float = if (isFinite()) this else default
+
 object FCManager {
     private val logger by taggedLogger(FCManager::class.java.simpleName)
 
@@ -45,20 +50,20 @@ object FCManager {
         }
 
     fun state2Telemetry(state: FlightControllerState): TelemetryData = TelemetryData(
-        roll = state.attitude.roll,
-        pitch = state.attitude.pitch,
-        yaw = state.attitude.yaw,
-        latitude = state.aircraftLocation.latitude,
-        longitude = state.aircraftLocation.longitude,
+        roll = state.attitude.roll.finiteOr(0.0),
+        pitch = state.attitude.pitch.finiteOr(0.0),
+        yaw = state.attitude.yaw.finiteOr(0.0),
+        latitude = state.aircraftLocation.latitude.finiteOrNull(),
+        longitude = state.aircraftLocation.longitude.finiteOrNull(),
         positionX = 0f,
         positionY = 0f,
         positionZ = 0f,
-        velocityX = state.velocityX,
-        velocityY = state.velocityY,
-        velocityZ = state.velocityZ,
+        velocityX = state.velocityX.finiteOr(0f),
+        velocityY = state.velocityY.finiteOr(0f),
+        velocityZ = state.velocityZ.finiteOr(0f),
         flightTime = state.flightTimeInSeconds,
-        takeOffAltitude = state.takeoffLocationAltitude,
-        relativeAltitude = state.aircraftLocation.altitude,
+        takeOffAltitude = state.takeoffLocationAltitude.finiteOrNull(),
+        relativeAltitude = state.aircraftLocation.altitude.finiteOrNull(),
         isFlying = state.isFlying,
         motorsOn = state.areMotorsOn(),
         satelliteCount = state.satelliteCount,


### PR DESCRIPTION
### Problem

During indoor field testing with a Mavic 2 Pro, the app produced a sustained flood of `IllegalArgumentException: Cannot round NaN value` exceptions from the outgoing-message pipeline. The exceptions are caught downstream so the app keeps running, but every affected MAVLink message is dropped, meaning QGC receives almost no telemetry while the condition persists.

Excerpt from the logcat:

```bash
2026-04-27 16:16:54.xxx ERROR MAVLinkClient: (DefaultDispatcher-worker-11:4040) Error in outgoingMessages java.lang.IllegalArgumentException: Cannot round NaN value.
2026-04-27 16:16:54 ERROR MAVLinkClient: (DefaultDispatcher-worker-13:4042) Error in outgoingMessages java.lang.IllegalArgumentException: Cannot round NaN value.
2026-04-27 16:16:54 ERROR MAVLinkClient: (DefaultDispatcher-worker-3:3914)  Error in outgoingMessages java.lang.IllegalArgumentException: Cannot round NaN value.
2026-04-27 16:16:54 ERROR MAVLinkClient: (DefaultDispatcher-worker-5:3916)  Error in outgoingMessages java.lang.IllegalArgumentException: Cannot round NaN value.
INFO  chatty: uid=10209(org.WenuLink) DefaultDispatch identical 44 lines
ERROR MAVLinkClient: (DefaultDispatcher-worker-3:3914)  Error in outgoingMessages java.lang.IllegalArgumentException: Cannot round NaN value.
INFO  chatty: uid=10209(org.WenuLink) DefaultDispatch identical 71 lines
…
```

### Root cause

DJI's `FlightControllerState` returns NaN for `aircraftLocation.latitude/longitude/altitude` (and related fields) when GPS is unavailable, e.g. indoors. These NaN values flowed unchecked through `FCManager.state2Telemetry` into `TelemetryData`, and from there into MAVLink message builders that scale the values via `kotlin.math.roundToInt()`. Of the rounding helpers, `roundToInt()` is the only one that throws on NaN; `round()` and `Double.toInt()` handle it gracefully. But silently mapping NaN to 0 here would teleport the drone to (0, 0) on QGC's map, which is worse than not sending the message.

### Changes:

- `FCManager.state2Telemetry` sanitizes incoming DJI values via `finiteOr` / `finiteOrNull` extensions. NaN/Inf in lat/lon/altitudes becomes `null`. NaN/Inf in angles and velocities becomes `0`
- `TelemetryData` makes `latitude`, `longitude`, `takeOffAltitude`, `relativeAltitude`, and the derived `altitude` nullable. Other Doubles/Floats remain non-nullable but are now guaranteed finite by the boundary contract
- Message builders that depend on position (`msgGlobalPositionInt`, `msgRawGPSInt`, `msgAltitude`, `msgHUD`) return `null` when required fields are unavailable, which causes the message to be skipped
- `TelemetryMapper.toMavlink` translates `null` -> `Int.MAX_VALUE` (MAVLink's documented unknown dummy value for scaled-int position fields)
- `AircraftHandler.currentCoordinates` aggregates the three nullable fields into `Coordinates3D?`