### PR TITLE
Convert MAVLink and WebRTC controls to switches

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,6 +121,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig = true
         compose = true
     }
 }

--- a/app/src/main/java/org/WenuLink/WenuLinkApp.kt
+++ b/app/src/main/java/org/WenuLink/WenuLinkApp.kt
@@ -52,6 +52,7 @@ class WenuLinkApp : Application() {
     val isAircraftPresent = MutableStateFlow(false)
     val isSimulationReady = MutableStateFlow(false)
     val isAircraftBoot = MutableStateFlow(false)
+    val isUsingSimulation = MutableStateFlow(false)
     val isServiceUp = MutableStateFlow(false)
 
     private val permissionsList by lazy {
@@ -236,6 +237,7 @@ class WenuLinkApp : Application() {
                 updateWorkflow("Boot error: ${bootResult.errorReason}")
             } else {
                 isAircraftBoot.value = true
+                isUsingSimulation.value = useSimulation
                 updateWorkflow("Connected and ready for services")
             }
         }
@@ -252,6 +254,7 @@ class WenuLinkApp : Application() {
                 updateWorkflow("Shutdown error: ${shutdownResult.errorReason}")
             } else {
                 isAircraftBoot.value = false
+                isUsingSimulation.value = false
             }
             wenuLinkHandler.enableSimulation(false)
         }

