### PR TITLE
Fix CameraController for proper handling of different camera id device

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -122,7 +122,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
                         }
 
                         launch {
-                            cameraHooks()
+                            if (camera.hasCameraPresent) cameraHooks()
                         }
 
                         launch {
@@ -330,7 +330,6 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     }
 
     private fun cameraHooks() {
-        if (!camera.wasInitialized) return
         if (camera.consumeCaptureEvent()) {
             val cameraId = camera.availableCameras.firstOrNull()?.id ?: return
             onImageCaptured?.invoke(cameraId, camera.photoSeqIndex)

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
@@ -13,14 +13,14 @@ sealed interface CameraCommand : ICommand<CameraHandler> {
     override suspend fun onStop(ctx: CameraHandler) { }
 }
 
-data class SetModeCommand(val newMode: Int, val cameraIdx: Int) : CameraCommand {
+data class SetModeCommand(val newMode: Int, val cameraId: Int) : CameraCommand {
     override fun validate(ctx: CameraHandler): UnitResult = when (newMode) {
         CAMERA_MODE.CAMERA_MODE_IMAGE -> CommandResult.ok
         CAMERA_MODE.CAMERA_MODE_VIDEO -> CommandResult.ok
         else -> CommandResult.error("Unrecognized mode: $newMode")
     }
 
-    suspend fun setPhotoMode(cameraIdx: Int = 0): UnitResult {
+    suspend fun setPhotoMode(cameraId: Int): UnitResult {
         if (!CameraManager.isPhotoMode()) {
             CameraManager.setPhotoMode()?.let {
                 return CommandResult.error("setPhotoMode error: $it")
@@ -30,7 +30,7 @@ data class SetModeCommand(val newMode: Int, val cameraIdx: Int) : CameraCommand 
         return CommandResult.ok
     }
 
-    suspend fun setVideoMode(cameraIdx: Int = 0): UnitResult {
+    suspend fun setVideoMode(cameraId: Int): UnitResult {
         if (!CameraManager.isVideoMode()) {
             CameraManager.setVideoMode()?.let {
                 return CommandResult.error("setVideoMode error: $it")
@@ -42,70 +42,69 @@ data class SetModeCommand(val newMode: Int, val cameraIdx: Int) : CameraCommand 
 
     override suspend fun execute(ctx: CameraHandler): UnitResult {
         val setModeResult = when (newMode) {
-            CAMERA_MODE.CAMERA_MODE_IMAGE -> setPhotoMode()
-            CAMERA_MODE.CAMERA_MODE_VIDEO -> setVideoMode()
+            CAMERA_MODE.CAMERA_MODE_IMAGE -> setPhotoMode(cameraId)
+            CAMERA_MODE.CAMERA_MODE_VIDEO -> setVideoMode(cameraId)
             else -> CommandResult.ok
         }
 
         if (setModeResult.isOk) {
-            ctx.setMode(newMode, cameraIdx)
+            ctx.setMode(newMode, cameraId)
         }
         return setModeResult
     }
 }
 
-data class TakePhotoCommand(val cameraIdx: Int) : CameraCommand {
+data class TakePhotoCommand(val cameraId: Int) : CameraCommand {
     override fun validate(ctx: CameraHandler): UnitResult = when {
-        !ctx.isPhotoMode(cameraIdx) -> CommandResult.error("Not in photo mode!")
-        !ctx.captureIdle(cameraIdx) -> CommandResult.error("Busy")
+        ctx.isVideoMode(cameraId) && ctx.canPhotoInVideo(cameraId) -> CommandResult.ok
+        !ctx.isPhotoMode(cameraId) -> CommandResult.error("Not in photo mode!")
+        !ctx.captureIdle(cameraId) -> CommandResult.error("Busy")
         else -> CommandResult.ok
     }
 
     override suspend fun execute(ctx: CameraHandler): UnitResult {
         // mark IN_PROGRESS
-        ctx.updateCaptureStatus(CameraCaptureStatus.IN_PROGRESS, cameraIdx)
+        ctx.updateCaptureStatus(CameraCaptureStatus.IN_PROGRESS, cameraId)
         // Trigger camera and wait for photo to be taken
         val error = CameraManager.requestPhotoShoot()
         if (error == null) {
-            ctx.captureTimestamp = System.currentTimeMillis()
-            ctx.photoSeqIndex += 1
+            ctx.updateCaptureTimestamp(System.currentTimeMillis(), cameraId)
         }
         // mark IDLE back
-        ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+        ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraId)
         return error
             ?.let { CommandResult.error(it) }
             ?: CommandResult.ok
     }
 }
 
-data class StartRecordCommand(val cameraIdx: Int) : CameraCommand {
+data class StartRecordCommand(val cameraId: Int) : CameraCommand {
     override fun validate(ctx: CameraHandler): UnitResult = when {
-        !ctx.isVideoMode(cameraIdx) -> CommandResult.error("Not in video mode!")
-        !ctx.canRecordVideo(cameraIdx) -> CommandResult.error("Unable to start recording")
-        !ctx.captureIdle(cameraIdx) -> CommandResult.error("Busy")
+        !ctx.isVideoMode(cameraId) -> CommandResult.error("Not in video mode!")
+        !ctx.captureIdle(cameraId) -> CommandResult.error("Busy")
         else -> CommandResult.ok
     }
 
     override suspend fun execute(ctx: CameraHandler): UnitResult {
         // mark IN_PROGRESS
-        ctx.updateCaptureStatus(CameraCaptureStatus.IN_PROGRESS, cameraIdx)
+        ctx.updateCaptureStatus(CameraCaptureStatus.IN_PROGRESS, cameraId)
         // Trigger camera and wait for photo to be taken
         return CameraManager.requestStartVideoRecording()
             ?.let {
-                ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+                ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraId)
                 CommandResult.error(it)
             }
             ?: let {
-                ctx.captureTimestamp = System.currentTimeMillis()
+                ctx.updateCaptureTimestamp(System.currentTimeMillis(), cameraId)
                 CommandResult.ok
             }
     }
 }
 
-data class StopRecordCommand(val cameraIdx: Int) : CameraCommand {
+data class StopRecordCommand(val cameraId: Int) : CameraCommand {
     override fun validate(ctx: CameraHandler): UnitResult = when {
-        !ctx.isVideoMode(cameraIdx) -> CommandResult.error("Not in video mode!")
-        !ctx.captureInProgress(cameraIdx) -> CommandResult.error("Record not started")
+        !ctx.isVideoMode(cameraId) -> CommandResult.error("Not in video mode!")
+        !ctx.captureInProgress(cameraId) -> CommandResult.error("Record not started")
         else -> CommandResult.ok
     }
 
@@ -115,16 +114,17 @@ data class StopRecordCommand(val cameraIdx: Int) : CameraCommand {
             ?.let { CommandResult.error(it) }
             ?: let {
                 // mark IDLE back
-                ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+                ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraId)
+                ctx.updateCaptureTimestamp(-1, cameraId)
                 CommandResult.ok
             }
     }
 }
 
-data class StartIntervalShootCommand(val cameraIdx: Int, val intervalSeconds: Int) : CameraCommand {
+data class StartIntervalShootCommand(val cameraId: Int, val intervalSeconds: Int) : CameraCommand {
     override fun validate(ctx: CameraHandler): UnitResult = when {
-        !ctx.isPhotoMode(cameraIdx) -> CommandResult.error("Not in photo mode!")
-        !ctx.captureIdle(cameraIdx) -> CommandResult.error("Busy")
+        !ctx.isPhotoMode(cameraId) -> CommandResult.error("Not in photo mode!")
+        !ctx.captureIdle(cameraId) -> CommandResult.error("Busy")
         else -> CommandResult.ok
     }
 
@@ -135,7 +135,7 @@ data class StartIntervalShootCommand(val cameraIdx: Int, val intervalSeconds: In
         CameraManager.setIntervalSeconds(intervalSeconds)
             ?.let { return CommandResult.error(it) }
 
-        ctx.updateCaptureStatus(CameraCaptureStatus.INTERVAL_PROGRESS, cameraIdx)
+        ctx.updateCaptureStatus(CameraCaptureStatus.INTERVAL_PROGRESS, cameraId)
 
         return CameraManager.requestStartIntervalShoot()
             ?.let { CommandResult.error(it) }
@@ -144,15 +144,15 @@ data class StartIntervalShootCommand(val cameraIdx: Int, val intervalSeconds: In
 
     override suspend fun onStop(ctx: CameraHandler) {
         CameraManager.requestStopIntervalShoot()
-        ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+        ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraId)
     }
 }
 
-data class StopIntervalShootCommand(val cameraIdx: Int) : CameraCommand {
+data class StopIntervalShootCommand(val cameraId: Int) : CameraCommand {
     override fun validate(ctx: CameraHandler): UnitResult = when {
-        !ctx.isPhotoMode(cameraIdx) -> CommandResult.error("Not in photo mode!")
+        !ctx.isPhotoMode(cameraId) -> CommandResult.error("Not in photo mode!")
 
-        !ctx.checkCaptureStatus(CameraCaptureStatus.INTERVAL_PROGRESS, cameraIdx) ->
+        !ctx.checkCaptureStatus(CameraCaptureStatus.INTERVAL_PROGRESS, cameraId) ->
             CommandResult.error("Interval shoot not started")
 
         else -> CommandResult.ok
@@ -162,7 +162,7 @@ data class StopIntervalShootCommand(val cameraIdx: Int) : CameraCommand {
         CameraManager.requestStopIntervalShoot()
             ?.let { CommandResult.error(it) }
             ?: let {
-                ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraIdx)
+                ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraId)
                 CommandResult.ok
             }
 }

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraCommands.kt
@@ -56,7 +56,7 @@ data class SetModeCommand(val newMode: Int, val cameraId: Int) : CameraCommand {
 
 data class TakePhotoCommand(val cameraId: Int) : CameraCommand {
     override fun validate(ctx: CameraHandler): UnitResult = when {
-        ctx.isVideoMode(cameraId) && ctx.canPhotoInVideo(cameraId) -> CommandResult.ok
+        ctx.isVideoMode(cameraId) && ctx.canTakePhotoInVideo(cameraId) -> CommandResult.ok
         !ctx.isPhotoMode(cameraId) -> CommandResult.error("Not in photo mode!")
         !ctx.captureIdle(cameraId) -> CommandResult.error("Busy")
         else -> CommandResult.ok
@@ -115,7 +115,7 @@ data class StopRecordCommand(val cameraId: Int) : CameraCommand {
             ?: let {
                 // mark IDLE back
                 ctx.updateCaptureStatus(CameraCaptureStatus.IDLE, cameraId)
-                ctx.updateCaptureTimestamp(-1, cameraId)
+                ctx.updateCaptureTimestamp(null, cameraId)
                 CommandResult.ok
             }
     }

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraData.kt
@@ -25,14 +25,11 @@ data class CameraState(
      * - CaptureType.IMAGE: capture interval in seconds
      * - CaptureType.VIDEO: elapsed recording time in milliseconds
      */
-    val captureTimestamp: Long = -1,
+    val captureTimestamp: Long? = null,
     val totalPhotos: Int = 0
 ) {
-    val timeMillis: Long get() = if (captureTimestamp != -1L) {
-        System.currentTimeMillis() - captureTimestamp
-    } else {
-        0
-    }
+    val timeMillis: Long
+        get() = captureTimestamp?.let { System.currentTimeMillis() - it } ?: 0
 }
 
 data class CameraMetadata(

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraData.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraData.kt
@@ -25,8 +25,15 @@ data class CameraState(
      * - CaptureType.IMAGE: capture interval in seconds
      * - CaptureType.VIDEO: elapsed recording time in milliseconds
      */
-    val captureTime: Long = 0
-)
+    val captureTimestamp: Long = -1,
+    val totalPhotos: Int = 0
+) {
+    val timeMillis: Long get() = if (captureTimestamp != -1L) {
+        System.currentTimeMillis() - captureTimestamp
+    } else {
+        0
+    }
+}
 
 data class CameraMetadata(
     val id: Int = 1,

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
@@ -86,7 +86,9 @@ class CameraHandler : CommandHandler<CameraHandler>() {
             )
         )
         // set mode as a command avoid thread issues
-        dispatchCommand(SetModeCommand(CAMERA_MODE.CAMERA_MODE_IMAGE, 1))
+        dispatchCommand(
+            SetModeCommand(CAMERA_MODE.CAMERA_MODE_IMAGE, availableCameras.first().id)
+        )
 
         // TODO: grab current number of photos in storage
 
@@ -159,9 +161,9 @@ class CameraHandler : CommandHandler<CameraHandler>() {
         cameraId
     )
 
-    fun canPhotoInVideo(cameraId: Int): Boolean = CameraManager.canTakePhotoInVideo()
+    fun canTakePhotoInVideo(cameraId: Int): Boolean = CameraManager.canTakePhotoInVideo()
 
-    fun updateCaptureTimestamp(timestamp: Long, cameraId: Int) =
+    fun updateCaptureTimestamp(timestamp: Long?, cameraId: Int) =
         getCameraWithIndex(cameraId)?.let { (idx, camera) ->
             logger.d { "updateTimestamp" }
             availableCameras[idx] = camera.copy(

--- a/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/camera/CameraHandler.kt
@@ -28,9 +28,9 @@ class CameraHandler : CommandHandler<CameraHandler>() {
     private val logger by taggedLogger(CameraHandler::class.java.simpleName)
     val availableCameras: MutableList<CameraMetadata> = mutableListOf()
     var photoSeqIndex: Int = 0
-    var captureTimestamp: Long = System.currentTimeMillis()
     var wasInitialized = false
         private set
+    val hasCameraPresent: Boolean get() = availableCameras.isNotEmpty() && wasInitialized
     private val _captureCount = MutableStateFlow(0)
     val captureCount: StateFlow<Int> = _captureCount.asStateFlow()
     private var wasStoringPhoto = false
@@ -59,7 +59,7 @@ class CameraHandler : CommandHandler<CameraHandler>() {
 
     private fun registerCameraState() = CameraManager.registerStateCallback { state ->
         if (state.isStoringPhoto && !wasStoringPhoto) {
-            _captureCount.value += 1
+            increasePhotoCounter(availableCameras.first().id)
         }
         wasStoringPhoto = state.isStoringPhoto
     }
@@ -85,16 +85,23 @@ class CameraHandler : CommandHandler<CameraHandler>() {
                     CAMERA_CAP_FLAGS.CAMERA_CAP_FLAGS_HAS_MODES.toLong()
             )
         )
-        setMode(CAMERA_MODE.CAMERA_MODE_IMAGE, 0)
+        // set mode as a command avoid thread issues
+        dispatchCommand(SetModeCommand(CAMERA_MODE.CAMERA_MODE_IMAGE, 1))
 
-        logger.d { "Managing ${availableCameras.size} detected camera(s)" }
+        // TODO: grab current number of photos in storage
+
+        logger.d { "Handling ${availableCameras.size} detected camera(s)" }
         return true
     }
 
     fun getCamera(cameraId: Int): CameraMetadata? =
         availableCameras.firstOrNull { it.id == cameraId }
 
-    fun setMode(newMode: Int, cameraIdx: Int = 0) {
+    private fun getCameraWithIndex(cameraId: Int): Pair<Int, CameraMetadata>? =
+        availableCameras.withIndex().firstOrNull { it.value.id == cameraId }
+            ?.let { it.index to it.value }
+
+    fun setMode(newMode: Int, cameraId: Int) {
         val captureType = when (newMode) {
             CAMERA_MODE.CAMERA_MODE_IMAGE -> CameraCaptureType.IMAGE
             CAMERA_MODE.CAMERA_MODE_VIDEO -> CameraCaptureType.VIDEO
@@ -108,8 +115,8 @@ class CameraHandler : CommandHandler<CameraHandler>() {
             0
         )
 
-        getCamera(cameraIdx)?.let {
-            availableCameras.set(cameraIdx, it.copy(state = newState))
+        getCameraWithIndex(cameraId)?.let { (idx, camera) ->
+            availableCameras[idx] = camera.copy(state = newState)
         }
     }
 
@@ -117,48 +124,59 @@ class CameraHandler : CommandHandler<CameraHandler>() {
         val current = captureCount.value
         if (current <= lastSeenCaptureCount) return false
         lastSeenCaptureCount = current
-        photoSeqIndex += 1
         return true
     }
 
-    fun updateCaptureStatus(newStatus: CameraCaptureStatus, cameraIdx: Int = 0) {
-        getCamera(cameraIdx)?.let {
-            availableCameras.set(
-                cameraIdx,
-                it.copy(
-                    state = it.state.copy(
-                        captureStatus = newStatus
-                    )
-                )
+    fun updateCaptureStatus(newStatus: CameraCaptureStatus, cameraId: Int) =
+        getCameraWithIndex(cameraId)?.let { (idx, camera) ->
+            availableCameras[idx] = camera.copy(
+                state = camera.state.copy(captureStatus = newStatus)
+            )
+        }
+
+    fun checkCaptureStatus(status: CameraCaptureStatus, cameraId: Int) =
+        getCamera(cameraId)?.state?.captureStatus == status
+
+    fun captureInProgress(cameraId: Int): Boolean = checkCaptureStatus(
+        CameraCaptureStatus.IN_PROGRESS,
+        cameraId
+    )
+
+    fun captureIdle(cameraId: Int): Boolean = checkCaptureStatus(
+        CameraCaptureStatus.IDLE,
+        cameraId
+    )
+
+    fun checkCameraMode(mode: Int, cameraId: Int) = getCamera(cameraId)?.state?.mavlinkMode == mode
+
+    fun isPhotoMode(cameraId: Int): Boolean = checkCameraMode(
+        CAMERA_MODE.CAMERA_MODE_IMAGE,
+        cameraId
+    )
+
+    fun isVideoMode(cameraId: Int): Boolean = checkCameraMode(
+        CAMERA_MODE.CAMERA_MODE_VIDEO,
+        cameraId
+    )
+
+    fun canPhotoInVideo(cameraId: Int): Boolean = CameraManager.canTakePhotoInVideo()
+
+    fun updateCaptureTimestamp(timestamp: Long, cameraId: Int) =
+        getCameraWithIndex(cameraId)?.let { (idx, camera) ->
+            logger.d { "updateTimestamp" }
+            availableCameras[idx] = camera.copy(
+                state = camera.state.copy(captureTimestamp = timestamp)
+            )
+        }
+
+    fun increasePhotoCounter(cameraId: Int) {
+        logger.d { "Photo taken, increasing number" }
+        photoSeqIndex += 1 // sequence index
+        _captureCount.value += 1 // session count
+        getCameraWithIndex(cameraId)?.let { (idx, camera) ->
+            availableCameras[idx] = camera.copy(
+                state = camera.state.copy(totalPhotos = camera.state.totalPhotos + 1) // total count
             )
         }
     }
-
-    fun checkCaptureStatus(status: CameraCaptureStatus, cameraIdx: Int = 0) =
-        getCamera(cameraIdx)?.state?.captureStatus == status
-
-    fun captureInProgress(cameraIdx: Int = 0): Boolean = checkCaptureStatus(
-        CameraCaptureStatus.IN_PROGRESS,
-        cameraIdx
-    )
-
-    fun captureIdle(cameraIdx: Int = 0): Boolean = checkCaptureStatus(
-        CameraCaptureStatus.IDLE,
-        cameraIdx
-    )
-
-    fun checkCameraMode(mode: Int, cameraIdx: Int = 0) =
-        getCamera(cameraIdx)?.state?.mavlinkMode == mode
-
-    fun isPhotoMode(cameraIdx: Int = 0): Boolean = checkCameraMode(
-        CAMERA_MODE.CAMERA_MODE_IMAGE,
-        cameraIdx
-    )
-
-    fun isVideoMode(cameraIdx: Int = 0): Boolean = checkCameraMode(
-        CAMERA_MODE.CAMERA_MODE_VIDEO,
-        cameraIdx
-    )
-
-    fun canRecordVideo(cameraIdx: Int = 0): Boolean = CameraManager.canRecordVideo()
 }

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/CameraController.kt
@@ -46,7 +46,7 @@ import org.WenuLink.mavlink.messages.VideoStopCaptureCommandLong
 class CameraController(
     override val client: MAVLinkClient,
     override val handler: WenuLinkHandler,
-    private val onSetMessageRate: (messageId: Int, intervalMs: Long) -> Unit
+    private val onSetMessageRate: (messageId: Int, microSeconds: Long) -> Unit
 ) : IController {
     private val logger by taggedLogger(CameraController::class.java.simpleName)
 
@@ -114,7 +114,6 @@ class CameraController(
 
     private fun reportSettings() {
         if (handler.availableCameras.isEmpty()) {
-            sendRequestAck(MAV_RESULT.MAV_RESULT_UNSUPPORTED)
             logger.d { "Unsupported: No cameras were detected" }
             sendRequestAck(MAV_RESULT.MAV_RESULT_UNSUPPORTED)
             return
@@ -132,21 +131,39 @@ class CameraController(
     }
 
     private fun handleSetCameraMode(commandLongMsg: msg_command_long) {
-        sendCommandAck(commandLongMsg.command, MAV_RESULT.MAV_RESULT_IN_PROGRESS, 0)
         val params = SetCameraModeCommandLong(commandLongMsg)
+        val cameras: List<CameraMetadata> = getCameras(params.id)
 
-        handler.dispatchCommand(
-            WenuLinkCommand.Camera(SetModeCommand(params.mode, params.id))
-        ) { result ->
-            sendCommandAck(
-                commandLongMsg.command,
-                if (result.isOk) {
-                    MAV_RESULT.MAV_RESULT_ACCEPTED
-                } else {
-                    MAV_RESULT.MAV_RESULT_FAILED
-                },
-                100
+        if (cameras.isEmpty()) {
+            client.sendMessage(
+                MessageUtils.msgCommandAck(
+                    commandLongMsg.msgid,
+                    MAV_RESULT.MAV_RESULT_UNSUPPORTED
+                )
             )
+            return
+        }
+
+        sendCommandAck(commandLongMsg.command, MAV_RESULT.MAV_RESULT_IN_PROGRESS, 50)
+
+        cameras.forEach { cameraInfo ->
+            handler.dispatchCommand(
+                WenuLinkCommand.Camera(SetModeCommand(params.mode, cameraInfo.id))
+            ) { result ->
+                if (result.hasError) {
+                    logger.w {
+                        "Error in set mode mode ${params.mode} for camera ID ${cameraInfo.id}"
+                    }
+                }
+                sendCommandAck(
+                    commandLongMsg.command,
+                    if (result.isOk) {
+                        MAV_RESULT.MAV_RESULT_ACCEPTED
+                    } else {
+                        MAV_RESULT.MAV_RESULT_FAILED
+                    }
+                )
+            }
         }
     }
 
@@ -157,19 +174,25 @@ class CameraController(
     )
 
     private fun sendCaptureStatus() = client.sendMessage(
-        msgCaptureStatus(handler.availableCameras.first()).apply {
-            time_boot_ms = handler.systemBootTime
-        }
+        msgCaptureStatus(handler.availableCameras.first())
     )
 
-    private fun getCamera(targetCamera: Int): CameraMetadata? =
-        handler.camera.getCamera(targetCamera).also {
-            it ?: logger.d { "Camera index $targetCamera not found" }
+    private fun getCameras(targetCamera: Int): List<CameraMetadata> = if (targetCamera == 0) {
+        handler.camera.availableCameras.also {
+            if (it.isEmpty()) logger.w { "No cameras found" }
         }
+    } else {
+        handler.camera.getCamera(targetCamera)?.let { listOf(it) } ?: run {
+            logger.d { "Camera id $targetCamera not found" }
+            emptyList()
+        }
+    }
 
     private fun requestStartCapture(commandLongMsg: msg_command_long) {
         val params = ImageStartCaptureMessage(commandLongMsg)
-        val cameraInfo: CameraMetadata = getCamera(params.targetCameraId) ?: run {
+        val cameras: List<CameraMetadata> = getCameras(params.targetCameraId)
+
+        if (cameras.isEmpty()) {
             client.sendMessage(
                 MessageUtils.msgCommandAck(
                     commandLongMsg.msgid,
@@ -187,14 +210,6 @@ class CameraController(
             client.sendMessage(msgImageCaptured(ImageMetadata(seqIndex, true, cameraId, telemetry)))
         }
 
-        val command = if (params.totalImages == 1) {
-            WenuLinkCommand.Camera(TakePhotoCommand(cameraInfo.id))
-        } else {
-            WenuLinkCommand.Camera(
-                StartIntervalShootCommand(cameraInfo.id, params.intervalSec.roundToInt())
-            )
-        }
-
         client.sendMessage(
             MessageUtils.msgCommandAck(
                 commandLongMsg.msgid,
@@ -202,17 +217,27 @@ class CameraController(
             )
         )
 
-        handler.dispatchCommand(command) { result ->
-            if (result.hasError) {
-                logger.w { "requestStartCapture error: ${result.errorReason}" }
+        cameras.forEach { cameraInfo ->
+            val command = if (params.totalImages == 1) {
+                WenuLinkCommand.Camera(TakePhotoCommand(cameraInfo.id))
+            } else {
+                WenuLinkCommand.Camera(
+                    StartIntervalShootCommand(cameraInfo.id, params.intervalSec.roundToInt())
+                )
             }
-            if (params.totalImages == 1) handler.onImageCaptured = null
+
+            handler.dispatchCommand(command) { result ->
+                if (result.hasError) logger.w { "requestStartCapture error: ${result.errorReason}" }
+                if (params.totalImages == 1) handler.onImageCaptured = null
+            }
         }
     }
 
     private fun requestStopCapture(commandLongMsg: msg_command_long) {
         val params = ImageStopCaptureCommandLong(commandLongMsg)
-        val cameraInfo: CameraMetadata = getCamera(params.targetCameraId) ?: run {
+        val cameras: List<CameraMetadata> = getCameras(params.targetCameraId)
+
+        if (cameras.isEmpty()) {
             client.sendMessage(
                 MessageUtils.msgCommandAck(
                     commandLongMsg.msgid,
@@ -230,20 +255,20 @@ class CameraController(
         )
 
         handler.onImageCaptured = null
-        handler.dispatchCommand(
-            WenuLinkCommand.Camera(StopIntervalShootCommand(cameraInfo.id))
-        ) { result ->
-            if (result.hasError) {
-                logger.w {
-                    "requestStopCapture error: ${result.errorReason}"
-                }
+        cameras.forEach { cameraInfo ->
+            handler.dispatchCommand(
+                WenuLinkCommand.Camera(StopIntervalShootCommand(cameraInfo.id))
+            ) { result ->
+                if (result.hasError) logger.w { "requestStopCapture error: ${result.errorReason}" }
             }
         }
     }
 
     private fun requestStartRecording(commandLongMsg: msg_command_long) {
         val params = VideoStartCaptureCommandLong(commandLongMsg)
-        val cameraInfo: CameraMetadata = getCamera(params.targetCameraId) ?: run {
+        val cameras: List<CameraMetadata> = getCameras(params.targetCameraId)
+
+        if (cameras.isEmpty()) {
             client.sendMessage(
                 MessageUtils.msgCommandAck(
                     commandLongMsg.msgid,
@@ -260,24 +285,32 @@ class CameraController(
             )
         )
 
-        handler.dispatchCommand(
-            WenuLinkCommand.Camera(StartRecordCommand(cameraInfo.id))
-        ) { result ->
-            if (result.hasError) {
-                logger.w { "Error in requestStartRecording: ${result.errorReason}" }
-            } else {
-                // setting messages frequency
-                onSetMessageRate(
-                    msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
-                    ((1f / params.statusFreqHz) * 1000).roundToLong()
-                )
+        cameras.forEach { cameraInfo ->
+            handler.dispatchCommand(
+                WenuLinkCommand.Camera(StartRecordCommand(cameraInfo.id))
+            ) { result ->
+                if (result.hasError) {
+                    logger.w { "Error in requestStartRecording: ${result.errorReason}" }
+                } else if (params.statusFreqHz == 0f) {
+                    logger.i { "No messages for camera capture status" }
+                } else {
+                    val intervalUs = ((1f / params.statusFreqHz) * 1_000_000).roundToLong()
+                    logger.d { "record started, sending capture status every $intervalUs us" }
+                    // setting messages frequency
+                    onSetMessageRate(
+                        msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
+                        intervalUs
+                    )
+                }
             }
         }
     }
 
     private fun requestStopRecording(commandLongMsg: msg_command_long) {
         val params = VideoStopCaptureCommandLong(commandLongMsg)
-        val cameraInfo: CameraMetadata = getCamera(params.targetCameraId) ?: run {
+        val cameras: List<CameraMetadata> = getCameras(params.targetCameraId)
+
+        if (cameras.isEmpty()) {
             client.sendMessage(
                 MessageUtils.msgCommandAck(
                     commandLongMsg.msgid,
@@ -294,18 +327,20 @@ class CameraController(
             )
         )
 
-        handler.dispatchCommand(
-            WenuLinkCommand.Camera(StopRecordCommand(cameraInfo.id))
-        ) { result ->
-            if (result.hasError) {
-                logger.w { "Error in requestStopRecording: ${result.errorReason}" }
-                return@dispatchCommand
+        cameras.forEach { cameraInfo ->
+            handler.dispatchCommand(
+                WenuLinkCommand.Camera(StopRecordCommand(cameraInfo.id))
+            ) { result ->
+                if (result.hasError) {
+                    logger.w { "Error in requestStopRecording: ${result.errorReason}" }
+                    return@dispatchCommand
+                }
+                // deactivating messages
+                onSetMessageRate(
+                    msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
+                    -1
+                )
             }
-            // deactivating messages
-            onSetMessageRate(
-                msg_camera_capture_status.MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
-                -1
-            )
         }
     }
 
@@ -362,22 +397,22 @@ class CameraController(
 
     fun msgCaptureStatus(cameraInfo: CameraMetadata): msg_camera_capture_status =
         msg_camera_capture_status().apply {
-            // TODO: add proper updates
             when (cameraInfo.state.mavlinkMode) {
                 CAMERA_MODE.CAMERA_MODE_IMAGE -> {
                     image_status = cameraInfo.state.captureStatus.value.toShort()
-                    image_interval = cameraInfo.state.captureTime.toFloat()
+                    image_interval = cameraInfo.state.timeMillis / 1000f // ms -> s
                 }
 
                 CAMERA_MODE.CAMERA_MODE_VIDEO -> {
                     video_status = cameraInfo.state.captureStatus.value.toShort()
-                    recording_time_ms = cameraInfo.state.captureTime
+                    recording_time_ms = cameraInfo.state.timeMillis
                 }
             }
 
+            time_boot_ms = handler.systemBootTime
             // TODO: read true value
             available_capacity = 4000f
-            image_count = 0
+            image_count = cameraInfo.state.totalPhotos
             camera_device_id = cameraInfo.id.toShort()
         }
 

--- a/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/CameraManager.kt
@@ -225,7 +225,7 @@ object CameraManager {
 
     fun isSingleShoot() = captureMode == SettingsDefinitions.ShootPhotoMode.SINGLE
 
-    fun canRecordVideo() = mInstance?.isCaptureInVideoSupported == true
+    fun canTakePhotoInVideo() = mInstance?.isCaptureInVideoSupported == true
 
     suspend fun requestPhotoShoot(): String? {
         val camera = mInstance ?: return "Camera instance is null"


### PR DESCRIPTION
Command message related to camera action triggered from QGC always send the camera device id equals to 0, requesting to perform the action for all camera devices present, which was not properly handled.

Fixes #84 by iterating over a list of cameras according to the camera device id argument from message and enhance command definition by clarifying the argument to be id instead of index.