### PR TITLE
Split address configuration into separate IP and port fields

### DIFF
--- a/app/src/main/java/org/WenuLink/WenuLinkPreferences.kt
+++ b/app/src/main/java/org/WenuLink/WenuLinkPreferences.kt
@@ -6,14 +6,22 @@ import androidx.core.content.edit
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+private fun SharedPreferences.getStringOrDefault(key: String, default: String): String =
+    getString(key, default) ?: default
+
 object WenuLinkPreferences {
     private const val PREFS_NAME = "wenulink_config"
-    private const val KEY_MAVLINK_GCS_ADDRESS = "mavlink_gcs_address"
-    private const val KEY_WEBRTC_SIGNAL_ADDRESS = "webrtc_signal_address"
+
+    private const val KEY_MAVLINK_IP = "mavlink_ip"
+    private const val KEY_MAVLINK_PORT = "mavlink_port"
+    private const val KEY_WEBRTC_IP = "webrtc_ip"
+    private const val KEY_WEBRTC_PORT = "webrtc_port"
     private const val KEY_THEME = "app_theme_mode"
 
-    private const val MAVLINK_DEFAULT_ADDRESS = "192.168.1.220:14550"
-    private const val WEBRTC_DEFAULT_ADDRESS = "192.168.1.100:8090"
+    private const val MAVLINK_DEFAULT_IP = "192.168.1.220"
+    private const val MAVLINK_DEFAULT_PORT = 14550
+    private const val WEBRTC_DEFAULT_IP = "192.168.1.100"
+    private const val WEBRTC_DEFAULT_PORT = 8090
 
     private val _themeFlow = MutableStateFlow<Int?>(null)
     val themeFlow = _themeFlow.asStateFlow()
@@ -21,20 +29,29 @@ object WenuLinkPreferences {
     private fun getPrefs(context: Context): SharedPreferences =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-    private fun SharedPreferences.getStringOrDefault(key: String, default: String): String =
-        getString(key, default) ?: default
-
     fun getMavlinkIp(context: Context): String =
-        getPrefs(context).getStringOrDefault(KEY_MAVLINK_GCS_ADDRESS, MAVLINK_DEFAULT_ADDRESS)
+        getPrefs(context).getStringOrDefault(KEY_MAVLINK_IP, MAVLINK_DEFAULT_IP)
 
     fun saveMavlinkIp(context: Context, ip: String) =
-        getPrefs(context).edit { putString(KEY_MAVLINK_GCS_ADDRESS, ip) }
+        getPrefs(context).edit { putString(KEY_MAVLINK_IP, ip) }
+
+    fun getMavlinkPort(context: Context): Int =
+        getPrefs(context).getInt(KEY_MAVLINK_PORT, MAVLINK_DEFAULT_PORT)
+
+    fun saveMavlinkPort(context: Context, port: Int) =
+        getPrefs(context).edit { putInt(KEY_MAVLINK_PORT, port) }
 
     fun getWebRtcIp(context: Context): String =
-        getPrefs(context).getStringOrDefault(KEY_WEBRTC_SIGNAL_ADDRESS, WEBRTC_DEFAULT_ADDRESS)
+        getPrefs(context).getStringOrDefault(KEY_WEBRTC_IP, WEBRTC_DEFAULT_IP)
 
     fun saveWebRtcIp(context: Context, ip: String) =
-        getPrefs(context).edit { putString(KEY_WEBRTC_SIGNAL_ADDRESS, ip) }
+        getPrefs(context).edit { putString(KEY_WEBRTC_IP, ip) }
+
+    fun getWebRtcPort(context: Context): Int =
+        getPrefs(context).getInt(KEY_WEBRTC_PORT, WEBRTC_DEFAULT_PORT)
+
+    fun saveWebRtcPort(context: Context, port: Int) =
+        getPrefs(context).edit { putInt(KEY_WEBRTC_PORT, port) }
 
     fun getThemeMode(context: Context): Int {
         val mode = getPrefs(context).getInt(KEY_THEME, 0)

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -46,12 +46,18 @@ class WenuLinkService : Service() {
         // create WebRTC instance
         if (WebRTCService.isEnabled && !isWebRTCReady()) {
             webRTC = WebRTCService.getInstance()
-            webRTC.updateServerAddress(WenuLinkPreferences.getWebRtcIp(applicationContext))
+            webRTC.updateServerAddress(
+                WenuLinkPreferences.getWebRtcIp(applicationContext),
+                WenuLinkPreferences.getWebRtcPort(applicationContext)
+            )
         }
         // create MAVLink instance
         if (MAVLinkService.isEnabled && !isMAVLinkReady()) {
             mavlink = MAVLinkService(handler)
-            mavlink.updateGCSAddress(WenuLinkPreferences.getMavlinkIp(applicationContext))
+            mavlink.updateGCSAddress(
+                WenuLinkPreferences.getMavlinkIp(applicationContext),
+                WenuLinkPreferences.getMavlinkPort(applicationContext)
+            )
         }
     }
 

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -37,9 +37,8 @@ class MAVLinkService(handler: WenuLinkHandler) {
     private val _isRunning = MutableStateFlow(false)
     val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
 
-    fun updateGCSAddress(serverAddress: String) {
-        val (ip, port) = serverAddress.split(":")
-        groundControlStation = ServiceAddress(ip, port.toInt(), "UDP")
+    fun updateGCSAddress(ip: String, port: Int) {
+        groundControlStation = ServiceAddress(ip, port, "UDP")
     }
 
     fun clientExists() = client != null

--- a/app/src/main/java/org/WenuLink/ui/screens/config/AddressScreen.kt
+++ b/app/src/main/java/org/WenuLink/ui/screens/config/AddressScreen.kt
@@ -1,58 +1,46 @@
 package org.WenuLink.ui.screens.config
 
-import android.content.ClipData
-import android.widget.Toast
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import kotlinx.coroutines.launch
 import org.WenuLink.ui.navigation.AddressTarget
 import org.WenuLink.views.SettingsViewModel
 
 private data class AddressScreenConfig(
     val title: String,
-    val label: String,
-    val placeholder: String,
-    val onSave: () -> Unit
+    val ipLabel: String,
+    val ipPlaceholder: String,
+    val portPlaceholder: String
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -63,33 +51,46 @@ fun AddressScreen(
     isServiceRunning: Boolean,
     target: AddressTarget
 ) {
-    val context = LocalContext.current
-    val clipboard = LocalClipboard.current
-    val scope = rememberCoroutineScope()
+    val focusManager = LocalFocusManager.current
 
-    // config variable
-    val currentAddress by when (target) {
+    val currentIp by when (target) {
         is AddressTarget.MAVLink -> settingsViewModel.mavlinkIp.collectAsState()
         is AddressTarget.WebRTC -> settingsViewModel.webrtcIp.collectAsState()
     }
+    val currentPort by when (target) {
+        is AddressTarget.MAVLink -> settingsViewModel.mavlinkPort.collectAsState()
+        is AddressTarget.WebRTC -> settingsViewModel.webrtcPort.collectAsState()
+    }
+    val saveIp: (String) -> Unit = when (target) {
+        is AddressTarget.MAVLink -> settingsViewModel::saveMavlinkIp
+        is AddressTarget.WebRTC -> settingsViewModel::saveWebrtcIp
+    }
+    val savePort: (Int) -> Unit = when (target) {
+        is AddressTarget.MAVLink -> settingsViewModel::saveMavlinkPort
+        is AddressTarget.WebRTC -> settingsViewModel::saveWebrtcPort
+    }
 
-    var localAddress by remember(currentAddress) { mutableStateOf(currentAddress) }
-
-    var isEditing by remember { mutableStateOf(false) }
-
-    val config: AddressScreenConfig = when (target) {
+    val config = when (target) {
         is AddressTarget.MAVLink -> AddressScreenConfig(
-            "MAVLink Protocol",
-            "MAVLink GCS Address",
-            "e.g. 192.168.1.220:14550"
-        ) { settingsViewModel.saveMavlinkIp(localAddress) }
+            title = "MAVLink Protocol",
+            ipLabel = "MAVLink GCS Address",
+            ipPlaceholder = "e.g. 192.168.1.220",
+            portPlaceholder = "14550"
+        )
 
         is AddressTarget.WebRTC -> AddressScreenConfig(
-            "WebRTC Streaming",
-            "WebRTC Signaling Address",
-            "e.g. 192.168.1.100:8090"
-        ) { settingsViewModel.saveWebrtcIp(localAddress) }
+            title = "WebRTC Streaming",
+            ipLabel = "WebRTC Signaling Address",
+            ipPlaceholder = "e.g. 192.168.1.100",
+            portPlaceholder = "8090"
+        )
     }
+
+    var ipInput by remember(currentIp) { mutableStateOf(currentIp) }
+    var portInput by remember(currentPort) { mutableStateOf(currentPort.toString()) }
+
+    val ipError = validateIp(ipInput)
+    val portError = validatePort(portInput)
 
     ConfigScaffold(config.title, navController) {
         if (isServiceRunning) {
@@ -112,148 +113,100 @@ fun AddressScreen(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = "Stop Drone Service to edit addresses",
+                        text = "Stop Drone Service to edit address",
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onErrorContainer,
                         fontWeight = FontWeight.Bold
                     )
                 }
             }
-        } else {
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 16.dp)
-            ) {
-                Row(
-                    modifier = Modifier.padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(Icons.Default.Info, null, tint = MaterialTheme.colorScheme.primary)
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = if (isEditing) "Editing Mode Active" else "View Only Mode",
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-            }
         }
 
-        IpFieldItem(
-            label = config.label,
-            value = localAddress,
-            isEditing = isEditing,
-            placeholder = config.placeholder,
-            onValueChange = { localAddress = it },
-            onCopy = {
-                scope.launch {
-                    clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", currentAddress)))
-                }
-                Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
-            }
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        Button(
-            enabled = !isServiceRunning,
-            onClick = {
-                if (isEditing) {
-                    config.onSave()
-                    Toast.makeText(
-                        context,
-                        "Settings saved successfully",
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
-                isEditing = !isEditing
-            },
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = if (isEditing) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.secondaryContainer
-                },
-                contentColor = if (isEditing) {
-                    MaterialTheme.colorScheme.onPrimary
-                } else {
-                    MaterialTheme.colorScheme.onSecondaryContainer
-                }
-            )
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.Top
         ) {
-            Icon(
-                imageVector = if (isEditing) Icons.Default.Save else Icons.Default.Edit,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp)
+            OutlinedTextField(
+                value = ipInput,
+                onValueChange = { input ->
+                    ipInput = input.filter { !it.isWhitespace() }
+                },
+                label = { Text(config.ipLabel) },
+                placeholder = { Text(config.ipPlaceholder) },
+                singleLine = true,
+                isError = ipError != null,
+                supportingText = { Text(ipError.orEmpty()) },
+                enabled = !isServiceRunning,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Next,
+                    autoCorrectEnabled = false
+                ),
+                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                    fontFamily = FontFamily.Monospace
+                ),
+                modifier = Modifier
+                    .weight(1f)
+                    .onFocusChanged { focus ->
+                        if (!focus.isFocused &&
+                            validateIp(ipInput) == null &&
+                            ipInput != currentIp
+                        ) {
+                            saveIp(ipInput)
+                        }
+                    }
             )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(if (isEditing) "SAVE CONFIGURATION" else "EDIT CONFIGURATION")
+            OutlinedTextField(
+                value = portInput,
+                onValueChange = { input ->
+                    if (input.length <= 5 && input.all(Char::isDigit)) {
+                        portInput = input
+                    }
+                },
+                label = { Text("Port") },
+                placeholder = { Text(config.portPlaceholder) },
+                singleLine = true,
+                isError = portError != null,
+                supportingText = { Text(portError.orEmpty()) },
+                enabled = !isServiceRunning,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = { focusManager.clearFocus() }
+                ),
+                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                    fontFamily = FontFamily.Monospace
+                ),
+                modifier = Modifier
+                    .width(120.dp)
+                    .onFocusChanged { focus ->
+                        if (!focus.isFocused) {
+                            val parsed = portInput.toIntOrNull()
+                            if (parsed != null &&
+                                parsed in 1..65535 &&
+                                parsed != currentPort
+                            ) {
+                                savePort(parsed)
+                            }
+                        }
+                    }
+            )
         }
     }
 }
 
