### PR TITLE
Feature: BridgeHealth on Main Screen

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkService.kt
@@ -20,6 +20,7 @@ import org.WenuLink.MainActivity
 import org.WenuLink.WenuLinkApp
 import org.WenuLink.WenuLinkPreferences
 import org.WenuLink.commands.UnitResult
+import org.WenuLink.mavlink.BridgeHealth
 import org.WenuLink.mavlink.MAVLinkService
 import org.WenuLink.webrtc.WebRTCService
 
@@ -32,6 +33,9 @@ class WenuLinkService : Service() {
     private lateinit var thisApp: WenuLinkApp
     val mavlinkStateFlow: StateFlow<Boolean>?
         get() = if (isMAVLinkReady()) mavlink.isRunning else null
+    val mavlinkBridgeHealth: StateFlow<BridgeHealth>?
+        get() = if (isMAVLinkReady()) mavlink.bridgeHealth else null
+
     val webRTCStateFlow: StateFlow<Boolean>?
         get() = if (isWebRTCReady()) webRTC.isRunning else null
 

--- a/app/src/main/java/org/WenuLink/mavlink/BridgeHealth.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/BridgeHealth.kt
@@ -1,0 +1,17 @@
+package org.WenuLink.mavlink
+
+data class BridgeHealth(
+    val rxPerSec: Int,
+    val txPerSec: Int,
+    val lastGcsHeartbeatAt: Long?,
+    val parseErrors: Long
+) {
+    companion object {
+        val idle = BridgeHealth(
+            rxPerSec = 0,
+            txPerSec = 0,
+            lastGcsHeartbeatAt = null,
+            parseErrors = 0L
+        )
+    }
+}

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
@@ -10,6 +10,7 @@ import java.net.InetAddress
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -26,6 +27,14 @@ class MAVLinkClient(
     private val clientScope = CoroutineScope(Dispatchers.IO) // TODO: Use mavlinkScope
     val mustReceiveMessages = AtomicBoolean(false)
     val mustSendMessages = AtomicBoolean(false)
+    val rxCount = AtomicLong(0L)
+    val txCount = AtomicLong(0L)
+    val parseErrors = AtomicLong(0L)
+
+    @Volatile
+    var lastObservedPeer: String? = null
+        private set
+
     var systemID = 1
         private set
 
@@ -53,6 +62,7 @@ class MAVLinkClient(
                     val received = mavlinkParser.mavlink_parse_char(byte.toInt() and 0xFF)
                     received?.let {
                         val message = it.unpack()
+                        rxCount.incrementAndGet()
                         onMessageReceived.invoke(message)
                     }
                 }
@@ -61,6 +71,7 @@ class MAVLinkClient(
             } catch (e: SocketException) {
                 logger.w { "Socket closed with exception: ${e.message}" }
             } catch (e: Exception) {
+                parseErrors.incrementAndGet()
                 logger.e { "Error receiving MAVLink: ${e.message}" }
             }
         }
@@ -101,6 +112,7 @@ class MAVLinkClient(
             val datagram = DatagramPacket(bytes, bytes.size, address, targetPort)
             try {
                 socket.send(datagram)
+                txCount.incrementAndGet()
             } catch (e: Exception) {
                 logger.e { "Failed to send: ${e.message}" }
             }

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkClient.kt
@@ -31,10 +31,6 @@ class MAVLinkClient(
     val txCount = AtomicLong(0L)
     val parseErrors = AtomicLong(0L)
 
-    @Volatile
-    var lastObservedPeer: String? = null
-        private set
-
     var systemID = 1
         private set
 

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkController.kt
@@ -172,6 +172,8 @@ class MAVLinkController(private val handler: WenuLinkHandler) {
 
     fun isStationConnected(): Boolean = connectionController.isGCSPresent
 
+    fun getLastGcsHeartbeatAt(): Long? = connectionController.lastHeartbeatAt
+
     suspend fun waitGroundStation(timeout: Long = 5000L): Boolean {
         // prevent to send data before initialization
         telemetryController.stopBroadcast()

--- a/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/MAVLinkService.kt
@@ -6,9 +6,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.WenuLink.adapters.AsyncUtils
 import org.WenuLink.adapters.ServiceAddress
@@ -36,6 +38,11 @@ class MAVLinkService(handler: WenuLinkHandler) {
 
     private val _isRunning = MutableStateFlow(false)
     val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
+
+    private val _bridgeHealth = MutableStateFlow(BridgeHealth.idle)
+    val bridgeHealth: StateFlow<BridgeHealth> = _bridgeHealth.asStateFlow()
+
+    private var healthJob: Job? = null
 
     fun updateGCSAddress(ip: String, port: Int) {
         groundControlStation = ServiceAddress(ip, port, "UDP")
@@ -97,6 +104,7 @@ class MAVLinkService(handler: WenuLinkHandler) {
         messagesScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         listeningJob = launchListeningJob()
         sendingJob = launchSendingJob()
+        healthJob = launchHealthTicker()
 
         logger.d {
             "MAVLinkService (ready?=$isReady) " +
@@ -158,6 +166,8 @@ class MAVLinkService(handler: WenuLinkHandler) {
         messagesScope?.cancel()
         sendingJob = null
         listeningJob = null
+        healthJob = null
+        _bridgeHealth.value = BridgeHealth.idle
     }
 
     suspend fun stopService() {
@@ -167,5 +177,31 @@ class MAVLinkService(handler: WenuLinkHandler) {
         destroyClient()
         _isRunning.value = false
         isReady = false
+    }
+
+    private fun buildHealthSnapshot(rxDelta: Long, txDelta: Long, parseErrors: Long): BridgeHealth =
+        BridgeHealth(
+            rxDelta.toInt(),
+            txDelta.toInt(),
+            controller.getLastGcsHeartbeatAt(),
+            parseErrors
+        )
+
+    private fun launchHealthTicker(): Job = messagesScope!!.launch {
+        var lastRx = 0L
+        var lastTx = 0L
+        while (isActive) {
+            delay(1000L)
+            val c = client ?: continue
+            val rxNow = c.rxCount.get()
+            val txNow = c.txCount.get()
+            _bridgeHealth.value = buildHealthSnapshot(
+                rxDelta = rxNow - lastRx,
+                txDelta = txNow - lastTx,
+                parseErrors = c.parseErrors.get()
+            )
+            lastRx = rxNow
+            lastTx = txNow
+        }
     }
 }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/ConnectionController.kt
@@ -44,6 +44,8 @@ class ConnectionController(
             val isRecent = (System.currentTimeMillis() - gcsLastTimestamp) < 5000L
             return hasGCS && isRecent
         }
+    val lastHeartbeatAt: Long?
+        get() = gcsLastTimestamp.takeIf { it > 0L }
 
     // TODO: update with sensors from AircraftHandler
     private val sensorsPresent = MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_SENSOR_3D_GYRO or

--- a/app/src/main/java/org/WenuLink/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/WenuLink/ui/navigation/AppNavigation.kt
@@ -38,15 +38,7 @@ fun AppNavigation(
     val isServiceRunning by servicesViewModel.isServiceUp.collectAsState()
     val isMAVLinkRunning by servicesViewModel.isMAVLinkRunning.collectAsState()
     val isWebRTCRunning by servicesViewModel.isWebRTCRunning.collectAsState()
-    // val telemetry by servicesViewModel.telemetryData.observeAsState()
-
-//    val telemetrySummary = if (telemetry != null) {
-//        "R:${"%.1f".format(
-//            telemetry!!.roll
-//        )} P:${"%.1f".format(telemetry!!.pitch)} Y:${"%.1f".format(telemetry!!.yaw)}"
-//    } else {
-//        "No Telemetry Data"
-//    }
+    val bridgeHealth by servicesViewModel.mavlinkBridgeHealth.collectAsState()
 
     val uiState = DashboardUiState(
         workflowStatus = workflowStatus,
@@ -58,8 +50,7 @@ fun AppNavigation(
         isServiceRunning = isServiceRunning,
         isMAVLinkRunning = isMAVLinkRunning,
         isWebRTCRunning = isWebRTCRunning,
-        // TODO: decide if we want telemetry in the frontend
-        // telemetrySummary = telemetrySummary,
+        bridgeHealth = bridgeHealth,
         recentLogs = logMessages
     )
 

--- a/app/src/main/java/org/WenuLink/ui/screens/main/DashboardUiState.kt
+++ b/app/src/main/java/org/WenuLink/ui/screens/main/DashboardUiState.kt
@@ -1,5 +1,7 @@
 package org.WenuLink.ui.screens.main
 
+import org.WenuLink.mavlink.BridgeHealth
+
 data class DashboardUiState(
     val workflowStatus: String = "Idle",
     val isPermissionsGranted: Boolean = false,
@@ -10,7 +12,7 @@ data class DashboardUiState(
     val isServiceRunning: Boolean = false,
     val isMAVLinkRunning: Boolean = false,
     val isWebRTCRunning: Boolean = false,
-    val telemetrySummary: String = "No Telemetry Data",
+    val bridgeHealth: BridgeHealth = BridgeHealth.idle,
     // TODO: Logging feature
     val recentLogs: List<String> = listOf("TODO: Logging feature...")
 )

--- a/app/src/main/java/org/WenuLink/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/org/WenuLink/ui/screens/main/MainScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import org.WenuLink.mavlink.BridgeHealth
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -261,11 +262,10 @@ private fun StatusSection(uiState: DashboardUiState) {
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(
-                    uiState.telemetrySummary,
+                    text = formatBridgeHealth(uiState.bridgeHealth, uiState.isMAVLinkRunning),
                     style = MaterialTheme.typography.labelSmall,
                     modifier = Modifier.padding(8.dp),
-                    fontFamily = FontFamily.Monospace,
-                    maxLines = 1
+                    fontFamily = FontFamily.Monospace
                 )
             }
         }
@@ -408,4 +408,14 @@ private fun ConnectionSection(
             }
         }
     }
+}
+
+private fun formatBridgeHealth(h: BridgeHealth, isRunning: Boolean): String {
+    if (!isRunning) return "idle"
+
+    val gcs = h.lastGcsHeartbeatAt
+        ?.let { "%.1fs".format((System.currentTimeMillis() - it) / 1000.0) }
+        ?: "—"
+
+    return "gcs $gcs | tx ${h.txPerSec}/s rx ${h.rxPerSec}/s | err ${h.parseErrors}"
 }

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.WenuLink.WenuLinkApp
+import org.WenuLink.mavlink.BridgeHealth
 
 class ServicesViewModel(application: Application) : AndroidViewModel(application) {
     private val logger by taggedLogger(ServicesViewModel::class.java.simpleName)
@@ -30,6 +31,9 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
     // To expose the StateFlow for MAVLink
     val isMAVLinkRunning: StateFlow<Boolean>
         get() = thisApp.wenuLinkService?.mavlinkStateFlow ?: MutableStateFlow(false)
+
+    val mavlinkBridgeHealth: StateFlow<BridgeHealth>
+        get() = thisApp.wenuLinkService?.mavlinkBridgeHealth ?: MutableStateFlow(BridgeHealth.idle)
 
     // To expose the StateFlow for WebRTC
     val isWebRTCRunning: StateFlow<Boolean>


### PR DESCRIPTION
Adds a lightweight bridge-health readout to the main screen, replacing the `telemetrySummary` slot previously removed in #82. Surfaces the diagnostic signals that QGC and the RC display can't show: whether the WenuLink bridge itself is alive and producing output, for use during initial bring-up (bad IP, firewall blocking the port, no GCS connection yet).