--- a/app/src/main/java/org/WenuLink/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/WenuLink/ui/navigation/AppNavigation.kt
@@ -35,6 +35,7 @@ fun AppNavigation(
     val isAircraftPresent by app.isAircraftPresent.collectAsState()
     val isSimulationReady by app.isSimulationReady.collectAsState()
     val canRunService by app.isAircraftBoot.collectAsState()
+    val isUsingSimulation by servicesViewModel.isUsingSimulation.collectAsState()
     val isServiceRunning by servicesViewModel.isServiceUp.collectAsState()
     val isMAVLinkRunning by servicesViewModel.isMAVLinkRunning.collectAsState()
     val isWebRTCRunning by servicesViewModel.isWebRTCRunning.collectAsState()
@@ -47,6 +48,7 @@ fun AppNavigation(
         isAircraftPresent = isAircraftPresent,
         isSimulationReady = isSimulationReady,
         canRunService = canRunService,
+        isUsingSimulation = isUsingSimulation,
         isServiceRunning = isServiceRunning,
         isMAVLinkRunning = isMAVLinkRunning,
         isWebRTCRunning = isWebRTCRunning,

--- a/app/src/main/java/org/WenuLink/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/org/WenuLink/ui/screens/about/AboutScreen.kt
@@ -67,8 +67,9 @@ fun AboutScreen(navController: NavController) {
     )
 
     val onOpenGithub = {
-        val intent = Intent(Intent.ACTION_VIEW, "https://github.com/WenuLink".toUri())
-        context.startActivity(intent)
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, "https://github.com/WenuLink/wenu-link-android".toUri())
+        )
     }
 
     Scaffold(
@@ -90,7 +91,6 @@ fun AboutScreen(navController: NavController) {
         },
         contentWindowInsets = WindowInsets.safeDrawing
     ) { innerPadding ->
-
         if (isLandscape) {
             LandscapeAboutContent(
                 modifier = Modifier.padding(innerPadding),

--- a/app/src/main/java/org/WenuLink/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/org/WenuLink/ui/screens/about/AboutScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import androidx.navigation.NavController
+import org.WenuLink.BuildConfig
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -210,7 +211,7 @@ private fun AppIdentitySection() {
             fontWeight = FontWeight.Bold
         )
         Text(
-            text = "v1-beta",
+            text = "v${BuildConfig.VERSION_NAME}",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.secondary
         )

--- a/app/src/main/java/org/WenuLink/ui/screens/main/DashboardUiState.kt
+++ b/app/src/main/java/org/WenuLink/ui/screens/main/DashboardUiState.kt
@@ -9,6 +9,7 @@ data class DashboardUiState(
     val isAircraftPresent: Boolean = false,
     val isSimulationReady: Boolean = false,
     val canRunService: Boolean = false,
+    val isUsingSimulation: Boolean = false,
     val isServiceRunning: Boolean = false,
     val isMAVLinkRunning: Boolean = false,
     val isWebRTCRunning: Boolean = false,

--- a/app/src/main/java/org/WenuLink/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/org/WenuLink/ui/screens/main/MainScreen.kt
@@ -23,13 +23,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Flight
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -38,17 +43,32 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import org.WenuLink.mavlink.BridgeHealth
+
+private data class SimChipStyle(
+    val label: String,
+    val icon: ImageVector,
+    val container: Color,
+    val content: Color
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -231,7 +251,10 @@ private fun StatusSection(uiState: DashboardUiState) {
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Text(
                     "STATUS:",
                     style = MaterialTheme.typography.titleSmall,
@@ -239,7 +262,14 @@ private fun StatusSection(uiState: DashboardUiState) {
                     color = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(uiState.workflowStatus, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    uiState.workflowStatus,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                if (uiState.canRunService) {
+                    SimulationChip(isSimulation = uiState.isUsingSimulation)
+                }
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
             Row(modifier = Modifier.fillMaxWidth()) {
@@ -334,20 +364,100 @@ private fun ActionsSection(
             ) {
                 Text("FORCE STOP")
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                OutlinedButton(onClick = onMavlinkToggle, modifier = Modifier.weight(1f)) {
-                    Text(if (isMAVLinkRunning) "Stop MAVLink" else "Start MAVLink")
-                }
-                OutlinedButton(onClick = onWebRTCToggle, modifier = Modifier.weight(1f)) {
-                    Text(if (isWebRTCRunning) "Stop WebRTC" else "Start WebRTC")
-                }
-            }
+            Spacer(modifier = Modifier.height(12.dp))
+            ServiceSwitchRow(
+                label = "MAVLink",
+                checked = isMAVLinkRunning,
+                onToggle = onMavlinkToggle
+            )
+            ServiceSwitchRow(
+                label = "WebRTC",
+                checked = isWebRTCRunning,
+                onToggle = onWebRTCToggle
+            )
         }
     }
+}
+
+@Composable
+private fun ServiceSwitchRow(label: String, checked: Boolean, onToggle: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+        PendingSwitch(checked = checked, enabled = true, onToggle = onToggle)
+    }
+}
+
+@Composable
+private fun PendingSwitch(checked: Boolean, enabled: Boolean, onToggle: () -> Unit) {
+    var pending by remember { mutableStateOf(false) }
+    var requestedTarget by remember { mutableStateOf(checked) }
+
+    LaunchedEffect(checked) {
+        if (pending && checked == requestedTarget) pending = false
+    }
+    LaunchedEffect(pending) {
+        if (pending) {
+            delay(5_000L)
+            pending = false
+        }
+    }
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (pending) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                strokeWidth = 2.dp
+            )
+            Spacer(Modifier.width(8.dp))
+        }
+        Switch(
+            checked = checked,
+            enabled = enabled && !pending,
+            onCheckedChange = {
+                requestedTarget = it
+                pending = true
+                onToggle()
+            }
+        )
+    }
+}
+
+@Composable
+private fun SimulationChip(isSimulation: Boolean) {
+    val (label, icon, container, content) = if (isSimulation) {
+        SimChipStyle(
+            label = "SIM",
+            icon = Icons.Default.Science,
+            container = Color(0xFFFFB300), // amber
+            content = Color.Black
+        )
+    } else {
+        SimChipStyle(
+            label = "AIRCRAFT",
+            icon = Icons.Default.Flight,
+            container = MaterialTheme.colorScheme.primaryContainer,
+            content = MaterialTheme.colorScheme.onPrimaryContainer
+        )
+    }
+    AssistChip(
+        onClick = {},
+        enabled = false,
+        label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+        leadingIcon = {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(16.dp))
+        },
+        colors = AssistChipDefaults.assistChipColors(
+            disabledContainerColor = container,
+            disabledLabelColor = content,
+            disabledLeadingIconContentColor = content
+        )
+    )
 }
 
 @Composable

--- a/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
+++ b/app/src/main/java/org/WenuLink/views/ServicesViewModel.kt
@@ -26,6 +26,7 @@ class ServicesViewModel(application: Application) : AndroidViewModel(application
     val isAircraftPresent: StateFlow<Boolean> = thisApp.isAircraftPresent.asStateFlow()
     val isSimReady: StateFlow<Boolean> = thisApp.isSimulationReady.asStateFlow()
     val isAircraftBoot: StateFlow<Boolean> = thisApp.isAircraftBoot.asStateFlow()
+    val isUsingSimulation: StateFlow<Boolean> = thisApp.isUsingSimulation.asStateFlow()
     val isServiceUp: StateFlow<Boolean> = thisApp.isServiceUp.asStateFlow()
 
     // To expose the StateFlow for MAVLink


### PR DESCRIPTION
#### Changes: 

- `Start/Stop MAVLink` and `Start/Stop WebRTC` become Material 3 Switches, to better represent binary states compared to action buttons
- Surface a new `isUsingSimulation` StateFlow from` WenuLinkApp` through `ServicesViewModel` and `DashboardUiState`. An AssistChip in the top-right of the` StatusSection` card shows "SIM" (amber) or "AIRCRAFT" (primary container)
- Replace hardcoded "v1-beta" with `BuildConfig.VERSION_NAME` so the displayed version stays in sync with the gradle definition
- Chnage GitHub link to point to the repo instead of the organization