-@Composable
-private fun IpFieldItem(
-    label: String,
-    value: String,
-    isEditing: Boolean,
-    placeholder: String,
-    onValueChange: (String) -> Unit,
-    onCopy: () -> Unit
-) {
-    Column {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.secondary
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        OutlinedTextField(
-            value = value,
-            onValueChange = onValueChange,
-            readOnly = !isEditing,
-            placeholder = { Text(placeholder, color = Color.Gray) },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            textStyle = MaterialTheme.typography.bodyLarge.copy(
-                fontFamily = FontFamily.Monospace
-            ),
-            trailingIcon = {
-                if (isEditing) {
-                    Icon(
-                        Icons.Default.Edit,
-                        "Editing",
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                } else {
-                    IconButton(onClick = onCopy) {
-                        Icon(
-                            Icons.Default.ContentCopy,
-                            "Copy",
-                            tint = MaterialTheme.colorScheme.outline
-                        )
-                    }
-                }
-            },
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = if (isEditing) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.outline
-                },
-                unfocusedContainerColor = if (isEditing) {
-                    Color.Transparent
-                } else {
-                    MaterialTheme.colorScheme.surfaceVariant.copy(
-                        alpha = 0.3f
-                    )
-                }
-            )
-        )
-    }
+private fun validateIp(input: String): String? = when {
+    input.isEmpty() -> "Address required"
+    input.contains(':') -> "Remove the colon, port is separate"
+    input.contains('/') -> "Don't include the scheme prefix"
+    else -> null
+}
+
+private fun validatePort(input: String): String? {
+    if (input.isEmpty()) return "Port required"
+    val port = input.toIntOrNull() ?: return "Invalid number"
+    return if (port !in 1..65535) "Port must be 1–65535" else null
 }

