### PR TITLE
Fix/mission upload reset

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -17,6 +17,7 @@ import org.WenuLink.adapters.mission.MissionCommand
 import org.WenuLink.adapters.mission.RepositionAction
 import org.WenuLink.adapters.mission.ReturnAction
 import org.WenuLink.adapters.mission.StartWaypointMission
+import org.WenuLink.adapters.mission.UploadWaypointMission
 import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.ICommand
 import org.WenuLink.commands.UnitResult
@@ -33,6 +34,10 @@ sealed interface RequestCommand : ICommand<WenuLinkHandler> {
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult
     override suspend fun onStop(ctx: WenuLinkHandler)
 }
+
+/**
+ * Aircraft related classes
+ */
 
 open class RequestTransition(open val transition: StateTransition) : RequestCommand {
     override fun validate(ctx: WenuLinkHandler): UnitResult =
@@ -97,6 +102,10 @@ data class RequestTakeoff(val altitude: Float = 2f, val timeout: Long = 15_000L)
     }
 }
 
+/**
+ * Mission related classes
+ */
+
 data class RequestStartMission(
     private val startSequence: Int,
     private val endSequence: Int,
@@ -112,8 +121,9 @@ data class RequestStartMission(
         val homeResult = checkHomePosition(ctx)
         if (homeResult.hasError) return homeResult
 
-        // Handle initial transitions
-        super.execute(ctx)
+        // upload mission
+        val uploadResult = ctx.dispatchAndAwait(WenuLinkCommand.Mission(UploadWaypointMission(3)))
+        if (uploadResult.hasError) return uploadResult
 
         val authorityResult = ctx.dispatchControlAuthority(ControlAuthorityType.WAYPOINT_MISSION)
         if (authorityResult.hasError) return authorityResult
@@ -123,12 +133,15 @@ data class RequestStartMission(
         val startResult = ctx.dispatchAndAwait(WenuLinkCommand.Mission(StartWaypointMission))
         if (startResult.hasError) return startResult
 
+        // Handle initial transitions
+        super.execute(ctx)
+
         // Wait arm and takeoff
         val takeoffOk = ctx.aircraft.waitFlightState(true, 15_000L)
         if (!takeoffOk) return CommandResult.error("Vehicle did not takeoff!")
 
         // Wait initial altitude for mission start (5min top)
-        val initOk = ctx.mission.waitMissionStart(300_000L)
+        val initOk = ctx.mission.waitInitialWaypoint(300_000L)
         if (!initOk) return CommandResult.error("Mission did not start!")
 
         // Handle final transition

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -228,7 +228,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     }
 
     fun missionPause() {
-        if (!mission.state.isActive()) return
+        if (!mission.state.isActive) return
 
         logger.i { "Pause mission" }
         when {
@@ -251,7 +251,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     }
 
     fun missionResume() {
-        if (!mission.state.isPaused()) return
+        if (!mission.state.isPaused) return
 
         logger.i { "Resume mission" }
         when {
@@ -272,7 +272,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
     }
 
     fun missionStop() {
-        if (!mission.state.isActive()) return
+        if (!mission.state.isActive) return
 
         when {
             controlAuthority.isWaypoint() ->
@@ -325,7 +325,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
 
     private fun waypointMissionHooks() = when {
         mission.state.isComplete -> onMissionComplete()
-        mission.state.mustProcessSequence() -> mission.processNode()
+        mission.state.mustProcessSequence -> mission.processNode()
         else -> {}
     }
 

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
@@ -1,10 +1,19 @@
 package org.WenuLink.adapters.mission
 
+import com.MAVLink.common.msg_mission_item_int
+import com.MAVLink.enums.MAV_CMD
 import org.WenuLink.adapters.aircraft.Coordinates3D
+import org.WenuLink.mavlink.messages.ConditionYawMessage
+import org.WenuLink.mavlink.messages.ImageStartCaptureMessage
+import org.WenuLink.mavlink.messages.NavDelayMessage
+import org.WenuLink.mavlink.messages.NavTakeoffMissionItem
+import org.WenuLink.mavlink.messages.NavWaypointMissionItem
 
-class MissionAssembler {
+class MissionAssembler(private val id: Int) {
     private val nodes = mutableListOf<MissionNode>()
     private var rtlWhenFinish = false
+    var timestamp = System.currentTimeMillis()
+        private set
     var nWaypoints = 0
         private set
 
@@ -39,4 +48,79 @@ class MissionAssembler {
     }
 
     fun build(): AssembledMission = AssembledMission(nodes.toList(), nWaypoints, rtlWhenFinish)
+
+    fun addWaypointNode(itemMsg: msg_mission_item_int): Boolean {
+//        logger.d { "Append mission item." }
+        when (itemMsg.command) {
+            MAV_CMD.MAV_CMD_NAV_TAKEOFF -> assembleTakeoffNode(itemMsg)
+
+            MAV_CMD.MAV_CMD_NAV_WAYPOINT -> assembleWaypointNode(itemMsg)
+
+            MAV_CMD.MAV_CMD_NAV_DELAY,
+            MAV_CMD.MAV_CMD_CONDITION_DELAY -> addActionToLast(
+                DelayAction.fromParameters(NavDelayMessage(itemMsg))
+            )
+
+            MAV_CMD.MAV_CMD_CONDITION_YAW -> addActionToLast(
+                RotateAction.fromParameters(ConditionYawMessage(itemMsg))
+            )
+
+            MAV_CMD.MAV_CMD_IMAGE_START_CAPTURE -> addActionToLast(
+                PhotoAction.fromParameters(ImageStartCaptureMessage(itemMsg))
+            )
+
+            MAV_CMD.MAV_CMD_IMAGE_STOP_CAPTURE ->
+                addActionToLast(StopPhotoAction)
+
+            MAV_CMD.MAV_CMD_VIDEO_START_CAPTURE ->
+                addActionToLast(VideoAction())
+
+            MAV_CMD.MAV_CMD_VIDEO_STOP_CAPTURE ->
+                addActionToLast(StopVideoAction)
+
+            MAV_CMD.MAV_CMD_NAV_RETURN_TO_LAUNCH ->
+                setRTLWhenFinish()
+
+            else -> return false
+        }
+        return true
+    }
+
+    private fun assembleTakeoffNode(itemMsg: msg_mission_item_int) {
+        val params = NavTakeoffMissionItem(itemMsg)
+        addTakeoff(
+            Coordinates3D(params.latitude, params.longitude, params.altitude)
+        )
+    }
+
+    private fun assembleWaypointNode(itemMsg: msg_mission_item_int) {
+        val params = NavWaypointMissionItem(itemMsg)
+        // Assumes Global only
+        val coordinates = Coordinates3D(params.latitude, params.longitude, params.altitude)
+
+        // TODO: airframe check
+//         val frameReference = itemMsg.frame.toInt()
+//         // We only support the following frame models:
+//         // 0 = Global (WGS84) coordinate frame + altitude relative to mean sea level (MSL).
+//         // 3 = Global (WGS84) coordinate frame + altitude relative to the home position.
+//         if (frameReference != 0 && frameReference != 3) {
+//             logger.w { "frameReference: $frameReference is not available" }
+//             sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED_FRAME)
+//             return
+//         }
+
+        addWaypoint(coordinates)
+
+        // Delay (seconds)
+        if (params.holdTimeSec > 0f) {
+            addActionToLast(DelayAction((params.holdTimeSec * 1000).toLong()))
+        }
+
+        // Yaw
+        if (!params.yaw.isNaN()) {
+            addActionToLast(RotateAction(params.yaw))
+        }
+
+//        logger.d { "Waypoint: ($coordinates) (Yaw=${params.yaw}°) (Delay=${params.holdTimeSec}s)" }
+    }
 }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -54,12 +54,14 @@ data class UploadWaypointMission(val maxTries: Int = 3) : MissionCommand {
         }
     }
     override suspend fun execute(ctx: MissionHandler): UnitResult {
-        repeat(maxTries) {
-            val uploadResult = tryUpload(ctx)
-            if (!uploadResult.hasError) return UnitResult.ok
+        val maxAttempts = maxTries.coerceAtLeast(1)
+        var attempt = 0
+        var result: UnitResult = CommandResult.error("No upload attempted")
+        while (result.hasError && attempt < maxAttempts) {
+            result = tryUpload(ctx)
+            attempt++
         }
-        // If all retries failed, do final attempt and return result
-        return tryUpload(ctx)
+        return result
     }
 
     override suspend fun onStop(ctx: MissionHandler) {

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -35,7 +35,7 @@ data class UploadMissionCommand(
     private val flightSpeed: Float = 5f
 ) : MissionCommand {
     override fun validate(ctx: MissionHandler): UnitResult = when {
-        ctx.state.canCreateMission() -> CommandResult.ok
+        ctx.state.canUploadMission -> CommandResult.ok
         else -> CommandResult.error("Upload not ready")
     }
 
@@ -55,9 +55,9 @@ data class UploadMissionCommand(
 
 data object StartWaypointMission : MissionCommand {
     override fun validate(ctx: MissionHandler): UnitResult = when {
-        ctx.state.canCreateMission() -> CommandResult.error("No mission found")
-        ctx.state.isActive() -> CommandResult.error("Already started")
-        ctx.state.canStartMission() -> CommandResult.ok
+        ctx.state.canUploadMission -> CommandResult.error("No mission found")
+        ctx.state.isActive -> CommandResult.error("Already started")
+        ctx.state.canStartMission -> CommandResult.ok
         else -> CommandResult.error("Not ready")
     }
 
@@ -77,7 +77,7 @@ data object StartWaypointMission : MissionCommand {
 
 data object PauseWaypointMission : MissionCommand {
     override fun validate(ctx: MissionHandler): UnitResult = when {
-        ctx.state.isActive() -> CommandResult.ok
+        ctx.state.isActive -> CommandResult.ok
         else -> CommandResult.error("Not started")
     }
 
@@ -97,7 +97,7 @@ data object PauseWaypointMission : MissionCommand {
 
 data object ResumeWaypointMission : MissionCommand {
     override fun validate(ctx: MissionHandler): UnitResult = when {
-        ctx.state.isPaused() -> CommandResult.ok
+        ctx.state.isPaused -> CommandResult.ok
         else -> CommandResult.error("Already in execution")
     }
 
@@ -117,7 +117,7 @@ data object ResumeWaypointMission : MissionCommand {
 
 data object StopWaypointMission : MissionCommand {
     override fun validate(ctx: MissionHandler): UnitResult = when {
-        !ctx.state.canCreateMission() -> CommandResult.ok
+        !ctx.state.canUploadMission -> CommandResult.ok
         else -> CommandResult.error("Nothing to stop")
     }
 
@@ -188,7 +188,7 @@ data class DelayAction(val timeMillis: Long) : MissionActionCommand {
     }
 
     override fun validate(ctx: MissionHandler): UnitResult = when {
-        ctx.state.isActive() -> CommandResult.error("Busy")
+        ctx.state.isActive -> CommandResult.error("Busy")
         else -> CommandResult.ok
     }
 

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionCommands.kt
@@ -30,27 +30,43 @@ sealed interface MissionCommand : ICommand<MissionHandler> {
     override suspend fun onStop(ctx: MissionHandler)
 }
 
-data class UploadMissionCommand(
-    private val assembler: MissionAssembler,
-    private val flightSpeed: Float = 5f
-) : MissionCommand {
+data class UploadWaypointMission(val maxTries: Int = 3) : MissionCommand {
     override fun validate(ctx: MissionHandler): UnitResult = when {
-        ctx.state.canUploadMission -> CommandResult.ok
-        else -> CommandResult.error("Upload not ready")
+        !ctx.state.uploadReady -> CommandResult.error("No mission found")
+        !ctx.state.hasAssembler -> CommandResult.error("No mission assembler")
+        !ctx.state.canUploadMission -> CommandResult.error("Not ready to upload")
+        else -> CommandResult.ok
     }
 
-    override suspend fun execute(ctx: MissionHandler): UnitResult =
-        suspendCancellableCoroutine { cont ->
-            MissionManager.uploadMission(assembler.build(), flightSpeed) { _, error ->
+    suspend fun tryUpload(ctx: MissionHandler): UnitResult = suspendCancellableCoroutine { cont ->
+        ctx.state.assembler?.let {
+            ctx.setUploadingMission(true)
+            MissionManager.uploadMission(it.build(), ctx.flightSpeed) { _, error ->
+                ctx.setUploadingMission(false)
+                ctx.syncState()
                 cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
-            }
-
-            cont.invokeOnCancellation {
-                // Add SDK cancel if available
             }
         }
 
-    override suspend fun onStop(ctx: MissionHandler) = MissionManager.clearMission()
+        cont.invokeOnCancellation {
+            // Add SDK cancel if available
+            ctx.setUploadingMission(false)
+        }
+    }
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
+        repeat(maxTries) {
+            val uploadResult = tryUpload(ctx)
+            if (!uploadResult.hasError) return UnitResult.ok
+        }
+        // If all retries failed, do final attempt and return result
+        return tryUpload(ctx)
+    }
+
+    override suspend fun onStop(ctx: MissionHandler) {
+        // TODO: SDK mission cancelUploading
+        MissionManager.clearMission()
+        ctx.setUploadingMission(false)
+    }
 }
 
 data object StartWaypointMission : MissionCommand {
@@ -58,21 +74,25 @@ data object StartWaypointMission : MissionCommand {
         ctx.state.canUploadMission -> CommandResult.error("No mission found")
         ctx.state.isActive -> CommandResult.error("Already started")
         ctx.state.canStartMission -> CommandResult.ok
-        else -> CommandResult.error("Not ready")
+        else -> CommandResult.error("Unable to start")
     }
 
-    override suspend fun execute(ctx: MissionHandler): UnitResult =
-        suspendCancellableCoroutine { cont ->
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
+        val startResult = suspendCancellableCoroutine { cont ->
             MissionManager.startMission { error ->
                 cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
-                // Add SDK cancel if available
             }
         }
+        if (startResult.hasError) return startResult
 
-    override suspend fun onStop(ctx: MissionHandler) = ctx.dispatchCommand(PauseWaypointMission)
+        val isActive = ctx.waitMissionStart(15_000L)
+        return if (isActive) CommandResult.ok else CommandResult.error("Start mission timeout")
+    }
+
+    override suspend fun onStop(ctx: MissionHandler) = ctx.dispatchCommand(StopWaypointMission)
 }
 
 data object PauseWaypointMission : MissionCommand {
@@ -81,16 +101,20 @@ data object PauseWaypointMission : MissionCommand {
         else -> CommandResult.error("Not started")
     }
 
-    override suspend fun execute(ctx: MissionHandler): UnitResult =
-        suspendCancellableCoroutine { cont ->
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
+        val pauseResult = suspendCancellableCoroutine { cont ->
             MissionManager.pauseMission { error ->
                 cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
-                // Add SDK cancel if available
             }
         }
+        if (pauseResult.hasError) return pauseResult
+
+        val isPaused = ctx.waitMissionPause(15_000L)
+        return if (isPaused) CommandResult.ok else CommandResult.error("Pause mission timeout")
+    }
 
     override suspend fun onStop(ctx: MissionHandler) { }
 }
@@ -101,16 +125,20 @@ data object ResumeWaypointMission : MissionCommand {
         else -> CommandResult.error("Already in execution")
     }
 
-    override suspend fun execute(ctx: MissionHandler): UnitResult =
-        suspendCancellableCoroutine { cont ->
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
+        val resumeResult = suspendCancellableCoroutine { cont ->
             MissionManager.resumeMission { error ->
                 cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
-                // Add SDK cancel if available
             }
         }
+        if (resumeResult.hasError) return resumeResult
+
+        val isResumed = ctx.waitMissionStart(15_000L)
+        return if (isResumed) CommandResult.ok else CommandResult.error("Resume mission timeout")
+    }
 
     override suspend fun onStop(ctx: MissionHandler) { }
 }
@@ -121,16 +149,20 @@ data object StopWaypointMission : MissionCommand {
         else -> CommandResult.error("Nothing to stop")
     }
 
-    override suspend fun execute(ctx: MissionHandler): UnitResult =
-        suspendCancellableCoroutine { cont ->
+    override suspend fun execute(ctx: MissionHandler): UnitResult {
+        val stopResult = suspendCancellableCoroutine { cont ->
             MissionManager.stopMission { error ->
                 cont.resume(if (error == null) CommandResult.ok else CommandResult.error(error))
             }
 
             cont.invokeOnCancellation {
-                // Add SDK cancel if available
             }
         }
+        if (stopResult.hasError) return stopResult
+
+        val isStop = ctx.waitMissionComplete(5000L)
+        return if (isStop) CommandResult.ok else CommandResult.error("Stop mission timeout")
+    }
 
     override suspend fun onStop(ctx: MissionHandler) { }
 }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -1,22 +1,15 @@
 package org.WenuLink.adapters.mission
 
 import com.MAVLink.common.msg_mission_item_int
-import com.MAVLink.enums.MAV_CMD
 import com.MAVLink.enums.MISSION_STATE
 import dji.sdk.mission.timeline.actions.MissionAction
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.WenuLink.adapters.AsyncUtils
-import org.WenuLink.adapters.aircraft.Coordinates3D
 import org.WenuLink.commands.CommandHandler
 import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.UnitResult
-import org.WenuLink.mavlink.messages.ConditionYawMessage
-import org.WenuLink.mavlink.messages.ImageStartCaptureMessage
-import org.WenuLink.mavlink.messages.NavDelayMessage
-import org.WenuLink.mavlink.messages.NavTakeoffMissionItem
-import org.WenuLink.mavlink.messages.NavWaypointMissionItem
 import org.WenuLink.sdk.MissionActionManager
 import org.WenuLink.sdk.MissionManager
 
@@ -27,18 +20,23 @@ data class MissionState(
     val currentSequence: Int? = null,
     val assembler: MissionAssembler? = null,
     val unvisitedSequence: Boolean = true,
-    val isComplete: Boolean = false
+    val isComplete: Boolean = false,
+    val isUploading: Boolean = false,
+    val isReceivingItems: Boolean = false,
+    val uploadReady: Boolean = false
 ) {
     // Report the next sequence as target
     val targetSequence: Int get() = currentSequence?.let { it + 1 } ?: 0
 
     val currentMissionSize: Int get() = assembler?.size() ?: 0
 
+    val hasAssembler: Boolean get() = assembler != null
+
     val isActive: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_ACTIVE
 
     val isPaused: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_PAUSED
 
-    val canUploadMission: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_NO_MISSION && assembler != null
+    val canUploadMission: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_NO_MISSION
 
     val canStartMission: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_NOT_STARTED
 
@@ -62,6 +60,13 @@ data class MissionState(
 
     fun markVisited(): MissionState = copy(unvisitedSequence = false)
 
+    fun setUploading(isUploading: Boolean): MissionState = copy(isUploading = isUploading)
+
+    fun setReceivingItems(isReceivingItems: Boolean): MissionState =
+        copy(isReceivingItems = isReceivingItems)
+
+    fun setUploadReady(uploadReady: Boolean): MissionState = copy(uploadReady = uploadReady)
+
     fun fromMissionManager(): MissionState = copy(
         mavlink = when {
             isComplete -> MISSION_STATE.MISSION_STATE_COMPLETE
@@ -77,13 +82,12 @@ data class MissionState(
         startSequence = 1,
         currentSequence = null,
         isComplete = false,
-        unvisitedSequence = true,
-        assembler = null
+        unvisitedSequence = true
     ).fromMissionManager()
 
-    fun clearWaypoints() {
+    fun resetAssembler(): MissionState {
         assembler?.reset()
-        if (!canUploadMission) MissionManager.clearMission()
+        return copy(assembler = null)
     }
 }
 
@@ -121,8 +125,9 @@ class MissionHandler : CommandHandler<MissionHandler>() {
     }
 
     @Synchronized
-    fun syncState() {
+    fun syncState(): MissionState {
         state = state.fromMissionManager()
+        return state
     }
 
     @Synchronized
@@ -156,37 +161,70 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         return state
     }
 
+    @Synchronized
+    fun setUploadingMission(isUploading: Boolean) {
+        logger.d { "Uploading mission: $isUploading" }
+        state = state.setUploading(isUploading)
+    }
+
+    @Synchronized
+    fun setReceivingItems(isReceiving: Boolean) {
+        logger.d { "Processing mission: $isReceiving (${MissionManager.currentState})" }
+        state = state.setReceivingItems(isReceiving)
+    }
+
     fun setSpeed(speed: Float) {
         val range = -15f..15f
         flightSpeed = speed.coerceIn(range)
         if (speed !in range) logger.w { "Clipped speed $speed to [$range]" }
     }
 
+    @Synchronized
     fun resetState() {
+        logger.d { "Reset mission state" }
         state = state.reset()
     }
 
     fun clear() {
-        resetState()
-        state.clearWaypoints()
-        MissionActionManager.clearScheduleAndListeners()
+        logger.d { "Full mission clear ${MissionManager.currentState}" }
+        resetWaypoints()
+        resetActions()
     }
 
     /**
      * MissionManager methods
      */
+    fun resetWaypoints() {
+        logger.d { "Clearing mission elements" }
+        MissionManager.clearMission()
+    }
 
-    fun createWaypointMission() {
-        if (!state.canUploadMission) {
-            // reset previous uploaded elements
-            logger.i { "Removing previous incomplete upload" }
-            state.clearWaypoints()
+    @Synchronized
+    fun createWaypointMission(): UnitResult {
+        if (state.isReceivingItems) return UnitResult.error("Other mission process is ongoing")
+
+        if (state.hasAssembler) {
+            logger.d { "Clearing previous mission assembler" }
+            state = state.resetAssembler()
+            state = state.setUploadReady(false)
         }
+        logger.d { "Adding new mission id 202606" }
         state = state.createMission(202606)
+
+        setReceivingItems(true)
+        return UnitResult.ok
+    }
+
+    fun missionUploadReady(): UnitResult {
+        if (!state.isReceivingItems) return UnitResult.error("No mission to upload")
+        setReceivingItems(false)
+        // TODO: validates mission items
+        state = state.setUploadReady(true)
+        return UnitResult.ok
     }
 
     fun processItem(itemMsg: msg_mission_item_int): Boolean {
-        if (!state.canUploadMission) logger.w { "Processing item without mission assembler" }
+        if (!state.hasAssembler) logger.w { "Processing item without assembler" }
         return state.assembler?.addWaypointNode(itemMsg) ?: false
     }
 
@@ -194,17 +232,28 @@ class MissionHandler : CommandHandler<MissionHandler>() {
 
     fun hasWaypointNodes(): Boolean = state.assembler?.hasNodes() ?: false
 
-    fun uploadWaypoints(onResult: (UnitResult) -> Unit) = // TODO: retry if no success
-        state.assembler?.let { dispatchCommand(UploadMissionCommand(it, flightSpeed), onResult) }
+    suspend fun waitMissionStart(timeout: Long = 10_000L): Boolean =
+        AsyncUtils.waitTimeout(200L, timeout) { state.isActive }
 
-    suspend fun waitMissionStart(timeout: Long = 300_000L): Boolean =
+    suspend fun waitMissionPause(timeout: Long = 10_000L): Boolean =
+        AsyncUtils.waitTimeout(200L, timeout) { state.isPaused }
+
+    suspend fun waitInitialWaypoint(timeout: Long = 300_000L): Boolean =
         AsyncUtils.waitTimeout(500L, timeout) { state.currentSequence != null }
+
+    suspend fun waitMissionComplete(timeout: Long = 10_000L): Boolean =
+        AsyncUtils.waitTimeout(200L, timeout) { state.isComplete }
 
     /**
      * MissionActionManager methods
      */
 
     fun teardownActions() = lastActionKey?.let { MissionActionManager.removeCallback(it) }
+
+    fun resetActions() {
+        logger.i { "Clearing mission actions" }
+        MissionActionManager.clearScheduleAndListeners()
+    }
 
     fun scheduleImmediateAction(action: MissionAction): UnitResult {
         logger.d { "Scheduling $action" }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -25,22 +25,32 @@ data class MissionState(
     val id: Int = 202512,
     val startSequence: Int = 1,
     val currentSequence: Int? = null,
-    val assembler: MissionAssembler = MissionAssembler(),
+    val assembler: MissionAssembler? = null,
     val unvisitedSequence: Boolean = true,
     val isComplete: Boolean = false
 ) {
     // Report the next sequence as target
     val targetSequence: Int get() = currentSequence?.let { it + 1 } ?: 0
 
-    fun totalNodes(): Int = assembler.size()
+    val currentMissionSize: Int get() = assembler?.size() ?: 0
 
-    fun isActive() = mavlink == MISSION_STATE.MISSION_STATE_ACTIVE
+    val isActive: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_ACTIVE
 
-    fun isPaused() = mavlink == MISSION_STATE.MISSION_STATE_PAUSED
+    val isPaused: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_PAUSED
 
-    fun canCreateMission() = mavlink == MISSION_STATE.MISSION_STATE_NO_MISSION
+    val canUploadMission: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_NO_MISSION && assembler != null
 
-    fun canStartMission() = mavlink == MISSION_STATE.MISSION_STATE_NOT_STARTED
+    val canStartMission: Boolean get() = mavlink == MISSION_STATE.MISSION_STATE_NOT_STARTED
+
+    val mustProcessSequence: Boolean get() = isActive && unvisitedSequence
+
+    val itemTime: Long get() = if (assembler != null) {
+        System.currentTimeMillis() - assembler.timestamp
+    } else {
+        0
+    }
+
+    fun createMission(id: Int): MissionState = copy(assembler = MissionAssembler(id))
 
     fun setStartSequence(sequence: Int): MissionState =
         copy(startSequence = sequence, isComplete = false)
@@ -63,16 +73,18 @@ data class MissionState(
         }
     )
 
-    fun mustProcessSequence() = isActive() && unvisitedSequence
-
     fun reset(): MissionState = copy(
         startSequence = 1,
         currentSequence = null,
         isComplete = false,
-        unvisitedSequence = true
+        unvisitedSequence = true,
+        assembler = null
     ).fromMissionManager()
 
-    fun clearWaypoints() = assembler.reset()
+    fun clearWaypoints() {
+        assembler?.reset()
+        if (!canUploadMission) MissionManager.clearMission()
+    }
 }
 
 class MissionHandler : CommandHandler<MissionHandler>() {
@@ -94,6 +106,7 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         private set
     var state = MissionState()
         private set
+    // TODO MissionItem timeout guard
 
     override fun registerScope(scope: CoroutineScope) {
         MissionManager.addListeners { index ->
@@ -149,10 +162,6 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         if (speed !in range) logger.w { "Clipped speed $speed to [$range]" }
     }
 
-    fun getWaypointNode(index: Int): MissionNode = state.assembler.getNode(index)
-
-    fun hasWaypointNodes(): Boolean = state.assembler.hasNodes()
-
     fun resetState() {
         state = state.reset()
     }
@@ -163,87 +172,30 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         MissionActionManager.clearScheduleAndListeners()
     }
 
-    fun addWaypointNode(itemMsg: msg_mission_item_int): Boolean {
-        logger.d { "Append mission item." }
-        when (itemMsg.command) {
-            MAV_CMD.MAV_CMD_NAV_TAKEOFF -> assembleTakeoffNode(itemMsg)
-
-            MAV_CMD.MAV_CMD_NAV_WAYPOINT -> assembleWaypointNode(itemMsg)
-
-            MAV_CMD.MAV_CMD_NAV_DELAY,
-            MAV_CMD.MAV_CMD_CONDITION_DELAY -> state.assembler.addActionToLast(
-                DelayAction.fromParameters(NavDelayMessage(itemMsg))
-            )
-
-            MAV_CMD.MAV_CMD_CONDITION_YAW -> state.assembler.addActionToLast(
-                RotateAction.fromParameters(ConditionYawMessage(itemMsg))
-            )
-
-            MAV_CMD.MAV_CMD_IMAGE_START_CAPTURE -> state.assembler.addActionToLast(
-                PhotoAction.fromParameters(ImageStartCaptureMessage(itemMsg))
-            )
-
-            MAV_CMD.MAV_CMD_IMAGE_STOP_CAPTURE ->
-                state.assembler.addActionToLast(StopPhotoAction)
-
-            MAV_CMD.MAV_CMD_VIDEO_START_CAPTURE ->
-                state.assembler.addActionToLast(VideoAction())
-
-            MAV_CMD.MAV_CMD_VIDEO_STOP_CAPTURE ->
-                state.assembler.addActionToLast(StopVideoAction)
-
-            MAV_CMD.MAV_CMD_NAV_RETURN_TO_LAUNCH ->
-                state.assembler.setRTLWhenFinish()
-
-            else -> return false
-        }
-        return true
-    }
-
-    private fun assembleTakeoffNode(itemMsg: msg_mission_item_int) {
-        val params = NavTakeoffMissionItem(itemMsg)
-        state.assembler.addTakeoff(
-            Coordinates3D(params.latitude, params.longitude, params.altitude)
-        )
-    }
-
-    private fun assembleWaypointNode(itemMsg: msg_mission_item_int) {
-        val params = NavWaypointMissionItem(itemMsg)
-        // Assumes Global only
-        val coordinates = Coordinates3D(params.latitude, params.longitude, params.altitude)
-
-        // TODO: airframe check
-//         val frameReference = itemMsg.frame.toInt()
-//         // We only support the following frame models:
-//         // 0 = Global (WGS84) coordinate frame + altitude relative to mean sea level (MSL).
-//         // 3 = Global (WGS84) coordinate frame + altitude relative to the home position.
-//         if (frameReference != 0 && frameReference != 3) {
-//             logger.w { "frameReference: $frameReference is not available" }
-//             sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED_FRAME)
-//             return
-//         }
-
-        state.assembler.addWaypoint(coordinates)
-
-        // Delay (seconds)
-        if (params.holdTimeSec > 0f) {
-            state.assembler.addActionToLast(DelayAction((params.holdTimeSec * 1000).toLong()))
-        }
-
-        // Yaw
-        if (!params.yaw.isNaN()) {
-            state.assembler.addActionToLast(RotateAction(params.yaw))
-        }
-
-        logger.d { "Waypoint: ($coordinates) (Yaw=${params.yaw}°) (Delay=${params.holdTimeSec}s)" }
-    }
-
     /**
      * MissionManager methods
      */
 
+    fun createWaypointMission() {
+        if (!state.canUploadMission) {
+            // reset previous uploaded elements
+            logger.i { "Removing previous incomplete upload" }
+            state.clearWaypoints()
+        }
+        state = state.createMission(202606)
+    }
+
+    fun processItem(itemMsg: msg_mission_item_int): Boolean {
+        if (!state.canUploadMission) logger.w { "Processing item without mission assembler" }
+        return state.assembler?.addWaypointNode(itemMsg) ?: false
+    }
+
+    fun getWaypointNode(index: Int): MissionNode? = state.assembler?.getNode(index)
+
+    fun hasWaypointNodes(): Boolean = state.assembler?.hasNodes() ?: false
+
     fun uploadWaypoints(onResult: (UnitResult) -> Unit) = // TODO: retry if no success
-        dispatchCommand(UploadMissionCommand(state.assembler, flightSpeed), onResult)
+        state.assembler?.let { dispatchCommand(UploadMissionCommand(it, flightSpeed), onResult) }
 
     suspend fun waitMissionStart(timeout: Long = 300_000L): Boolean =
         AsyncUtils.waitTimeout(500L, timeout) { state.currentSequence != null }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -15,7 +15,7 @@ import org.WenuLink.sdk.MissionManager
 
 data class MissionState(
     val mavlink: Int = MISSION_STATE.MISSION_STATE_UNKNOWN,
-    val id: Int = 202512,
+    val id: Int = 100,
     val startSequence: Int = 1,
     val currentSequence: Int? = null,
     val assembler: MissionAssembler? = null,
@@ -85,10 +85,7 @@ data class MissionState(
         unvisitedSequence = true
     ).fromMissionManager()
 
-    fun resetAssembler(): MissionState {
-        assembler?.reset()
-        return copy(assembler = null)
-    }
+    fun resetAssembler(): MissionState = copy(assembler = null)
 }
 
 class MissionHandler : CommandHandler<MissionHandler>() {
@@ -200,7 +197,7 @@ class MissionHandler : CommandHandler<MissionHandler>() {
     }
 
     @Synchronized
-    fun createWaypointMission(): UnitResult {
+    fun createWaypointMission(missionId: Int = 100): UnitResult {
         if (state.isReceivingItems) return UnitResult.error("Other mission process is ongoing")
 
         if (state.hasAssembler) {
@@ -208,8 +205,8 @@ class MissionHandler : CommandHandler<MissionHandler>() {
             state = state.resetAssembler()
             state = state.setUploadReady(false)
         }
-        logger.d { "Adding new mission id 202606" }
-        state = state.createMission(202606)
+        logger.d { "Adding new mission id $missionId" }
+        state = state.createMission(missionId)
 
         setReceivingItems(true)
         return UnitResult.ok
@@ -224,7 +221,10 @@ class MissionHandler : CommandHandler<MissionHandler>() {
     }
 
     fun processItem(itemMsg: msg_mission_item_int): Boolean {
-        if (!state.hasAssembler) logger.w { "Processing item without assembler" }
+        if (!state.hasAssembler) {
+            logger.w { "processItem called without assembler, item ${itemMsg.command} dropped" }
+            return false
+        }
         return state.assembler?.addWaypointNode(itemMsg) ?: false
     }
 

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -262,7 +262,13 @@ class NavigationController(
     fun sendStatusText(status: String, severity: Int) = client.sendMessage(
         msg_statustext().apply {
             logger.d { "sendStatusText $status" }
-            text = status.chunked(50).first().toByteArray()
+            text = (
+                if ((status.length + 3) > 50) {
+                    status.take(47) + "..."
+                } else {
+                    status
+                }
+                ).toByteArray()
             this.severity = severity.toShort()
         }
     )

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -105,8 +105,8 @@ class NavigationController(
         else -> null
     }
 
-    fun node2MissionItemMsg(nIdx: Int): msg_mission_item_int {
-        val node = handler.mission.getWaypointNode(nIdx)
+    fun node2MissionItemMsg(nIdx: Int): msg_mission_item_int? {
+        val node = handler.mission.getWaypointNode(nIdx) ?: return null
         val coordinates = node.coordinates3D
         return when (node) {
             is MissionNode.Takeoff -> NavTakeoffMissionItem(
@@ -145,7 +145,7 @@ class NavigationController(
     fun sendMissionCount() = client.sendMessage(
         msg_mission_count().apply {
             mission_type = MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION.toShort()
-            count = handler.mission.state.totalNodes()
+            count = handler.mission.state.currentMissionSize
             opaque_id = handler.mission.state.id.toLong()
             logger.d { "sendMissionCount: $count" }
         }
@@ -156,8 +156,7 @@ class NavigationController(
         val idx = itemMsg.seq
         logger.d { "sendMissionItem #$idx" }
         if (handler.mission.hasWaypointNodes()) {
-            val itemMsg = node2MissionItemMsg(idx)
-            client.sendMessage(itemMsg)
+            node2MissionItemMsg(idx)?.let { client.sendMessage(it) }
         }
     }
 
@@ -178,8 +177,6 @@ class NavigationController(
         logger.d { "createNewMission" }
         val missionMsg = msg as msg_mission_count
 
-        if (!handler.mission.state.canCreateMission()) return
-
         // TODO: Stop mission execution first if needed
         numberOfExpectedItems = missionMsg.count
         currentRetryTimes = 0
@@ -189,9 +186,10 @@ class NavigationController(
         if (numberOfExpectedItems > 0) {
             // ask for the first item an iterate over count
             logger.d { "Creating new mission with ${missionMsg.count} items" }
+            handler.mission.createWaypointMission()
             // Request first mission item...
             requestMissionItem(0)
-            // TODO: timeout waiting start?
+            // TODO: timeout guard start
         }
     }
 
@@ -221,7 +219,7 @@ class NavigationController(
         }
 
         // Store item and request next or upload the mission
-        val accepted = handler.mission.addWaypointNode(itemMsg)
+        val accepted = handler.mission.processItem(itemMsg)
         if (!accepted) {
             logger.w { "Unsupported mission command: ${itemMsg.command}" }
             sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED)
@@ -339,13 +337,11 @@ class NavigationController(
 
     fun msgMissionCurrent(): msg_mission_current = msg_mission_current().apply {
         seq = handler.mission.state.targetSequence
-        total = handler.mission.state.assembler.size()
+        total = handler.mission.state.currentMissionSize
         mission_id = handler.mission.state.id.toLong()
         mission_state = handler.mission.state.mavlink.toShort()
-        mission_mode = if (handler.mission.state.isActive()) 1 else 2
+        mission_mode = if (handler.mission.state.isActive) 1 else 2
     }
-
-    // TODO: start, pause, and resume procedures
 
     fun msgHomePosition(): MAVLinkMessage? = msg_home_position().apply {
         val homeLoc = handler.aircraft.state.homeCoordinates ?: return null

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -67,7 +67,7 @@ class NavigationController(
         msg_mission_count.MAVLINK_MSG_ID_MISSION_COUNT to ::createNewMission,
         msg_mission_item_int.MAVLINK_MSG_ID_MISSION_ITEM_INT to ::processMissionItem,
         msg_mission_request_int.MAVLINK_MSG_ID_MISSION_REQUEST_INT to ::sendMissionItem,
-        msg_mission_clear_all.MAVLINK_MSG_ID_MISSION_CLEAR_ALL to { sendMissionClear() },
+        msg_mission_clear_all.MAVLINK_MSG_ID_MISSION_CLEAR_ALL to { processMissionClear() },
         msg_mission_ack.MAVLINK_MSG_ID_MISSION_ACK to ::processAck
     )
 
@@ -160,7 +160,7 @@ class NavigationController(
         }
     }
 
-    fun sendMissionClear() {
+    fun processMissionClear() {
         handler.missionClear()
         sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED)
     }
@@ -186,10 +186,17 @@ class NavigationController(
         if (numberOfExpectedItems > 0) {
             // ask for the first item an iterate over count
             logger.d { "Creating new mission with ${missionMsg.count} items" }
-            handler.mission.createWaypointMission()
-            // Request first mission item...
-            requestMissionItem(0)
-            // TODO: timeout guard start
+            val newMissionResult = handler.mission.createWaypointMission()
+            if (newMissionResult.hasError) {
+                sendStatusText(
+                    newMissionResult.errorReason,
+                    MAV_SEVERITY.MAV_SEVERITY_ERROR
+                )
+            } else {
+                // Request first mission item...
+                requestMissionItem(0)
+                // TODO: timeout guard start
+            }
         }
     }
 
@@ -233,20 +240,15 @@ class NavigationController(
             requestMissionItem(nextExpectedSeq)
         } else {
             // reached the end of the mission items
-            handler.mission.uploadWaypoints { result ->
-                if (result.hasError) {
-                    sendStatusText(
-                        result.errorReason,
-                        MAV_SEVERITY.MAV_SEVERITY_ERROR
-                    )
+            val canUploadResult = handler.mission.missionUploadReady()
+            sendAckAnswer(
+                if (canUploadResult.hasError) {
+                    sendStatusText(canUploadResult.errorReason, MAV_SEVERITY.MAV_SEVERITY_ERROR)
+                    MAV_MISSION_RESULT.MAV_MISSION_DENIED
                 } else {
-                    sendStatusText(
-                        "Successful mission upload",
-                        MAV_SEVERITY.MAV_SEVERITY_INFO
-                    )
+                    MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED
                 }
-            }
-            sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED)
+            )
         }
     }
 
@@ -259,8 +261,8 @@ class NavigationController(
 
     fun sendStatusText(status: String, severity: Int) = client.sendMessage(
         msg_statustext().apply {
-            logger.d { "sendStatusText" }
-            text = status.toByteArray()
+            logger.d { "sendStatusText $status" }
+            text = status.chunked(50).first().toByteArray()
             this.severity = severity.toShort()
         }
     )
@@ -281,7 +283,7 @@ class NavigationController(
                 )
             )
         ) { result ->
-            logger.d { "missionStart: $result" }
+            if (result.hasError) logger.w { "Error on mission start: ${result.errorReason}" }
         }
     }
 

--- a/app/src/main/java/org/WenuLink/sdk/MissionManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/MissionManager.kt
@@ -180,7 +180,11 @@ object MissionManager {
     fun resumeMission(onResult: (String?) -> Unit) =
         operator.resumeMission(SDKUtils.createCompletionCallback(onResult))
 
-    fun clearMission() = operator.clearMission()
+    fun clearMission() {
+        val nElements = operator.loadedMission?.waypointCount ?: 0
+        logger.d { "Clearing mission with $nElements elements" }
+        operator.clearMission()
+    }
 
     fun addListeners(onWaypointStart: (Int) -> Unit) {
         logger.d { "addListeners" }


### PR DESCRIPTION
Main changes were made in `MissionCommands` and `RequestCommands`  with the temporal mission list handled by `MissionAssembler` being used during the MAVLink plan flight upload process. 
The mission is then uploaded to the aircraft after checking the home position and before start the mission in the `RequestStartMission` command.
Since the upload process sometimes fails, a maximum of 3 automatic retry was defined before command's fail.

Other code reorganization regards classes concern was also included.