### PR TITLE
Fix/mission item altitude

### DIFF
--- a/app/src/main/java/org/WenuLink/adapters/mission/ItemAssemblyResult.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/ItemAssemblyResult.kt
@@ -1,0 +1,8 @@
+package org.WenuLink.adapters.mission
+
+sealed interface ItemAssemblyResult {
+    data object Accepted : ItemAssemblyResult
+    data object UnsupportedCommand : ItemAssemblyResult
+    data object UnsupportedFrame : ItemAssemblyResult
+    data object NoActiveMission : ItemAssemblyResult
+}

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionAssembler.kt
@@ -2,6 +2,8 @@ package org.WenuLink.adapters.mission
 
 import com.MAVLink.common.msg_mission_item_int
 import com.MAVLink.enums.MAV_CMD
+import com.MAVLink.enums.MAV_FRAME
+import io.getstream.log.taggedLogger
 import org.WenuLink.adapters.aircraft.Coordinates3D
 import org.WenuLink.mavlink.messages.ConditionYawMessage
 import org.WenuLink.mavlink.messages.ImageStartCaptureMessage
@@ -10,6 +12,8 @@ import org.WenuLink.mavlink.messages.NavTakeoffMissionItem
 import org.WenuLink.mavlink.messages.NavWaypointMissionItem
 
 class MissionAssembler(private val id: Int) {
+
+    private val logger by taggedLogger(MissionAssembler::class.java.simpleName)
     private val nodes = mutableListOf<MissionNode>()
     private var rtlWhenFinish = false
     var timestamp = System.currentTimeMillis()
@@ -28,6 +32,8 @@ class MissionAssembler(private val id: Int) {
         rtlWhenFinish = false
         nWaypoints = 0
     }
+
+    fun addHome(coordinates: Coordinates3D): Boolean = nodes.add(MissionNode.Home(coordinates))
 
     fun addTakeoff(coordinates: Coordinates3D): Boolean =
         nodes.add(MissionNode.Takeoff(coordinates))
@@ -49,12 +55,17 @@ class MissionAssembler(private val id: Int) {
 
     fun build(): AssembledMission = AssembledMission(nodes.toList(), nWaypoints, rtlWhenFinish)
 
-    fun addWaypointNode(itemMsg: msg_mission_item_int): Boolean {
-//        logger.d { "Append mission item." }
-        when (itemMsg.command) {
-            MAV_CMD.MAV_CMD_NAV_TAKEOFF -> assembleTakeoffNode(itemMsg)
+    fun addWaypointNode(itemMsg: msg_mission_item_int): ItemAssemblyResult {
+        logger.d { "Append mission item." }
 
-            MAV_CMD.MAV_CMD_NAV_WAYPOINT -> assembleWaypointNode(itemMsg)
+        // ArduPilot mission protocol: seq 0 is always the home location, never a flight item.
+        // https://mavlink.io/en/services/mission.html#flight-plan-missions
+        if (itemMsg.seq == 0) return assembleHomeNode(itemMsg)
+
+        when (itemMsg.command) {
+            MAV_CMD.MAV_CMD_NAV_TAKEOFF -> return assembleTakeoffNode(itemMsg)
+
+            MAV_CMD.MAV_CMD_NAV_WAYPOINT -> return assembleWaypointNode(itemMsg)
 
             MAV_CMD.MAV_CMD_NAV_DELAY,
             MAV_CMD.MAV_CMD_CONDITION_DELAY -> addActionToLast(
@@ -69,45 +80,55 @@ class MissionAssembler(private val id: Int) {
                 PhotoAction.fromParameters(ImageStartCaptureMessage(itemMsg))
             )
 
-            MAV_CMD.MAV_CMD_IMAGE_STOP_CAPTURE ->
-                addActionToLast(StopPhotoAction)
+            MAV_CMD.MAV_CMD_IMAGE_STOP_CAPTURE -> addActionToLast(StopPhotoAction)
 
-            MAV_CMD.MAV_CMD_VIDEO_START_CAPTURE ->
-                addActionToLast(VideoAction())
+            MAV_CMD.MAV_CMD_VIDEO_START_CAPTURE -> addActionToLast(VideoAction())
 
-            MAV_CMD.MAV_CMD_VIDEO_STOP_CAPTURE ->
-                addActionToLast(StopVideoAction)
+            MAV_CMD.MAV_CMD_VIDEO_STOP_CAPTURE -> addActionToLast(StopVideoAction)
 
-            MAV_CMD.MAV_CMD_NAV_RETURN_TO_LAUNCH ->
-                setRTLWhenFinish()
+            MAV_CMD.MAV_CMD_NAV_RETURN_TO_LAUNCH -> setRTLWhenFinish()
 
-            else -> return false
+            else -> return ItemAssemblyResult.UnsupportedCommand
         }
-        return true
+
+        return ItemAssemblyResult.Accepted
     }
 
-    private fun assembleTakeoffNode(itemMsg: msg_mission_item_int) {
+    private fun assembleHomeNode(itemMsg: msg_mission_item_int): ItemAssemblyResult {
+        // QGC transmits home as NAV_WAYPOINT in MAV_FRAME_GLOBAL (AMSL altitude)
+        if (itemMsg.command != MAV_CMD.MAV_CMD_NAV_WAYPOINT) {
+            logger.w { "Item 0 is not a home waypoint (command=${itemMsg.command})" }
+            return ItemAssemblyResult.UnsupportedCommand
+        }
+
+        val params = NavWaypointMissionItem(itemMsg)
+        addHome(Coordinates3D(params.latitude, params.longitude, params.altitude))
+
+        logger.d { "Home: (${params.latitude}, ${params.longitude}) AMSL ${params.altitude}" }
+        return ItemAssemblyResult.Accepted
+    }
+
+    private fun hasSupportedFrame(itemMsg: msg_mission_item_int): Boolean =
+        when (itemMsg.frame.toInt()) {
+            MAV_FRAME.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            MAV_FRAME.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT -> true
+
+            else -> false
+        }
+
+    private fun assembleTakeoffNode(itemMsg: msg_mission_item_int): ItemAssemblyResult {
+        if (!hasSupportedFrame(itemMsg)) return ItemAssemblyResult.UnsupportedFrame
         val params = NavTakeoffMissionItem(itemMsg)
         addTakeoff(
             Coordinates3D(params.latitude, params.longitude, params.altitude)
         )
+        return ItemAssemblyResult.Accepted
     }
 
-    private fun assembleWaypointNode(itemMsg: msg_mission_item_int) {
+    private fun assembleWaypointNode(itemMsg: msg_mission_item_int): ItemAssemblyResult {
+        if (!hasSupportedFrame(itemMsg)) return ItemAssemblyResult.UnsupportedFrame
         val params = NavWaypointMissionItem(itemMsg)
-        // Assumes Global only
         val coordinates = Coordinates3D(params.latitude, params.longitude, params.altitude)
-
-        // TODO: airframe check
-//         val frameReference = itemMsg.frame.toInt()
-//         // We only support the following frame models:
-//         // 0 = Global (WGS84) coordinate frame + altitude relative to mean sea level (MSL).
-//         // 3 = Global (WGS84) coordinate frame + altitude relative to the home position.
-//         if (frameReference != 0 && frameReference != 3) {
-//             logger.w { "frameReference: $frameReference is not available" }
-//             sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED_FRAME)
-//             return
-//         }
 
         addWaypoint(coordinates)
 
@@ -121,6 +142,8 @@ class MissionAssembler(private val id: Int) {
             addActionToLast(RotateAction(params.yaw))
         }
 
-//        logger.d { "Waypoint: ($coordinates) (Yaw=${params.yaw}°) (Delay=${params.holdTimeSec}s)" }
+        logger.d { "Waypoint: ($coordinates) (Yaw=${params.yaw}°) (Delay=${params.holdTimeSec}s)" }
+
+        return ItemAssemblyResult.Accepted
     }
 }

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionHandler.kt
@@ -220,12 +220,13 @@ class MissionHandler : CommandHandler<MissionHandler>() {
         return UnitResult.ok
     }
 
-    fun processItem(itemMsg: msg_mission_item_int): Boolean {
-        if (!state.hasAssembler) {
+    fun processItem(itemMsg: msg_mission_item_int): ItemAssemblyResult {
+        val assembler = state.assembler
+        if (assembler == null) {
             logger.w { "processItem called without assembler, item ${itemMsg.command} dropped" }
-            return false
+            return ItemAssemblyResult.NoActiveMission
         }
-        return state.assembler?.addWaypointNode(itemMsg) ?: false
+        return assembler.addWaypointNode(itemMsg)
     }
 
     fun getWaypointNode(index: Int): MissionNode? = state.assembler?.getNode(index)

--- a/app/src/main/java/org/WenuLink/adapters/mission/MissionNode.kt
+++ b/app/src/main/java/org/WenuLink/adapters/mission/MissionNode.kt
@@ -6,6 +6,11 @@ sealed class MissionNode(
     val coordinates3D: Coordinates3D,
     val actions: MutableList<MissionActionCommand> = mutableListOf()
 ) {
+    /**
+     * ArduPilot home item (seq 0). Reference data only, never a flight target.
+     * Note: unlike all other nodes, [coordinates3D].alt is AMSL, not relative.
+     */
+    class Home(homeCoordinates3D: Coordinates3D) : MissionNode(homeCoordinates3D)
     class Takeoff(takeoffCoordinates3D: Coordinates3D) : MissionNode(takeoffCoordinates3D)
     class Land(landCoordinates3D: Coordinates3D) : MissionNode(landCoordinates3D)
     class Waypoint(wpCoordinates3D: Coordinates3D) : MissionNode(wpCoordinates3D)

--- a/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/controllers/NavigationController.kt
@@ -19,6 +19,7 @@ import com.MAVLink.common.msg_mission_request_list
 import com.MAVLink.common.msg_statustext
 import com.MAVLink.enums.GPS_FIX_TYPE
 import com.MAVLink.enums.MAV_CMD
+import com.MAVLink.enums.MAV_FRAME
 import com.MAVLink.enums.MAV_MISSION_RESULT
 import com.MAVLink.enums.MAV_MISSION_TYPE
 import com.MAVLink.enums.MAV_RESULT
@@ -30,6 +31,7 @@ import org.WenuLink.adapters.RequestMissionAction
 import org.WenuLink.adapters.RequestStartMission
 import org.WenuLink.adapters.WenuLinkCommand
 import org.WenuLink.adapters.WenuLinkHandler
+import org.WenuLink.adapters.mission.ItemAssemblyResult
 import org.WenuLink.adapters.mission.MissionNode
 import org.WenuLink.adapters.mission.RepositionAction
 import org.WenuLink.mavlink.MAVLinkClient
@@ -109,6 +111,12 @@ class NavigationController(
         val node = handler.mission.getWaypointNode(nIdx) ?: return null
         val coordinates = node.coordinates3D
         return when (node) {
+            is MissionNode.Home -> NavWaypointMissionItem(
+                latitude = coordinates.lat,
+                longitude = coordinates.long,
+                altitude = coordinates.alt
+            ).toMavLink(nIdx, MAV_FRAME.MAV_FRAME_GLOBAL)
+
             is MissionNode.Takeoff -> NavTakeoffMissionItem(
                 latitude = coordinates.lat,
                 longitude = coordinates.long,
@@ -226,12 +234,27 @@ class NavigationController(
         }
 
         // Store item and request next or upload the mission
-        val accepted = handler.mission.processItem(itemMsg)
-        if (!accepted) {
-            logger.w { "Unsupported mission command: ${itemMsg.command}" }
-            sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED)
-            return
+        when (handler.mission.processItem(itemMsg)) {
+            ItemAssemblyResult.Accepted -> Unit
+
+            ItemAssemblyResult.UnsupportedCommand -> {
+                logger.w { "Unsupported mission command: ${itemMsg.command}" }
+                sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED)
+                return
+            }
+
+            ItemAssemblyResult.UnsupportedFrame -> {
+                logger.w { "Unsupported frame ${itemMsg.frame} for command ${itemMsg.command}" }
+                sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_UNSUPPORTED_FRAME)
+                return
+            }
+
+            ItemAssemblyResult.NoActiveMission -> {
+                sendAckAnswer(MAV_MISSION_RESULT.MAV_MISSION_ERROR)
+                return
+            }
         }
+
         ackReceivedItem(nextExpectedSeq)
         nextExpectedSeq += 1
 

--- a/app/src/main/java/org/WenuLink/mavlink/messages/NavigationMessages.kt
+++ b/app/src/main/java/org/WenuLink/mavlink/messages/NavigationMessages.kt
@@ -138,9 +138,12 @@ data class NavWaypointMissionItem(
         altitude = msg.z
     )
 
-    fun toMavLink(seq: Int): msg_mission_item_int = msg_mission_item_int().apply {
+    fun toMavLink(
+        seq: Int,
+        frame: Int = MAV_FRAME.MAV_FRAME_GLOBAL_RELATIVE_ALT
+    ): msg_mission_item_int = msg_mission_item_int().apply {
         this.seq = seq
-        frame = MAV_FRAME.MAV_FRAME_GLOBAL_RELATIVE_ALT.toShort()
+        this.frame = frame.toShort()
         command = MAV_CMD.MAV_CMD_NAV_WAYPOINT
         mission_type = MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION.toShort()
         param1 = holdTimeSec

--- a/app/src/main/java/org/WenuLink/sdk/MissionManager.kt
+++ b/app/src/main/java/org/WenuLink/sdk/MissionManager.kt
@@ -116,10 +116,26 @@ object MissionManager {
             rtlWhenFinish = mission.rtlWhenFinish
         ) ?: return onResult(false, "Builder error")
 
-        mission.nodes.forEach { node ->
+        for (node in mission.nodes) {
             when (node) {
+                is MissionNode.Home -> {
+                    // ArduPilot home item: reference data only, never a DJI waypoint.
+                    // Its altitude is AMSL and must not reach the SDK.
+                }
+
                 is MissionNode.Takeoff -> {
-                    // No need to process taking off
+                    // Materialize the takeoff as the first DJI waypoint so the initial climb
+                    // (gotoFirstWaypointMode SAFELY) targets the requested takeoff altitude instead
+                    // of the first waypoint's altitude.
+                    val coordinates = node.coordinates3D
+                    if (coordinates.lat == 0.0 && coordinates.long == 0.0) {
+                        // MAVLink allows (0, 0) meaning "current location"; resolving that needs
+                        // the home position which this layer does not have.
+                        return onResult(false, "Takeoff item without coordinates is unsupported")
+                    }
+                    builder.addWaypoint(
+                        Waypoint(coordinates.lat, coordinates.long, coordinates.alt)
+                    )
                 }
 
                 is MissionNode.Land -> {
@@ -137,7 +153,7 @@ object MissionManager {
             }
         }
 
-        builder.waypointCount(mission.nWaypoints)
+        builder.waypointCount(builder.waypointList.size)
         operator.loadMission(builder.build())
             ?.let { onResult(false, it.description) }
             ?: uploadWaypointMission(onResult)


### PR DESCRIPTION
Fixes #107 

#### Changes

- New MissionNode.Home stores the seq 0 home item as metadata at node index 0. It is excluded from the DJI mission and re-emitted in MAV_FRAME_GLOBAL on download. Node index continues to equal MAVLink seq.
- Item assembly returns a sealed ItemAssemblyResult instead of a Boolean, enabling MAV_MISSION_UNSUPPORTED_FRAME NACKs. Only MAV_FRAME_GLOBAL_RELATIVE_ALT(_INT) is accepted for coordinate items; AMSL is rejected rather than converted, since MSDK v4 provides no reliable home AMSL reference.
- NAV_TAKEOFF is materialized as the first DJI waypoint, so the initial climb targets the planned takeoff altitude. Takeoff items with (0, 0) coordinates are rejected at upload. The waypoint count is derived from the builder's waypoint list.


Branched off #112 and intended to be merged after it, since both touch the mission upload path. Will rebase onto develop once #112 lands.