--- a/app/src/main/java/org/WenuLink/views/SettingsViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/SettingsViewModel.kt
@@ -11,9 +11,13 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val _mavlinkIp = MutableStateFlow(WenuLinkPreferences.getMavlinkIp(application))
     val mavlinkIp: StateFlow<String> = _mavlinkIp.asStateFlow()
+    private val _mavlinkPort = MutableStateFlow(WenuLinkPreferences.getMavlinkPort(application))
+    val mavlinkPort: StateFlow<Int> = _mavlinkPort.asStateFlow()
 
     private val _webrtcIp = MutableStateFlow(WenuLinkPreferences.getWebRtcIp(application))
     val webrtcIp: StateFlow<String> = _webrtcIp.asStateFlow()
+    private val _webrtcPort = MutableStateFlow(WenuLinkPreferences.getWebRtcPort(application))
+    val webrtcPort: StateFlow<Int> = _webrtcPort.asStateFlow()
 
     val themeMode: StateFlow<Int?> = WenuLinkPreferences.themeFlow
 
@@ -22,9 +26,19 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _mavlinkIp.value = ip
     }
 
+    fun saveMavlinkPort(port: Int) {
+        WenuLinkPreferences.saveMavlinkPort(getApplication(), port)
+        _mavlinkPort.value = port
+    }
+
     fun saveWebrtcIp(ip: String) {
         WenuLinkPreferences.saveWebRtcIp(getApplication(), ip)
         _webrtcIp.value = ip
+    }
+
+    fun saveWebrtcPort(port: Int) {
+        WenuLinkPreferences.saveWebRtcPort(getApplication(), port)
+        _webrtcPort.value = port
     }
 
     fun saveThemeMode(mode: Int) {

--- a/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
+++ b/app/src/main/java/org/WenuLink/webrtc/WebRTCService.kt
@@ -92,9 +92,8 @@ class WebRTCService {
         onIceCandidateRequest = { iceCandidate, _ -> webRTCClient!!.sendCandidate(iceCandidate) }
     )
 
-    fun updateServerAddress(serverAddress: String) {
-        val (ip, port) = serverAddress.split(":")
-        signalingServer = ServiceAddress(ip, port.toInt(), "WS")
+    fun updateServerAddress(ip: String, port: Int) {
+        signalingServer = ServiceAddress(ip, port, "WS")
     }
 
     fun canStartClient() = CameraCapturer.hasCameraPresent() && isEnabled


### PR DESCRIPTION
- Store IP (String) and port (Int) as separate keys in WenuLinkPreferences
- Update SettingsViewModel to expose ip/port as separate StateFlows with independent setters
- Change updateGCSAddress and updateServerAddress to take (ip, port) directly, removing the spliting
- Rewrite AddressScreen with two OutlinedTextFields: IP uses KeyboardType.Uri to allow hostnames, port uses KeyboardType.Number capped at five digits. Tap-to-edit replaces the explicit edit-mode toggle, with isServiceRunning as the sole edit guard. Each field commits independently on focus loss when valid; the keyboard's Done action clears focus to trigger the same path.
- Drop the copy-to-clipboard control. long-press text selection covers the rare case.
- Validation is lenient on the IP side (reject empty, ':', '/', and whitespace) and strict on the port (1..65535).