### PR TITLE
Fix/async state

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
+++ b/app/src/main/java/org/WenuLink/adapters/RequestCommand.kt
@@ -36,7 +36,7 @@ sealed interface RequestCommand : ICommand<WenuLinkHandler> {
 
 open class RequestTransition(open val transition: StateTransition) : RequestCommand {
     override fun validate(ctx: WenuLinkHandler): UnitResult =
-        ctx.aircraft.canDispatchTransition(transition)
+        ctx.aircraft.stateMachine.canDispatch(transition)
 
     suspend fun checkHomePosition(ctx: WenuLinkHandler): UnitResult {
         if (ctx.aircraft.state.isHomeSet()) return CommandResult.ok
@@ -46,7 +46,7 @@ open class RequestTransition(open val transition: StateTransition) : RequestComm
     }
 
     override suspend fun execute(ctx: WenuLinkHandler): UnitResult {
-        ctx.aircraft.dispatchTransition(transition)
+        ctx.aircraft.stateMachine.dispatch(transition)
         return CommandResult.ok
     }
 
@@ -130,9 +130,6 @@ data class RequestStartMission(
         // Wait initial altitude for mission start (5min top)
         val initOk = ctx.mission.waitMissionStart(300_000L)
         if (!initOk) return CommandResult.error("Mission did not start!")
-
-        // Handle final transition
-        ctx.aircraft.dispatchTransition(FlyingTransition)
 
         return CommandResult.ok
     }

--- a/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/WenuLinkHandler.kt
@@ -113,6 +113,7 @@ class WenuLinkHandler : CommandHandler<WenuLinkHandler>() {
                         // --- Sync real aircraft state ---
                         launch {
                             aircraft.syncSensors()
+                            aircraft.syncState()
                             if (aircraft.state.isFlying()) flyingModeHooks()
                         }
 

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftCommands.kt
@@ -14,27 +14,27 @@ sealed interface AircraftCommand : ICommand<AircraftHandler> {
 data class BootCommand(val timeout: Long = 5000L) : AircraftCommand {
     override fun validate(ctx: AircraftHandler): UnitResult = when {
         !ctx.isPowerOff -> CommandResult.error("Already booted")
-        else -> ctx.canDispatchTransition(BootTransition)
+        else -> ctx.stateMachine.canDispatch(BootTransition)
     }
 
     override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
-        ctx.dispatchTransition(BootTransition)
+        ctx.stateMachine.dispatch(BootTransition)
         val bootResult = ctx.boot(timeout)
         if (bootResult.hasError) return bootResult
-        ctx.dispatchTransition(StandbyTransition)
+        ctx.stateMachine.dispatch(StandbyTransition)
         return CommandResult.ok
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {
-        ctx.dispatchTransition(InitialTransition)
+        ctx.stateMachine.dispatch(InitialTransition)
     }
 }
 
 data class ArmCommand(val timeout: Long = 5000L) : AircraftCommand {
     override fun validate(ctx: AircraftHandler): UnitResult = when {
         !ctx.sensorsHealthy -> CommandResult.error("Sensors failing")
-        else -> ctx.canDispatchTransition(ArmTransition)
+        else -> ctx.stateMachine.canDispatch(ArmTransition)
     }
 
     override suspend fun execute(ctx: AircraftHandler): UnitResult {
@@ -47,7 +47,7 @@ data class ArmCommand(val timeout: Long = 5000L) : AircraftCommand {
             }
         }
         // Automatic takeoff only. Must wait for state changes
-        ctx.dispatchTransition(ArmTransition)
+        ctx.stateMachine.dispatch(ArmTransition)
 
         return CommandResult.ok
     }
@@ -59,12 +59,12 @@ data class ArmCommand(val timeout: Long = 5000L) : AircraftCommand {
 
 data class DisarmCommand(val timeout: Long = 5000L) : AircraftCommand {
     override fun validate(ctx: AircraftHandler): UnitResult =
-        ctx.canDispatchTransition(StandbyTransition)
+        ctx.stateMachine.canDispatch(StandbyTransition)
 
     override suspend fun execute(ctx: AircraftHandler): UnitResult {
         ctx.disarmMotors()
         return if (ctx.waitArmTransition(false, timeout)) {
-            ctx.dispatchTransition(StandbyTransition)
+            ctx.stateMachine.dispatch(StandbyTransition)
             CommandResult.ok
         } else {
             CommandResult.error("Unable to disarm motors")
@@ -76,14 +76,14 @@ data class DisarmCommand(val timeout: Long = 5000L) : AircraftCommand {
 
 data class TakeoffCommand(val timeout: Long = 15_000L) : AircraftCommand {
     override fun validate(ctx: AircraftHandler): UnitResult =
-        ctx.canDispatchTransition(TakeoffTransition)
+        ctx.stateMachine.canDispatch(TakeoffTransition)
 
     override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
-        ctx.dispatchTransition(TakeoffTransition)
+        ctx.stateMachine.dispatch(TakeoffTransition)
         ctx.takeOff()
         return if (ctx.waitFlightState(true, timeout)) {
-            ctx.dispatchTransition(FlyingTransition)
+            ctx.stateMachine.dispatch(FlyingTransition)
             CommandResult.ok
         } else {
             ctx.dispatchCommand(DisarmCommand())
@@ -100,19 +100,19 @@ data class ShutdownCommand(val withTransitionCheck: Boolean = true) : AircraftCo
     override fun validate(ctx: AircraftHandler): UnitResult = when {
         ctx.isPowerOff -> CommandResult.error("Already power off")
         !withTransitionCheck -> CommandResult.ok
-        else -> ctx.canDispatchTransition(PowerOffTransition)
+        else -> ctx.stateMachine.canDispatch(PowerOffTransition)
     }
 
     override suspend fun execute(ctx: AircraftHandler): UnitResult {
         // TODO: check if compatible with CancellableCoroutine
-        if (withTransitionCheck) ctx.dispatchTransition(PowerOffTransition)
+        if (withTransitionCheck) ctx.stateMachine.dispatch(PowerOffTransition)
         ctx.shutdown()
-        ctx.dispatchTransition(InitialTransition)
+        ctx.stateMachine.dispatch(InitialTransition)
         return CommandResult.ok
     }
 
     override suspend fun onStop(ctx: AircraftHandler) {
-        ctx.dispatchTransition(InitialTransition)
+        ctx.stateMachine.dispatch(InitialTransition)
     }
 }
 

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -224,14 +224,12 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     fun takeOff() {
         // sync and check for already-airborne cases
         if (state.isFlying()) {
-            logger.d { "Aircraft already airborne" }
+            logger.w { "Takeoff called but aircraft already airborne, skipping" }
             return
         }
         logger.d { "Aircraft taking off" }
         FCManager.startTakeoff { error ->
-            if (error != null) {
-                logger.w { "Takeoff error: $error" }
-            }
+            if (error != null) logger.e { "Takeoff error: $error" }
         }
     }
 

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -118,6 +118,18 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
 
         logger.i { "New aircraft state: $fcState" }
 
+        // state as armed and taking off
+        if (fcState.isArmed() && !state.isArmed() && !fcState.isFlying()) {
+            dispatchTransition(ArmTransition)
+            dispatchTransition(TakeoffTransition)
+        }
+        // state as isFlying
+        if (fcState.isFlying() && !state.isFlying()) dispatchTransition(FlyingTransition)
+        // state as landing
+        if (fcState.isLanding() && !state.isLanding()) dispatchTransition(LandTransition)
+        // state as standby
+        if (fcState.isStandBy() && !state.isStandBy()) dispatchTransition(StandbyTransition)
+
         stateMachine.forceSet(fcState)
     }
 
@@ -257,6 +269,11 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     }
 
     fun takeOff() {
+        // sync and check for already-airborne cases
+        if (state.isFlying()) {
+            logger.d { "Aircraft already airborne" }
+            return
+        }
         logger.d { "Aircraft taking off" }
         FCManager.startTakeoff { error ->
             if (error != null) {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -68,31 +68,6 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         return CommandResult.ok
     }
 
-    private fun enforceModeConsistency() {
-        if (stateMachine.isModeAllowed(state.flightMode).hasError) {
-            stateMachine.syncArmState()
-            return
-        }
-
-        val fallbackMode = if (state.isFlying()) {
-            ArduCopterFlightMode.GUIDED
-        } else {
-            ArduCopterFlightMode.STABILIZE
-        }
-
-        logger.w {
-            "Mode ${state.flightMode} invalid for state ${state.mavlink}, fallback to $fallbackMode"
-        }
-
-        stateMachine.updateFlightMode(fallbackMode)
-    }
-
-    fun canDispatchTransition(transition: StateTransition): UnitResult =
-        stateMachine.canDispatch(transition)
-
-    fun dispatchTransition(transition: StateTransition): AircraftState =
-        stateMachine.dispatch(transition)
-
     fun syncSensors(sensorsInterval: Long = 1000L) {
         if (isPowerOff) return
         val currentTimestamp = System.currentTimeMillis()
@@ -105,29 +80,10 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
     }
 
     fun syncState() {
-        // Check for armed and flying conditions to update the last
-        val fcState = state.resolveFrom(
+        stateMachine.sync(
             currentTelemetry?.motorsOn ?: false,
             currentTelemetry?.isFlying ?: false
         )
-
-        // Force new logic state update only when different
-        if (!stateMachine.hasStateChanged(fcState)) return
-
-//        // state as armed and taking off
-//        if (fcState.isArmed() && state.isStandBy()) {
-////            dispatchTransition(ArmTransition)
-//            // will take off if armed from the ground
-//            if (fcState.isTakingOff()) dispatchTransition(TakeoffTransition)
-//        }
-//        // state as isFlying
-//        if (fcState.isFlying() && !state.isTakingOff()) dispatchTransition(FlyingTransition)
-//        // state as standby
-//        if (!fcState.isArmed()) dispatchTransition(StandbyTransition)
-
-        logger.i { "New aircraft state: $state" }
-
-        stateMachine.forceSet(fcState)
     }
 
     private suspend fun loadParameters(timeout: Long = 5000L): Boolean {

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftHandler.kt
@@ -58,9 +58,7 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         val isAllowed = stateMachine.isModeAllowed(mode)
 
         if (isAllowed.hasError) {
-            return CommandResult.error(
-                "Mode $mode not allowed: ${isAllowed.errorReason}"
-            )
+            return CommandResult.error("Mode $mode not allowed: ${isAllowed.errorReason}")
         }
 
         logger.d { "Mode change: ${state.flightMode} -> $mode" }
@@ -116,19 +114,18 @@ class AircraftHandler : CommandHandler<AircraftHandler>() {
         // Force new logic state update only when different
         if (!stateMachine.hasStateChanged(fcState)) return
 
-        logger.i { "New aircraft state: $fcState" }
+//        // state as armed and taking off
+//        if (fcState.isArmed() && state.isStandBy()) {
+////            dispatchTransition(ArmTransition)
+//            // will take off if armed from the ground
+//            if (fcState.isTakingOff()) dispatchTransition(TakeoffTransition)
+//        }
+//        // state as isFlying
+//        if (fcState.isFlying() && !state.isTakingOff()) dispatchTransition(FlyingTransition)
+//        // state as standby
+//        if (!fcState.isArmed()) dispatchTransition(StandbyTransition)
 
-        // state as armed and taking off
-        if (fcState.isArmed() && !state.isArmed() && !fcState.isFlying()) {
-            dispatchTransition(ArmTransition)
-            dispatchTransition(TakeoffTransition)
-        }
-        // state as isFlying
-        if (fcState.isFlying() && !state.isFlying()) dispatchTransition(FlyingTransition)
-        // state as landing
-        if (fcState.isLanding() && !state.isLanding()) dispatchTransition(LandTransition)
-        // state as standby
-        if (fcState.isStandBy() && !state.isStandBy()) dispatchTransition(StandbyTransition)
+        logger.i { "New aircraft state: $state" }
 
         stateMachine.forceSet(fcState)
     }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
@@ -30,8 +30,10 @@ data class AircraftState(
     val homeCoordinates: Coordinates3D? = null,
     val modeFlag: Int = MAV_MODE_FLAG.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
     val flightMode: ArduCopterFlightMode = ArduCopterFlightMode.STABILIZE,
-    val armRequested: Boolean = false
+    val armTimestamp: Long = 0
 ) {
+    val armRequested = armTimestamp > 0
+
     fun isHomeSet() = homeCoordinates != null
 
     fun isStandBy() = mavlink == MAV_STATE.MAV_STATE_STANDBY
@@ -105,7 +107,7 @@ object StandbyTransition : StateTransition {
     override fun reduce(from: AircraftState): AircraftState = from.copy(
         mavlink = MAV_STATE.MAV_STATE_STANDBY,
         landed = MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND,
-        armRequested = false
+        armTimestamp = 0
     )
 }
 
@@ -117,7 +119,7 @@ object ArmTransition : StateTransition {
     }
 
     override fun reduce(from: AircraftState): AircraftState =
-        from.copy(mavlink = MAV_STATE.MAV_STATE_ACTIVE, armRequested = true)
+        from.copy(mavlink = MAV_STATE.MAV_STATE_ACTIVE, armTimestamp = System.currentTimeMillis())
 }
 
 object TakeoffTransition : StateTransition {
@@ -145,7 +147,7 @@ object FlyingTransition : StateTransition {
     }
 
     override fun reduce(from: AircraftState): AircraftState =
-        from.copy(landed = MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR, armRequested = false)
+        from.copy(landed = MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR, armTimestamp = 0)
 }
 
 object LandTransition : StateTransition {
@@ -243,18 +245,28 @@ class AircraftStateMachine {
     fun sync(isArmed: Boolean, isFlying: Boolean) {
         // Check state and dispatch state transitions accordingly
         val fcState = state.resolveFrom(isArmed, isFlying)
-        // arm and taking off
-        if (fcState.isArmed() && state.isOnTheGround()) {
-            dispatch(ArmTransition)
-            dispatch(TakeoffTransition)
-        }
-        // is flying
-        if (fcState.isFlying() && state.isTakingOff()) {
-            dispatch(FlyingTransition)
-        }
-        // is landing should be triggered and fixed until standby
-        if (!fcState.isArmed() && !fcState.isFlying() && !state.armRequested) {
-            dispatch(StandbyTransition)
+        when {
+            // RC trigger arm while on ground: advance to armed
+            fcState.isArmed() && state.isOnTheGround() -> dispatch(ArmTransition)
+
+            // Armed and on ground: advance to takeoff
+            fcState.isArmed() && fcState.isFlying() && state.isOnTheGround() ->
+                dispatch(TakeoffTransition)
+
+            // Taking off and now flying: advance to flying
+            fcState.isArmed() && fcState.isFlying() && state.isTakingOff() ->
+                dispatch(FlyingTransition)
+
+            // Disarmed and grounded: return to standby
+            !fcState.isArmed() && !fcState.isFlying() && !state.armRequested ->
+                dispatch(StandbyTransition)
+
+            // Catch unsuccessful arm
+            !fcState.isArmed() && state.armRequested -> {
+                if ((state.armTimestamp - System.currentTimeMillis()) > 10_000) {
+                    dispatch(StandbyTransition)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
@@ -40,6 +40,8 @@ data class AircraftState(
 
     fun isLanding() = landed == MAV_LANDED_STATE.MAV_LANDED_STATE_LANDING
 
+    fun isTakingOff() = landed == MAV_LANDED_STATE.MAV_LANDED_STATE_TAKEOFF
+
     fun isOnTheGround() = landed == MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
 
     fun isUninitialized() = mavlink == MAV_STATE.MAV_STATE_UNINIT
@@ -55,13 +57,16 @@ data class AircraftState(
             else -> MAV_STATE.MAV_STATE_STANDBY
         }
 
-        // Sync of landed state and transitions, Landing is updated from transition dispatch.
+        // Sync of landed state
         val landedState = when {
-            !isArmed && isOnTheGround() -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
+            !isArmed && !isFlying -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
             isArmed && isOnTheGround() -> MAV_LANDED_STATE.MAV_LANDED_STATE_TAKEOFF
+//            !isFlying && isTakingOff() -> MAV_LANDED_STATE.MAV_LANDED_STATE_TAKEOFF
+            isFlying && isTakingOff() -> MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR
+            isFlying && isOnTheGround() -> MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR
             isFlying && isLanding() -> MAV_LANDED_STATE.MAV_LANDED_STATE_LANDING
-            !isFlying && isLanding() -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
-            isFlying -> MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR
+//            !isFlying && isLanding() -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
+//            !isFlying && isFlying() -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
             else -> this.landed
         }
 

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/AircraftState.kt
@@ -3,6 +3,7 @@ package org.WenuLink.adapters.aircraft
 import com.MAVLink.enums.MAV_LANDED_STATE
 import com.MAVLink.enums.MAV_MODE_FLAG
 import com.MAVLink.enums.MAV_STATE
+import io.getstream.log.taggedLogger
 import org.WenuLink.commands.CommandResult
 import org.WenuLink.commands.UnitResult
 
@@ -28,13 +29,14 @@ data class AircraftState(
     val landed: Int = MAV_LANDED_STATE.MAV_LANDED_STATE_UNDEFINED,
     val homeCoordinates: Coordinates3D? = null,
     val modeFlag: Int = MAV_MODE_FLAG.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
-    val flightMode: ArduCopterFlightMode = ArduCopterFlightMode.STABILIZE
+    val flightMode: ArduCopterFlightMode = ArduCopterFlightMode.STABILIZE,
+    val armRequested: Boolean = false
 ) {
     fun isHomeSet() = homeCoordinates != null
 
     fun isStandBy() = mavlink == MAV_STATE.MAV_STATE_STANDBY
 
-    fun isArmed() = mavlink == MAV_STATE.MAV_STATE_ACTIVE
+    fun isArmed() = mavlink == MAV_STATE.MAV_STATE_ACTIVE || armRequested
 
     fun isFlying() = landed == MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR
 
@@ -50,31 +52,20 @@ data class AircraftState(
 
     fun isPowerOff() = mavlink == MAV_STATE.MAV_STATE_POWEROFF
 
-    fun resolveFrom(isArmed: Boolean, isFlying: Boolean): AircraftState {
-        // Sync ARM/DISARM state.
-        val mavState = when {
-            isArmed -> MAV_STATE.MAV_STATE_ACTIVE
-            else -> MAV_STATE.MAV_STATE_STANDBY
-        }
-
+    fun resolveFrom(isArmed: Boolean, isFlying: Boolean): AircraftState = this.copy(
+        // Sync ARM/DISARM state
+        mavlink = if (isArmed) {
+            MAV_STATE.MAV_STATE_ACTIVE
+        } else {
+            MAV_STATE.MAV_STATE_STANDBY
+        },
         // Sync of landed state
-        val landedState = when {
-            !isArmed && !isFlying -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
-            isArmed && isOnTheGround() -> MAV_LANDED_STATE.MAV_LANDED_STATE_TAKEOFF
-//            !isFlying && isTakingOff() -> MAV_LANDED_STATE.MAV_LANDED_STATE_TAKEOFF
-            isFlying && isTakingOff() -> MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR
-            isFlying && isOnTheGround() -> MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR
-            isFlying && isLanding() -> MAV_LANDED_STATE.MAV_LANDED_STATE_LANDING
-//            !isFlying && isLanding() -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
-//            !isFlying && isFlying() -> MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
-            else -> this.landed
+        landed = if (isFlying) {
+            MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR
+        } else {
+            MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
         }
-
-        return this.copy(
-            mavlink = mavState,
-            landed = landedState
-        )
-    }
+    )
 }
 
 sealed interface StateTransition {
@@ -113,7 +104,8 @@ object StandbyTransition : StateTransition {
 
     override fun reduce(from: AircraftState): AircraftState = from.copy(
         mavlink = MAV_STATE.MAV_STATE_STANDBY,
-        landed = MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND
+        landed = MAV_LANDED_STATE.MAV_LANDED_STATE_ON_GROUND,
+        armRequested = false
     )
 }
 
@@ -125,7 +117,7 @@ object ArmTransition : StateTransition {
     }
 
     override fun reduce(from: AircraftState): AircraftState =
-        from.copy(mavlink = MAV_STATE.MAV_STATE_ACTIVE)
+        from.copy(mavlink = MAV_STATE.MAV_STATE_ACTIVE, armRequested = true)
 }
 
 object TakeoffTransition : StateTransition {
@@ -153,7 +145,7 @@ object FlyingTransition : StateTransition {
     }
 
     override fun reduce(from: AircraftState): AircraftState =
-        from.copy(landed = MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR)
+        from.copy(landed = MAV_LANDED_STATE.MAV_LANDED_STATE_IN_AIR, armRequested = false)
 }
 
 object LandTransition : StateTransition {
@@ -215,30 +207,24 @@ data class FlightModeTransition(private val flightMode: ArduCopterFlightMode) : 
  * FSM / Reducer pattern.
  */
 class AircraftStateMachine {
+    private val logger by taggedLogger(AircraftStateMachine::class.java.simpleName)
     var state = AircraftState()
         private set
 
     fun canDispatch(event: StateTransition): UnitResult = event.canTransition(state)
 
     fun dispatch(event: StateTransition): AircraftState {
+        logger.d { "StateTransition: $event" }
         state = event.reduce(state)
-        return syncArmState()
+        return updateArmFlag()
     }
-
-    fun forceSet(target: AircraftState) {
-        state = target
-        syncArmState()
-    }
-
-    fun hasStateChanged(target: AircraftState) = state.mavlink != target.mavlink ||
-        state.landed != target.landed
 
     fun updateHomePosition(homeCoordinates: Coordinates3D): AircraftState {
         state = state.copy(homeCoordinates = homeCoordinates)
         return state
     }
 
-    fun syncArmState(): AircraftState {
+    fun updateArmFlag(): AircraftState {
         val modeFlag = if (state.isArmed()) {
             state.flightMode.baseMode or MAV_MODE_FLAG.MAV_MODE_FLAG_SAFETY_ARMED
         } else {
@@ -253,6 +239,24 @@ class AircraftStateMachine {
 
     fun isModeAllowed(mode: ArduCopterFlightMode): UnitResult =
         canDispatch(FlightModeTransition(mode))
+
+    fun sync(isArmed: Boolean, isFlying: Boolean) {
+        // Check state and dispatch state transitions accordingly
+        val fcState = state.resolveFrom(isArmed, isFlying)
+        // arm and taking off
+        if (fcState.isArmed() && state.isOnTheGround()) {
+            dispatch(ArmTransition)
+            dispatch(TakeoffTransition)
+        }
+        // is flying
+        if (fcState.isFlying() && state.isTakingOff()) {
+            dispatch(FlyingTransition)
+        }
+        // is landing should be triggered and fixed until standby
+        if (!fcState.isArmed() && !fcState.isFlying() && !state.armRequested) {
+            dispatch(StandbyTransition)
+        }
+    }
 }
 
 /**

--- a/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/aircraft/TelemetryHandler.kt
@@ -194,10 +194,10 @@ class TelemetryHandler : IHandler<TelemetryHandler> {
     private fun noIMU() = FCManager.getIMUCount() == 0
 
     @Synchronized
-    fun isReadingSensors() = noIMU() || lastIMUState.gyroscope.isNotEmpty() || mustRunSimulation
+    fun isReadingSensors() = noIMU() || mustRunSimulation || lastIMUState.gyroscope.isNotEmpty()
 
     @Synchronized
-    fun isCompassOk() = noIMU() || FCManager.compassOk() || mustRunSimulation
+    fun isCompassOk() = noIMU() || mustRunSimulation || FCManager.compassOk()
 
     @Synchronized
     fun isAccelerometerOk() = noIMU() || mustRunSimulation ||

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -377,7 +377,6 @@ class NavigationController(
         var yaw = telemetryData.yaw
         if (yaw < 0) yaw += 360
         hdg = (yaw * 100).roundToInt()
-//        client.sendMessage(msg)
     }
 
     fun msgRawGPSInt(): MAVLinkMessage? = msg_gps_raw_int().apply {

--- a/app/src/main/java/org/WenuLink/sdk/FCManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/FCManager.kt
@@ -127,12 +127,12 @@ object FCManager {
         -> AppSensorState.BOOT
 
         SensorState.DATA_EXCEPTION,
-        SensorState.IN_MOTION,
         SensorState.LARGE_BIAS
         -> AppSensorState.CALIBRATION_NEEDED
 
         SensorState.NORMAL_BIAS,
         SensorState.MEDIUM_BIAS,
+        SensorState.IN_MOTION,
         SensorState.UNKNOWN
         -> AppSensorState.OK
 


### PR DESCRIPTION
The presented changes aims to enforce the concerns of `AircraftStateMachine` to properly sync the current `AircraftState` through iterative `AircraftHandler.syncState` calls on the `monitorJob`, aiming to solve #110  and #108.

Current tests with P4P ensured the proper sync on arm and flying state reflected in QGC. Nevertheless, arm triggers and mission start operations from QGC still need to be check.
